### PR TITLE
fix: make archive import opt-in via IMPORT_ARCHIVE env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ DB_PATH=/app/data/typer.db
 
 # Timezone (default: Europe/Warsaw)
 TZ=Europe/Warsaw
+
+# Archive import (optional)
+# Set to true to auto-import .sql files from archive/ folder on first database init
+IMPORT_ARCHIVE=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ scores (
 - **New Commands:** Add Cog to `commands/` folder, load in `bot.py`.
 - **Database Changes:** Edit `database.py` `initialize()` (Handle migrations manually if needed).
 - **Debugging:** Check `utils/logger.py` for config. Set `LOG_LEVEL=DEBUG` in env.
+- **Archive Import:** Set `IMPORT_ARCHIVE=true` to enable automatic import of historical data on fresh database.
 - **Database Restore:** Use `scripts/restore_db.py` from Railway console for manual database restoration from backups.
 
 ## 6. Known Quirks

--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ I recommend **Railway** because it's cheap/free and supports persistent storage 
    - Mount path: `/app/data`
    - If you skip this, your database will vanish every time you deploy.
 4. Set Variables:
-   - `DISCORD_TOKEN`: Get this from Discord Developer Portal.
-   - `DB_PATH`: `/app/data/typer.db`
-   - `REMINDER_CHANNEL_ID`: (Optional) ID of channel to spam reminders in.
-   - `LOG_LEVEL`: (Optional) Set to `DEBUG` for verbose logs. Default `INFO`.
+    - `DISCORD_TOKEN`: Get this from Discord Developer Portal.
+    - `DB_PATH`: `/app/data/typer.db`
+    - `REMINDER_CHANNEL_ID`: (Optional) ID of channel to spam reminders in.
+    - `LOG_LEVEL`: (Optional) Set to `DEBUG` for verbose logs. Default `INFO`.
+    - `IMPORT_ARCHIVE`: (Optional) Set to `true` to import `.sql` files from `archive/` on first run. Default: disabled.
 
 ## Running Locally
 

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -119,8 +119,14 @@ class TyperBot(commands.Bot):
     async def _run_archive_imports(self):
         """Run SQL files from archive folder if database is empty."""
         import glob
+        import os
 
         import aiosqlite
+
+        auto_import = os.getenv("IMPORT_ARCHIVE", "").lower() in ("true", "1", "yes")
+        if not auto_import:
+            logger.info("Archive import disabled (set IMPORT_ARCHIVE=true to enable)")
+            return
 
         try:
             async with (


### PR DESCRIPTION
Previously, SQL files in archive/ were automatically imported on first database initialization. This caused example data to be imported unexpectedly.

Now requires IMPORT_ARCHIVE=true to be set. Values accepted: true, 1, yes.

Changes:
- bot.py: Added env var check at start of _run_archive_imports()
- .env.example: Added IMPORT_ARCHIVE option
- README.md: Documented IMPORT_ARCHIVE in environment variables
- AGENTS.md: Added archive import to Common Tasks section