### PR TITLE
feat: Use Discord native timestamps for all user-facing dates

### DIFF
--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -66,26 +66,28 @@ class TestParseDeadline:
         assert result.tzinfo == tz_module.APP_TZ
 
 
-class TestFormatForDisplay:
-    """Test format_for_display() function."""
+class TestFormatForDiscord:
+    """Test format_for_discord() function."""
 
-    def test_formats_correctly(self):
-        """Format datetime without timezone offset."""
+    def test_formats_full_timestamp(self):
+        """Format datetime as Discord full timestamp."""
         dt = tz_module.parse_deadline("2024-03-15 14:30")
-        result = tz_module.format_for_display(dt)
-        assert result == "Friday, March 15 at 14:30"
+        result = tz_module.format_for_discord(dt, "F")
+        unix_ts = int(dt.timestamp())
+        assert result == f"<t:{unix_ts}:F>"
 
-    def test_handles_dst_time(self):
-        """Format DST datetime correctly."""
-        dt = tz_module.parse_deadline("2024-07-15 20:00")  # Summer/DST
-        result = tz_module.format_for_display(dt)
-        assert result == "Monday, July 15 at 20:00"
+    def test_formats_relative_timestamp(self):
+        """Format datetime as Discord relative timestamp."""
+        dt = tz_module.parse_deadline("2024-07-15 20:00")
+        result = tz_module.format_for_discord(dt, "R")
+        unix_ts = int(dt.timestamp())
+        assert result == f"<t:{unix_ts}:R>"
 
-    def test_midnight_formatting(self):
-        """Handle midnight correctly."""
-        dt = tz_module.parse_deadline("2024-01-01 00:00")
-        result = tz_module.format_for_display(dt)
-        assert result == "Monday, January 01 at 00:00"
+    def test_raises_on_naive_datetime(self):
+        """Must raise error on naive datetime."""
+        naive = datetime(2024, 3, 15, 14, 30)
+        with pytest.raises(ValueError, match="timezone-aware"):
+            tz_module.format_for_discord(naive)
 
 
 class TestParseIso:

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -9,7 +9,7 @@ from discord.ext import commands, tasks
 from dotenv import load_dotenv
 
 from typer_bot.database import Database
-from typer_bot.utils import APP_TZ, now
+from typer_bot.utils import format_for_discord, now
 from typer_bot.utils.logger import set_trace_id
 
 logger = logging.getLogger(__name__)
@@ -225,11 +225,12 @@ class TyperBot(commands.Bot):
             if channel:
                 fixture = await self.db.get_current_fixture()
                 if fixture:
-                    deadline = fixture["deadline"].strftime("%A %H:%M")
+                    deadline = format_for_discord(fixture["deadline"], "F")
+                    relative = format_for_discord(fixture["deadline"], "R")
                     await channel.send(
                         f"📢 **{time_description} reminder!**\n\n"
                         f"Don't forget to submit your predictions for this week!\n"
-                        f"Deadline: **{deadline} ({APP_TZ})**\n"
+                        f"Deadline: **{deadline}** ({relative})\n"
                         f"Use `/predict` to enter your scores."
                     )
                     logger.info(f"Reminder sent to channel {channel_id}")

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -9,7 +9,13 @@ from discord import app_commands
 from discord.ext import commands
 
 from typer_bot.database import Database
-from typer_bot.utils import APP_TZ, calculate_points, now, parse_line_predictions
+from typer_bot.utils import (
+    APP_TZ,
+    calculate_points,
+    format_for_discord,
+    now,
+    parse_line_predictions,
+)
 from typer_bot.utils.config import BACKUP_DIR
 from typer_bot.utils.db_backup import cleanup_old_backups, create_backup
 
@@ -105,15 +111,14 @@ class AdminCommands(commands.Cog):
             default_deadline = default_deadline.replace(hour=18, minute=0, second=0, microsecond=0)
             state["default_deadline"] = default_deadline
 
-            default_str = default_deadline.strftime("%A, %B %d at %H:%M")
+            default_str = format_for_discord(default_deadline, "F")
+            relative_str = format_for_discord(default_deadline, "R")
             view = DeadlineChoiceView(self.db, user_id)
-            tz_name = str(APP_TZ)
             await message.author.send(
                 f"**Choose Deadline**\n\n"
-                f"Default: **{default_str}** (next Friday 18:00)\n\n"
+                f"Default: **{default_str}** ({relative_str})\n\n"
                 f"Or type a custom deadline in format: `YYYY-MM-DD HH:MM`\n"
-                f"Example: `{current_time.strftime('%Y-%m-%d')} 20:00` for today at 8 PM\n"
-                f"\n⚠️ All times are in **{tz_name}** timezone",
+                f"Example: `{current_time.strftime('%Y-%m-%d')} 20:00` for today at 8 PM",
                 view=view,
             )
 
@@ -173,8 +178,9 @@ class AdminCommands(commands.Cog):
         for i, game in enumerate(games, 1):
             lines.append(f"{i}. {game}")
 
-        deadline_str = deadline.strftime("%A, %B %d at %H:%M")
-        lines.append(f"\n**Deadline:** {deadline_str} ({APP_TZ})")
+        deadline_str = format_for_discord(deadline, "F")
+        relative_str = format_for_discord(deadline, "R")
+        lines.append(f"\n**Deadline:** {deadline_str} ({relative_str})")
 
         warning = ""
         if len(games) != 9:

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -1,12 +1,16 @@
 """User-facing Discord commands."""
 
-
 import discord
 from discord import app_commands
 from discord.ext import commands
 
 from typer_bot.database import Database
