### PR TITLE
fix: Add timezone awareness to prevent deadline mismatches

### DIFF
--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -10,6 +10,7 @@ from discord.ext import commands, tasks
 from dotenv import load_dotenv
 
 from typer_bot.database import Database
+from typer_bot.utils import now, APP_TZ
 from typer_bot.utils.logger import set_trace_id
 
 logger = logging.getLogger(__name__)
@@ -197,13 +198,13 @@ class TyperBot(commands.Bot):
     @tasks.loop(minutes=1)
     async def reminder_task(self):
         """Check for reminders to send."""
-        now = datetime.now()
+        current_time = now()
 
-        if now.weekday() == 3 and now.hour == 19 and now.minute == 0:
+        if current_time.weekday() == 3 and current_time.hour == 19 and current_time.minute == 0:
             logger.info("Sending Thursday reminder...")
             await self.send_reminder("Thursday evening")
 
-        if now.weekday() == 4 and now.hour == 17 and now.minute == 0:
+        if current_time.weekday() == 4 and current_time.hour == 17 and current_time.minute == 0:
             logger.info("Sending Friday reminder...")
             await self.send_reminder("Friday evening")
 
@@ -223,7 +224,7 @@ class TyperBot(commands.Bot):
                     await channel.send(
                         f"📢 **{time_description} reminder!**\n\n"
                         f"Don't forget to submit your predictions for this week!\n"
-                        f"Deadline: **{deadline}**\n"
+                        f"Deadline: **{deadline} ({APP_TZ})**\n"
                         f"Use `/predict` to enter your scores."
                     )
                     logger.info(f"Reminder sent to channel {channel_id}")

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -8,7 +8,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from typer_bot.database import Database
-from typer_bot.utils import calculate_points, parse_line_predictions
+from typer_bot.utils import calculate_points, parse_line_predictions, now, parse_deadline, APP_TZ
 from typer_bot.utils.db_backup import create_backup, cleanup_old_backups
 
 # user_id -> {"channel_id": int, "guild_id": int, "games": list, "deadline": datetime, "step": str}
@@ -95,21 +95,23 @@ class AdminCommands(commands.Cog):
             state["games"] = games
             state["step"] = "deadline"
 
-            now = datetime.now()
-            days_until_friday = (4 - now.weekday()) % 7
-            if days_until_friday == 0 and now.hour >= 18:
+            current_time = now()
+            days_until_friday = (4 - current_time.weekday()) % 7
+            if days_until_friday == 0 and current_time.hour >= 18:
                 days_until_friday = 7
-            default_deadline = now + timedelta(days=days_until_friday)
+            default_deadline = current_time + timedelta(days=days_until_friday)
             default_deadline = default_deadline.replace(hour=18, minute=0, second=0, microsecond=0)
             state["default_deadline"] = default_deadline
 
             default_str = default_deadline.strftime("%A, %B %d at %H:%M")
             view = DeadlineChoiceView(self.db, user_id)
+            tz_name = str(APP_TZ)
             await message.author.send(
                 f"**Choose Deadline**\n\n"
                 f"Default: **{default_str}** (next Friday 18:00)\n\n"
                 f"Or type a custom deadline in format: `YYYY-MM-DD HH:MM`\n"
-                f"Example: `{now.strftime('%Y-%m-%d')} 20:00` for today at 8 PM",
+                f"Example: `{current_time.strftime('%Y-%m-%d')} 20:00` for today at 8 PM\n"
+                f"\n⚠️ All times are in **{tz_name}** timezone",
                 view=view,
             )
 
@@ -124,7 +126,8 @@ class AdminCommands(commands.Cog):
 
                 for fmt in formats:
                     try:
-                        deadline = datetime.strptime(message.content.strip(), fmt)
+                        naive_deadline = datetime.strptime(message.content.strip(), fmt)
+                        deadline = naive_deadline.replace(tzinfo=APP_TZ)
                         break
                     except ValueError:
                         continue
@@ -169,7 +172,7 @@ class AdminCommands(commands.Cog):
             lines.append(f"{i}. {game}")
 
         deadline_str = deadline.strftime("%A, %B %d at %H:%M")
