### PR TITLE
Centralize data path configuration to utils/config.py

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,27 @@
 # Discord Bot Token (required)
 DISCORD_TOKEN=your_bot_token_here
 
+# Data directory (optional)
+# Railway: /app/data (must use persistent volume)
+# Local: . (current directory)
+DATA_DIR=/app/data
+
+# Database path (optional)
+# Defaults to DATA_DIR/typer.db
+# Railway: /app/data/typer.db (must use persistent volume)
+# Local: typer.db
+# DB_PATH=/app/data/typer.db
+
+# Backup directory (optional)
+# Defaults to DATA_DIR/backups
+# BACKUP_DIR=/app/data/backups
+
 # Logging (optional)
 # Levels: DEBUG, INFO, WARNING, ERROR
 LOG_LEVEL=INFO
 
 # Channel ID for reminders (optional)
 REMINDER_CHANNEL_ID=123456789012345678
-
-# Database path (optional)
-# Railway: /app/data/typer.db (must use persistent volume)
-# Local: typer.db
-DB_PATH=/app/data/typer.db
 
 # Timezone (default: Europe/Warsaw)
 TZ=Europe/Warsaw

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ You are working on `matchday-typer`, a Discord bot for football prediction leagu
 
 ## 2. Critical Constraints
 - **Persistence:** The database (`typer.db`) MUST live in `/app/data` on production (Railway volume).
+- **Configuration:** All data paths configurable via env vars in `utils/config.py`:
+  - `DATA_DIR`: Base directory (default: `/app/data`)
+  - `DB_PATH`: Full database path (default: `{DATA_DIR}/typer.db`)
+  - `BACKUP_DIR`: Backup storage (default: `{DATA_DIR}/backups`)
 - **DM Workflow:** All complex inputs (predictions, fixture creation) happen in DMs to keep channel clean.
 - **Async:** All database ops must be async (`aiosqlite`).
 - **Parsing:** Use `utils.prediction_parser.parse_line_predictions` for all score parsing. Do NOT write ad-hoc regex.