-from typer_bot.utils import APP_TZ, format_standings, now, parse_line_predictions
+from typer_bot.utils import (
+    format_for_discord,
+    format_standings,
+    now,
+    parse_line_predictions,
+)
 
 # user_id -> (fixture_id, games)
 pending_predictions = {}
@@ -73,8 +77,9 @@ class UserCommands(commands.Cog):
             for i, (game, pred) in enumerate(zip(games, predictions, strict=False), 1):
                 preview_lines.append(f"{i}. {game} **{pred}**")
 
-            deadline_str = fixture["deadline"].strftime("%A, %B %d at %H:%M")
-            preview_lines.append(f"\n**Deadline:** {deadline_str} ({APP_TZ})")
+            deadline_str = format_for_discord(fixture["deadline"], "F")
+            relative_str = format_for_discord(fixture["deadline"], "R")
+            preview_lines.append(f"\n**Deadline:** {deadline_str} ({relative_str})")
 
             late_warning = ""
             if is_late:
@@ -144,12 +149,14 @@ class UserCommands(commands.Cog):
         ]
         for game in fixture["games"]:
             lines.append(f"{game} 2:0")
+        deadline_str = format_for_discord(fixture["deadline"], "F")
+        relative_str = format_for_discord(fixture["deadline"], "R")
         lines.extend(
             [
                 "```",
                 "",
                 "Add your score (e.g., 2:0 or 2-1) at the end of each line.",
-                f"\n**Deadline:** {fixture['deadline'].strftime('%A, %B %d at %H:%M')} ({APP_TZ})",
+                f"\n**Deadline:** {deadline_str} ({relative_str})",
             ]
         )
 
@@ -257,8 +264,9 @@ class UserCommands(commands.Cog):
         for i, game in enumerate(fixture["games"], 1):
             lines.append(f"{i}. {game}")
 
-        deadline_str = fixture["deadline"].strftime("%A, %B %d at %H:%M")
-        lines.append(f"\n**Deadline:** {deadline_str} ({APP_TZ})")
+        deadline_str = format_for_discord(fixture["deadline"], "F")
+        relative_str = format_for_discord(fixture["deadline"], "R")
+        lines.append(f"\n**Deadline:** {deadline_str} ({relative_str})")
 
         await interaction.response.send_message("\n".join(lines), ephemeral=True)
 
@@ -300,12 +308,13 @@ class UserCommands(commands.Cog):
             lines.append(f"{i}. {game} **{pred}**")
 
         late_status = "⚠️ **LATE**" if prediction["is_late"] else "✅ On time"
-        submitted = prediction["submitted_at"].strftime("%Y-%m-%d %H:%M")
-        deadline_str = fixture["deadline"].strftime("%A, %B %d at %H:%M")
+        submitted = format_for_discord(prediction["submitted_at"], "f")
+        deadline_str = format_for_discord(fixture["deadline"], "F")
+        relative_str = format_for_discord(fixture["deadline"], "R")
 
         lines.extend(
             [
-                f"\n**Deadline:** {deadline_str} ({APP_TZ})",
+                f"\n**Deadline:** {deadline_str} ({relative_str})",
                 f"**Status:** {late_status}",
                 f"**Submitted:** {submitted}",
             ]

--- a/typer_bot/utils/__init__.py
+++ b/typer_bot/utils/__init__.py
@@ -2,7 +2,7 @@
 
 from .prediction_parser import format_standings, parse_line_predictions, parse_predictions
 from .scoring import calculate_points
-from .timezone import APP_TZ, format_for_display, now, parse_deadline, parse_iso
+from .timezone import APP_TZ, format_for_discord, now, parse_deadline, parse_iso
 
 __all__ = [
     "parse_predictions",
@@ -11,7 +11,7 @@ __all__ = [
     "calculate_points",
     "now",
     "parse_deadline",
-    "format_for_display",
+    "format_for_discord",
     "parse_iso",
     "APP_TZ",
 ]

--- a/typer_bot/utils/timezone.py
+++ b/typer_bot/utils/timezone.py
@@ -25,12 +25,20 @@ def parse_deadline(date_str: str) -> datetime:
     return naive.replace(tzinfo=APP_TZ)
 
 
-def format_for_display(dt: datetime) -> str:
-    """Format datetime for user display, stripping timezone info.
+def format_for_discord(dt: datetime, format_code: str = "F") -> str:
+    """Format datetime as Discord timestamp (auto-converts to user's local time).
 
-    Shows time in APP_TZ without the +HH:00 offset.
+    Args:
+        dt: Timezone-aware datetime object
+        format_code: Discord format code - F/f/D/d/t/T/R
+
+    Returns:
+        Discord timestamp string like "<t:{unix}:F>"
     """
-    return dt.strftime("%A, %B %d at %H:%M")
+    if dt.tzinfo is None:
+        raise ValueError("datetime must be timezone-aware")
+    unix_timestamp = int(dt.timestamp())
+    return f"<t:{unix_timestamp}:{format_code}>"
 
 
 def parse_iso(iso_str: str) -> datetime:


### PR DESCRIPTION
Replace all user-facing date displays with Discord native timestamps that auto-convert to each user's local timezone.
## Changes
- Added <t:unix:format> timestamp formatting via `format_for_discord()`
- All deadlines now show absolute + relative time (e.g., 'Friday... (in 2 days)')
- Removed APP_TZ timezone labels - no longer needed
- Updated tests for new formatting function
## User Impact
Users in different timezones will see deadlines correctly localized. Discord handles the conversion automatically.