-        lines.append(f"\n**Deadline:** {deadline_str}")
+        lines.append(f"\n**Deadline:** {deadline_str} ({APP_TZ})")
 
         warning = ""
         if len(games) != 9:
@@ -368,19 +371,19 @@ class AdminCommands(commands.Cog):
     async def _calculate_scores(self, interaction: discord.Interaction):
         """Calculate scores for current fixture."""
         user_id = str(interaction.user.id)
-        now = datetime.now().timestamp()
+        current_time = now().timestamp()
 
         if user_id in _calculate_cooldowns:
             last_used = _calculate_cooldowns[user_id]
-            if now - last_used < CALCULATE_COOLDOWN:
-                remaining = CALCULATE_COOLDOWN - (now - last_used)
+            if current_time - last_used < CALCULATE_COOLDOWN:
+                remaining = CALCULATE_COOLDOWN - (current_time - last_used)
                 await interaction.response.send_message(
                     f"⏳ Please wait {remaining:.1f}s before calculating again.",
                     ephemeral=True,
                 )
                 return
 
-        _calculate_cooldowns[user_id] = now
+        _calculate_cooldowns[user_id] = current_time
 
         fixture = await self.db.get_current_fixture()
         if not fixture:

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -7,7 +7,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from typer_bot.database import Database
-from typer_bot.utils import format_standings, parse_line_predictions
+from typer_bot.utils import format_standings, parse_line_predictions, now, APP_TZ
 
 # user_id -> (fixture_id, games)
 pending_predictions = {}
@@ -54,8 +54,8 @@ class UserCommands(commands.Cog):
         processing_msg = await message.author.send("⏳ Processing your predictions...")
 
         try:
-            now = datetime.now()
-            is_late = now > fixture["deadline"]
+            current_time = now()
+            is_late = current_time > fixture["deadline"]
 
             lines = message.content.strip().split("\n")
             predictions, errors = parse_line_predictions(lines, games)
@@ -75,7 +75,7 @@ class UserCommands(commands.Cog):
                 preview_lines.append(f"{i}. {game} **{pred}**")
 
             deadline_str = fixture["deadline"].strftime("%A, %B %d at %H:%M")
-            preview_lines.append(f"\n**Deadline:** {deadline_str}")
+            preview_lines.append(f"\n**Deadline:** {deadline_str} ({APP_TZ})")
 
             late_warning = ""
             if is_late:
@@ -150,7 +150,7 @@ class UserCommands(commands.Cog):
                 "```",
                 "",
                 "Add your score (e.g., 2:0 or 2-1) at the end of each line.",
-                f"\n**Deadline:** {fixture['deadline'].strftime('%A, %B %d at %H:%M')}",
+                f"\n**Deadline:** {fixture['deadline'].strftime('%A, %B %d at %H:%M')} ({APP_TZ})",
             ]
         )
 
@@ -259,7 +259,7 @@ class UserCommands(commands.Cog):
             lines.append(f"{i}. {game}")
 
         deadline_str = fixture["deadline"].strftime("%A, %B %d at %H:%M")
-        lines.append(f"\n**Deadline:** {deadline_str}")
+        lines.append(f"\n**Deadline:** {deadline_str} ({APP_TZ})")
 
         await interaction.response.send_message("\n".join(lines), ephemeral=True)
 
@@ -306,7 +306,7 @@ class UserCommands(commands.Cog):
 
         lines.extend(
             [
-                f"\n**Deadline:** {deadline_str}",
+                f"\n**Deadline:** {deadline_str} ({APP_TZ})",
                 f"**Status:** {late_status}",
                 f"**Submitted:** {submitted}",
             ]

--- a/typer_bot/database/database.py
+++ b/typer_bot/database/database.py
@@ -2,8 +2,11 @@
 
 import os
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import aiosqlite
+
+from typer_bot.utils import parse_iso
 
 
 class Database:
@@ -72,6 +75,11 @@ class Database:
 
     async def create_fixture(self, week_number: int, games: list[str], deadline: datetime) -> int:
         """Create a new fixture and return its ID."""
+        # Ensure deadline has timezone info before storing
+        if deadline.tzinfo is None:
+            from typer_bot.utils import APP_TZ
+
+            deadline = deadline.replace(tzinfo=APP_TZ)
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
                 "INSERT INTO fixtures (week_number, games, deadline) VALUES (?, ?, ?)",
@@ -93,7 +101,7 @@ class Database:
                         "id": row["id"],
                         "week_number": row["week_number"],
                         "games": row["games"].split("\n"),
-                        "deadline": datetime.fromisoformat(row["deadline"]),
+                        "deadline": parse_iso(row["deadline"]),
                         "status": row["status"],
                     }
                 return None
