### PR TITLE
fix(bot): remove invalid super().on_interaction() call

### DIFF
--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -39,7 +39,6 @@ class TyperBot(commands.Bot):
         # Use request ID format: req-<interaction_id>
         # This context is preserved for all async calls within this interaction
         set_trace_id(f"req-{interaction.id}")
-        await super().on_interaction(interaction)
 
     async def on_message(self, message: discord.Message):
         """Set trace ID for every message before processing."""


### PR DESCRIPTION
on_interaction is an event listener, not an overridable method. commands.Bot doesn't have on_interaction in its parent class, so calling super().on_interaction() raises AttributeError.

The trace ID is still set correctly before the (now removed) super call, so logging functionality is preserved. This just removes the error that was being logged for every interaction.