### PR TITLE
feat: add automatic database backup and manual restore

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,12 +58,15 @@ scores (
 - `typer_bot/utils/prediction_parser.py`: Central logic for parsing "2-1" or "2:1" strings.
 - `typer_bot/utils/scoring.py`: Point calculation rules.
 - `typer_bot/utils/logger.py`: structured logging configuration for Railway.
+- `typer_bot/utils/db_backup.py`: Automatic database backup after fixture completion.
+- `scripts/restore_db.py`: Manual database restore via Railway console.
 
 ## 5. Common Tasks
 - **Fixing Parsing:** Edit `prediction_parser.py`.
 - **New Commands:** Add Cog to `commands/` folder, load in `bot.py`.
 - **Database Changes:** Edit `database.py` `initialize()` (Handle migrations manually if needed).
 - **Debugging:** Check `utils/logger.py` for config. Set `LOG_LEVEL=DEBUG` in env.
+- **Database Restore:** Use `scripts/restore_db.py` from Railway console for manual database restoration from backups.
 
 ## 6. Known Quirks
 - **Double Digits:** Scores like `10-0` are allowed.

--- a/README.md
+++ b/README.md
@@ -60,9 +60,20 @@ python -m typer_bot
 
 ## Importing History
 If you have a bunch of old scores you want to keep:
-1. Put `.sql` files in the `archive/` folder (check `example_import.sql` for the format).
-2. Start the bot with a fresh database.
+1. Put `.sql` files in `archive/` folder (check `example_import.sql` for format).
+2. Start bot with a fresh database.
 3. It'll import them automatically.
+
+## Backup and Restore
+
+**Automatic:** Database backed up automatically after each `/admin calculate`. Stored in `/app/data/backups/`, last 10 kept.
+
+**Manual Restore:** Run from Railway console (requires shell access):
+```bash
+ls /app/data/backups/
+python scripts/restore_db.py /app/data/backups/backup_*.sql
+```
+Type "YES" to confirm. Current DB backed up to `.bak` file before restore.
 
 ## License
 MIT. Do whatever you want with it.

--- a/scripts/restore_db.py
+++ b/scripts/restore_db.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+"""Manual database restore script - run from Railway console."""
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+import re
+import shutil
+import sqlite3
+import sys
+
+
+def validate_backup_sql(sql_content: str) -> bool:
+    """Validate backup SQL - allows CREATE TABLE IF NOT EXISTS and INSERT only."""
+    normalized = re.sub(r"--.*?$", "", sql_content, flags=re.MULTILINE)
+    normalized = re.sub(r"/\*.*?\*/", "", normalized, flags=re.DOTALL)
+    normalized = re.sub(r"^\s*$", "", normalized, flags=re.MULTILINE)
+    normalized = normalized.upper()
+
+    dangerous = [
+        "DROP",
+        "DELETE",
+        "UPDATE",
+        "ALTER",
+        "TRUNCATE",
+        "REPLACE",
+        "ATTACH",
+        "DETACH",
+        "PRAGMA",
+    ]
+
+    for keyword in dangerous:
+        if re.search(rf"\b{keyword}\b", normalized):
+            return False
+
+    lines = normalized.split("\n")
+    for line in lines:
+        line = line.strip()
+        if line.startswith("CREATE") and ("TABLE" not in line or "IF NOT EXISTS" not in line):
+            return False
+
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="restore_db", description="Restore database from backup file"
+    )
+    parser.add_argument("backup_file", help="Path to backup SQL file")
+    args = parser.parse_args()
+
+    backup_path = Path(args.backup_file)
+    if not backup_path.exists():
+        print(f"Error: Backup file not found: {backup_path}")
+        sys.exit(1)
+
+    sql_content = backup_path.read_text(encoding="utf-8")
+    if not validate_backup_sql(sql_content):
+        print("Error: Backup file contains unsafe SQL")
+        print("Only CREATE TABLE IF NOT EXISTS and INSERT statements are allowed")
+        sys.exit(1)
+
+    print("\nWarning: This will REPLACE the current database!")
+    print(f"Backup file: {backup_path}")
+    confirm = input("Type 'YES' to confirm: ")
+
+    if confirm != "YES":
+        print("Restore cancelled")
+        sys.exit(0)
+
+    db_path = Path("/app/data/typer.db")
+
+    if db_path.exists():
+        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        bak_path = db_path.with_suffix(f".db.bak.{timestamp}")
+        shutil.copy(db_path, bak_path)
+        print(f"Current database backed up to {bak_path}")
+
+    try:
+        conn = sqlite3.connect(db_path)
+        conn.executescript(sql_content)
+        conn.commit()
+        conn.close()
+        print(f"Database restored from {backup_path}")
+    except Exception as e:
+        print(f"Restore failed: {e}")
+        print(f"Check if original database still exists at {bak_path}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -9,6 +9,7 @@ from discord.ext import commands
 
 from typer_bot.database import Database
 from typer_bot.utils import calculate_points, parse_line_predictions
+from typer_bot.utils.db_backup import create_backup, cleanup_old_backups
 
 # user_id -> {"channel_id": int, "guild_id": int, "games": list, "deadline": datetime, "step": str}
 pending_fixtures = {}
@@ -417,7 +418,15 @@ class AdminCommands(commands.Cog):
 
         scores.sort(key=lambda x: x["points"], reverse=True)
         await self.db.save_scores(fixture["id"], scores)
-
+        try:
+            await self.bot.loop.run_in_executor(
+                None, lambda: create_backup(self.db.db_path, "/app/data/backups")
+            )
+            await self.bot.loop.run_in_executor(
+                None, lambda: cleanup_old_backups("/app/data/backups", keep=10)
+            )
+        except Exception as e:
+            logger.warning(f"Backup failed but calculation succeeded: {e}")
         lines = [f"🏆 **Week {fixture['week_number']} Results**\n"]
         for i, score in enumerate(scores, 1):
             lines.append(

--- a/typer_bot/utils/db_backup.py
+++ b/typer_bot/utils/db_backup.py
@@ -1,0 +1,97 @@
+"""Automatic database backup utilities."""
+
+import re
+import sqlite3
+import logging
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def validate_backup_sql(sql_content: str) -> bool:
+    """Validate backup SQL - allows CREATE TABLE IF NOT EXISTS and INSERT only."""
+    normalized = re.sub(r"--.*?$", "", sql_content, flags=re.MULTILINE)
+    normalized = re.sub(r"/\*.*?\*/", "", normalized, flags=re.DOTALL)
+    normalized = re.sub(r"^\s*$", "", normalized, flags=re.MULTILINE)
+    normalized = normalized.upper()
+
+    dangerous = [
+        "DROP",
+        "DELETE",
+        "UPDATE",
+        "ALTER",
+        "TRUNCATE",
+        "REPLACE",
+        "ATTACH",
+        "DETACH",
+        "PRAGMA",
+    ]
+
+    for keyword in dangerous:
+        if re.search(rf"\b{keyword}\b", normalized):
+            return False
+
+    lines = normalized.split("\n")
+    for line in lines:
+        line = line.strip()
+        if line.startswith("CREATE"):
+            if "TABLE" not in line or "IF NOT EXISTS" not in line:
+                return False
+
+    return True
+
+
+def create_backup(db_path: str, backup_dir: str) -> str:
+    """
+    Create timestamped SQL backup of database.
+
+    Args:
+        db_path: Path to current database file
+        backup_dir: Directory to store backups
+
+    Returns:
+        Path to created backup file
+    """
+    db_path = Path(db_path)
+    backup_path = Path(backup_dir)
+    backup_path.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S-%f")[:-3]
+    backup_file = backup_path / f"backup_{timestamp}.sql"
+
+    conn = sqlite3.connect(db_path)
+    with open(backup_file, "w", encoding="utf-8") as f:
+        for line in conn.iterdump():
+            f.write(f"{line}\n")
+    conn.close()
+
+    logger.info(f"Database backed up to {backup_file}")
+    return str(backup_file)
+
+
+def cleanup_old_backups(backup_dir: str, keep: int = 10) -> int:
+    """
+    Remove oldest backups, keeping only most recent N.
+
+    Args:
+        backup_dir: Directory containing backup files
+        keep: Number of recent backups to retain
+
+    Returns:
+        Number of backups deleted
+    """
+    backup_path = Path(backup_dir)
+    if not backup_path.exists():
+        return 0
+
+    backups = sorted(backup_path.glob("backup_*.sql"), key=lambda f: f.stat().st_mtime)
+
+    deleted = 0
+    while len(backups) > keep:
+        old_backup = backups.pop(0)
+        old_backup.unlink()
+        logger.info(f"Deleted old backup: {old_backup}")
+        deleted += 1
+
+    return deleted


### PR DESCRIPTION
- Automatic backup after /admin calculate completes
- Backups stored in /app/data/backups/ (on Railway volume)
- Last 10 backups retained automatically
- Manual restore via Railway console for security
- Adds db_backup.py utility module with create_backup() and cleanup_old_backups()
- Adds restore_db.py CLI script with validation and YES confirmation
- Updates README.md and AGENTS.md with backup/restore documentation