@@ -109,7 +117,7 @@ class Database:
                         "id": row["id"],
                         "week_number": row["week_number"],
                         "games": row["games"].split("\n"),
-                        "deadline": datetime.fromisoformat(row["deadline"]),
+                        "deadline": parse_iso(row["deadline"]),
                         "status": row["status"],
                     }
                 return None
@@ -149,7 +157,7 @@ class Database:
                         "user_id": row["user_id"],
                         "user_name": row["user_name"],
                         "predictions": row["predictions"].split("\n"),
-                        "submitted_at": datetime.fromisoformat(row["submitted_at"]),
+                        "submitted_at": parse_iso(row["submitted_at"]),
                         "is_late": row["is_late"],
                     }
                 return None
@@ -167,7 +175,7 @@ class Database:
                         "user_id": row["user_id"],
                         "user_name": row["user_name"],
                         "predictions": row["predictions"].split("\n"),
-                        "submitted_at": datetime.fromisoformat(row["submitted_at"]),
+                        "submitted_at": parse_iso(row["submitted_at"]),
                         "is_late": row["is_late"],
                     }
                     for row in rows

--- a/typer_bot/utils/__init__.py
+++ b/typer_bot/utils/__init__.py
@@ -2,10 +2,16 @@
 
 from .prediction_parser import format_standings, parse_line_predictions, parse_predictions
 from .scoring import calculate_points
+from .timezone import now, parse_deadline, format_for_display, parse_iso, APP_TZ
 
 __all__ = [
     "parse_predictions",
     "parse_line_predictions",
     "format_standings",
     "calculate_points",
+    "now",
+    "parse_deadline",
+    "format_for_display",
+    "parse_iso",
+    "APP_TZ",
 ]

--- a/typer_bot/utils/timezone.py
+++ b/typer_bot/utils/timezone.py
@@ -1,0 +1,44 @@
+"""Timezone utilities for the prediction bot.
+
+All datetime operations use a single configurable timezone (from TZ env var).
+"""
+
+import os
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+APP_TZ = ZoneInfo(os.getenv("TZ", "Europe/Warsaw"))
+
+
+def now() -> datetime:
+    """Get current time in the configured application timezone."""
+    return datetime.now(APP_TZ)
+
+
+def parse_deadline(date_str: str) -> datetime:
+    """Parse a naive datetime string and attach the application timezone.
+
+    Expected format: "YYYY-MM-DD HH:MM"
+    Returns timezone-aware datetime in APP_TZ.
+    """
+    naive = datetime.strptime(date_str.strip(), "%Y-%m-%d %H:%M")
+    return naive.replace(tzinfo=APP_TZ)
+
+
+def format_for_display(dt: datetime) -> str:
+    """Format datetime for user display, stripping timezone info.
+
+    Shows time in APP_TZ without the +HH:00 offset.
+    """
+    return dt.strftime("%A, %B %d at %H:%M")
+
+
+def parse_iso(iso_str: str) -> datetime:
+    """Parse ISO format string, ensuring timezone awareness.
+
+    Backward compatible: naive strings are treated as APP_TZ.
+    """
+    dt = datetime.fromisoformat(iso_str)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=APP_TZ)
+    return dt


### PR DESCRIPTION
- Create timezone.py module with APP_TZ config from TZ env var
- Replace all datetime.now() with now() returning aware datetimes
- Parse user deadline inputs with APP_TZ timezone attached
- Display timezone info in all deadline messages (e.g., 'Europe/Warsaw')
- Store datetimes with timezone offset in ISO format
- Add backward compatibility: parse_iso() treats naive strings as APP_TZ

Fixes bug where UTC server time caused 1+ hour deadline offset.