### PR TITLE
feat: allow 'x' for nullifying cancelled/postponed games

### DIFF
--- a/tests/test_prediction_parser.py
+++ b/tests/test_prediction_parser.py
@@ -152,6 +152,38 @@ class TestParseLinePredictions:
         assert predictions == ["2-1", "1-0"]
         assert not errors
 
+    def test_nullified_game_lowercase_x(self):
+        """Parse 'x' as nullified game marker."""
+        lines = ["Team A 2-1", "Team B x"]
+        games = ["Team A", "Team B"]
+        predictions, errors = parse_line_predictions(lines, games)
+        assert predictions == ["2-1", "x"]
+        assert not errors
+
+    def test_nullified_game_uppercase_x(self):
+        """Parse 'X' as nullified game marker (case insensitive)."""
+        lines = ["Team A 2-1", "Team B X"]
+        games = ["Team A", "Team B"]
+        predictions, errors = parse_line_predictions(lines, games)
+        assert predictions == ["2-1", "x"]
+        assert not errors
+
+    def test_mixed_scores_and_nullified(self):
+        """Mix of regular scores and nullified games."""
+        lines = ["Team A 2-1", "Team B x", "Team C 0-0", "Team D X"]
+        games = ["Team A", "Team B", "Team C", "Team D"]
+        predictions, errors = parse_line_predictions(lines, games)
+        assert predictions == ["2-1", "x", "0-0", "x"]
+        assert not errors
+
+    def test_nullified_with_whitespace(self):
+        """Nullified marker with trailing whitespace."""
+        lines = ["Team A x   ", "Team B X   "]
+        games = ["Team A", "Team B"]
+        predictions, errors = parse_line_predictions(lines, games)
+        assert predictions == ["x", "x"]
+        assert not errors
+
 
 class TestFormatPredictionsPreview:
     """Test suite for format_predictions_preview function."""

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -95,3 +95,47 @@ class TestCalculatePoints:
         # Raw colon format would raise ValueError (int("2:1") fails)
         with pytest.raises(ValueError):
             calculate_points(["2:1"], ["2:1"])
+
+    def test_nullified_game_excluded_from_scoring(self):
+        """Games marked with 'x' should be excluded from scoring calculations."""
+        predictions = ["2-1", "3-0", "1-1"]
+        actual = ["2-1", "x", "1-1"]
+        result = calculate_points(predictions, actual)
+
+        # Should only score 2 games (excluding the nullified middle one)
+        assert result["points"] == 6  # 3 (exact) + 3 (exact)
+        assert result["exact_scores"] == 2
+        assert result["correct_results"] == 0
+
+    def test_multiple_nullified_games(self):
+        """Multiple nullified games should all be excluded."""
+        predictions = ["2-1", "3-0", "1-1", "0-0", "2-2"]
+        actual = ["2-1", "x", "1-1", "x", "2-2"]
+        result = calculate_points(predictions, actual)
+
+        # Should only score 3 games (positions 0, 2, 4)
+        assert result["points"] == 9  # 3 + 3 + 3 (all exact)
+        assert result["exact_scores"] == 3
+        assert result["correct_results"] == 0
+
+    def test_all_games_nullified(self):
+        """When all games are nullified, everyone gets 0 points."""
+        predictions = ["2-1", "3-0", "1-1"]
+        actual = ["x", "x", "x"]
+        result = calculate_points(predictions, actual)
+
+        assert result["points"] == 0
+        assert result["exact_scores"] == 0
+        assert result["correct_results"] == 0
+
+    def test_nullified_with_mixed_outcomes(self):
+        """Nullified games mixed with exact, correct outcome, and wrong predictions."""
+        predictions = ["2-1", "3-0", "1-1", "0-2", "2-0"]
+        # Results: exact, nullified, exact, wrong (predicted draw, actual home win), correct outcome
+        actual = ["2-1", "x", "1-1", "1-0", "3-1"]
+        result = calculate_points(predictions, actual)
+
+        # Points: 3 (exact) + 0 (nullified) + 3 (exact) + 0 (wrong) + 1 (correct outcome)
+        assert result["points"] == 7
+        assert result["exact_scores"] == 2
+        assert result["correct_results"] == 1

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -366,6 +366,7 @@ class AdminCommands(commands.Cog):
                     "```",
                     "",
                     "Add the actual score (e.g., 2:0 or 2-1) at the end of each line.",
+                    "Type 'x' for cancelled or postponed games.",
                 ]
             )
             await interaction.user.send("\n".join(lines))

--- a/typer_bot/utils/prediction_parser.py
+++ b/typer_bot/utils/prediction_parser.py
@@ -61,14 +61,23 @@ def parse_line_predictions(lines: list[str], games: list[str]) -> tuple[list[str
         return predictions, errors
 
     for i, line in enumerate(lines):
-        match = re.search(r"(\d+)\s*[-:]\s*(\d+)\s*$", line.strip())
+        stripped = line.strip()
+
+        # Check for nullified game marker (x or X)
+        if re.search(r"[xX]\s*$", stripped):
+            predictions.append("x")
+            logger.debug(f"Line {i + 1}: Parsed nullified game (x)")
+            continue
+
+        # Check for score pattern
+        match = re.search(r"(\d+)\s*[-:]\s*(\d+)\s*$", stripped)
         if match:
             home_score = match.group(1)
             away_score = match.group(2)
             predictions.append(f"{home_score}-{away_score}")
             logger.debug(f"Line {i + 1}: Parsed {home_score}-{away_score}")
         else:
-            error_msg = f"Line {i + 1}: Could not find score (expected format: '2:0' or '2-1')"
+            error_msg = f"Line {i + 1}: Could not find score (expected format: '2:0' or '2-1', or 'x' for cancelled games)"
             logger.warning(f"Parse error on line {i + 1}: '{line[:50]}...'")
             errors.append(error_msg)
 

--- a/typer_bot/utils/scoring.py
+++ b/typer_bot/utils/scoring.py
@@ -25,6 +25,10 @@ def calculate_points(
     correct_count = 0
 
     for pred, actual in zip(predictions, actual_results, strict=False):
+        # Skip nullified games (marked with 'x')
+        if actual == "x":
+            continue
+
         pred_home, pred_away = map(int, pred.split("-"))
         actual_home, actual_away = map(int, actual.split("-"))
 


### PR DESCRIPTION
- Update prediction_parser to accept 'x'/'X' as valid result marker
- Modify scoring to exclude nullified games from calculations
- Update admin instructions to mention 'x' option
- Add comprehensive tests for nullified game handling

Nullified games are excluded entirely from scoring, reducing max points proportionally.