@@ -56,6 +60,7 @@ scores (
 - `typer_bot/bot.py`: Entry point, setup hook, archive import logic.
 - `typer_bot/commands/user_commands.py`: `/predict`, `/standings` (Public).
 - `typer_bot/commands/admin_commands.py`: `/admin` hub (Protected).
+- `typer_bot/utils/config.py`: Centralized configuration (data paths via env vars).
 - `typer_bot/utils/prediction_parser.py`: Central logic for parsing "2-1" or "2:1" strings.
 - `typer_bot/utils/scoring.py`: Point calculation rules.
 - `typer_bot/utils/logger.py`: structured logging configuration for Railway.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ I recommend **Railway** because it's cheap/free and supports persistent storage 
    - If you skip this, your database will vanish every time you deploy.
 4. Set Variables:
    - `DISCORD_TOKEN`: Get this from Discord Developer Portal.
-   - `DB_PATH`: `/app/data/typer.db`
+   - `DATA_DIR`: (Optional) Base data directory. Default `/app/data`.
+   - `DB_PATH`: (Optional) Database path. Defaults to `{DATA_DIR}/typer.db`.
+   - `BACKUP_DIR`: (Optional) Backup storage. Defaults to `{DATA_DIR}/backups`.
    - `TZ`: (Optional) Timezone for deadlines. Default `Europe/Warsaw`. Examples: `America/New_York`, `Asia/Tokyo`.
    - `REMINDER_CHANNEL_ID`: (Optional) ID of channel to spam reminders in.
    - `LOG_LEVEL`: (Optional) Set to `DEBUG` for verbose logs. Default `INFO`.

--- a/scripts/restore_db.py
+++ b/scripts/restore_db.py
@@ -2,12 +2,14 @@
 """Manual database restore script - run from Railway console."""
 
 import argparse
-from datetime import datetime
-from pathlib import Path
 import re
 import shutil
 import sqlite3
 import sys
+from datetime import datetime
+from pathlib import Path
+
+from typer_bot.utils.config import DB_PATH
 
 
 def validate_backup_sql(sql_content: str) -> bool:
@@ -68,7 +70,7 @@ def main():
         print("Restore cancelled")
         sys.exit(0)
 
-    db_path = Path("/app/data/typer.db")
+    db_path = Path(DB_PATH)
 
     if db_path.exists():
         timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -9,6 +9,7 @@ from discord.ext import commands
 
 from typer_bot.database import Database
 from typer_bot.utils import APP_TZ, calculate_points, now, parse_line_predictions
+from typer_bot.utils.config import BACKUP_DIR
 from typer_bot.utils.db_backup import cleanup_old_backups, create_backup
 
 # user_id -> {"channel_id": int, "guild_id": int, "games": list, "deadline": datetime, "step": str}
@@ -423,10 +424,10 @@ class AdminCommands(commands.Cog):
         await self.db.save_scores(fixture["id"], scores)
         try:
             await self.bot.loop.run_in_executor(
-                None, lambda: create_backup(self.db.db_path, "/app/data/backups")
+                None, lambda: create_backup(self.db.db_path, BACKUP_DIR)
             )
             await self.bot.loop.run_in_executor(
-                None, lambda: cleanup_old_backups("/app/data/backups", keep=10)
+                None, lambda: cleanup_old_backups(BACKUP_DIR, keep=10)
             )
         except Exception as e:
             logger.warning(f"Backup failed but calculation succeeded: {e}")

--- a/typer_bot/database/database.py
+++ b/typer_bot/database/database.py
@@ -1,22 +1,24 @@
 """SQLite database operations for the prediction bot."""
 
-import os
 from datetime import datetime
 
 import aiosqlite
 
 from typer_bot.utils import parse_iso
+from typer_bot.utils.config import DB_PATH
 
 
 class Database:
     """SQLite database wrapper for football predictions."""
 
     def __init__(self, db_path: str = None):
-        self.db_path = db_path or os.getenv("DB_PATH", "typer.db")
+        self.db_path = db_path or DB_PATH
 
-        db_dir = os.path.dirname(self.db_path)
-        if db_dir and not os.path.exists(db_dir):
-            os.makedirs(db_dir, exist_ok=True)
+        from pathlib import Path
+
+        db_dir = Path(self.db_path).parent
+        if db_dir and not db_dir.exists():
+            db_dir.mkdir(parents=True, exist_ok=True)
 
     async def initialize(self):
         """Create tables if they don't exist."""

--- a/typer_bot/utils/config.py
+++ b/typer_bot/utils/config.py
@@ -1,0 +1,7 @@
+"""Configuration constants and environment variables."""
+
+import os
+
+DATA_DIR = os.getenv("DATA_DIR", "/app/data")
+DB_PATH = os.getenv("DB_PATH", f"{DATA_DIR}/typer.db")
+BACKUP_DIR = os.getenv("BACKUP_DIR", f"{DATA_DIR}/backups")


### PR DESCRIPTION
## Summary
- Add new `utils/config.py` module for centralized data path configuration
- Replace hardcoded paths with configurable environment variables
- Support flexible data directory, database path, and backup path configuration
## Changes
- **Created** `typer_bot/utils/config.py`: Centralized configuration constants (DATA_DIR, DB_PATH, BACKUP_DIR)
- **Updated** `typer_bot/database/database.py`: Import DB_PATH from config module
- **Updated** `typer_bot/commands/admin_commands.py`: Import and use BACKUP_DIR from config
- **Updated** `scripts/restore_db.py`: Import and use DB_PATH from config
- **Updated** `.env.example`: Document new DATA_DIR and BACKUP_DIR env vars
- **Updated** `AGENTS.md`: Add configuration section with new env vars
- **Updated** `README.md`: Update hosting instructions with new env vars
## Environment Variables
- `DATA_DIR`: Base data directory (default: `/app/data`)
- `DB_PATH`: Full database path (default: `{DATA_DIR}/typer.db`)
- `BACKUP_DIR`: Backup storage location (default: `{DATA_DIR}/backups`)
Backward compatible: Existing `DB_PATH` env var still works.