### PR TITLE
fix(logging): prevent discord stderr handler from corrupting log levels

### DIFF
--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -10,14 +10,7 @@ from discord.ext import commands, tasks
 from dotenv import load_dotenv
 
 from typer_bot.database import Database
-from typer_bot.utils.logger import _hijack_logger, set_trace_id
-
-# discord.py attaches its own stderr handler on import.
-# Clear it and force propagation to our root stdout handler.
-_hijack_logger("discord")
-_hijack_logger("discord.client")
-_hijack_logger("discord.gateway")
-_hijack_logger("discord.http")
+from typer_bot.utils.logger import set_trace_id
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +262,7 @@ def main():
     try:
         bot = TyperBot()
         logger.info("Starting bot.run()...")
-        bot.run(token)
+        bot.run(token, log_handler=None)
     except discord.LoginFailure:
         logger.exception("❌ Discord login failed - check if DISCORD_TOKEN is valid")
         sys.exit(1)

--- a/typer_bot/utils/logger.py
+++ b/typer_bot/utils/logger.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 # Global context for request trace IDs
@@ -73,7 +73,7 @@ class RailwayJSONFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         # Railway expects ISO8601 with timezone for proper log ordering
-        timestamp = datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat()
+        timestamp = datetime.fromtimestamp(record.created, tz=UTC).isoformat()
 
         log_entry = {
             "level": record.levelname.lower(),
@@ -135,13 +135,6 @@ def is_railway_environment() -> bool:
     )
 
 
-def _hijack_logger(name: str) -> None:
-    """Force a named logger to use root handler instead of its own."""
-    logger = logging.getLogger(name)
-    logger.handlers.clear()
-    logger.propagate = True  # Use root handler
-
-
 def setup_logging(level: int | None = None) -> None:
     """Configure root logger for Railway or local environment.
 
@@ -165,13 +158,6 @@ def setup_logging(level: int | None = None) -> None:
         handler.setFormatter(LocalFormatter())
 
     root_logger.addHandler(handler)
-
-    # discord.py attaches its own stderr handler - hijack it
-    _hijack_logger("discord")
-    _hijack_logger("discord.client")
-    _hijack_logger("discord.gateway")
-    _hijack_logger("discord.http")
-    _hijack_logger("aiosqlite")
 
     logging.getLogger("discord").setLevel(logging.WARNING)
     logging.getLogger("discord.http").setLevel(logging.WARNING)


### PR DESCRIPTION
Root cause: discord.py's Client.run() attaches a stderr handler at runtime (not import time).
Railway converts ALL stderr logs to level: 'error' regardless of actual Python log level.

Previous fixes failed because they hijacked handlers that didn't exist yet - discord.py attaches its stderr handler when bot.run() executes, not when the module is imported.

Solution: Pass log_handler=None to bot.run() to prevent discord.py from attaching its default stderr handler. This forces discord logs through our configured stdout handler with proper Railway JSON formatting and correct log levels.

Also removed all unnecessary _hijack_logger infrastructure (~21 lines) that was attempting to fix the wrong problem.

Impact: Discord logs now show correct levels in Railway (info=info, warn=warn) instead of everything being tagged as error.