### PR TITLE
feat: add portable environment detection with smoke test mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 # Discord Bot Token (required)
 DISCORD_TOKEN=your_bot_token_here
 
+# Environment (optional)
+# Set to "production" for production deployments on Railway, Coolify, etc.
+# If not set or set to "development", the bot runs in smoke test mode
+# (validates config but exits without connecting to Discord).
+# This prevents race conditions when multiple deployments share the same token.
+# ENVIRONMENT=production
+
 # Data directory (optional)
 # Railway: /app/data (must use persistent volume)
 # Local: . (current directory)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,3 +79,11 @@ scores (
 - **Double Digits:** Scores like `10-0` are allowed.
 - **Format:** Users provide flexible separators (`-`, `:`, `–`).
 - **History:** `archive/` folder contains SQL files auto-imported on first run (empty DB).
+
+## 7. Deployment Environment
+- **Configuration:** The `ENVIRONMENT` variable controls bot behavior:
+  - `production`: Bot connects to Discord and runs normally
+  - Not set/`development`: Bot runs in "smoke test" mode - validates config then exits
+- **Purpose:** Prevents race conditions when multiple deployments (e.g., PR previews) share the same Discord token
+- **Railway:** Set `ENVIRONMENT=production` in Railway variables for production deployments
+- **Portability:** Works on any platform (Railway, Coolify, local, etc.) - just set the variable accordingly

--- a/railway.toml
+++ b/railway.toml
@@ -5,3 +5,9 @@ builder = "railpack"
 startCommand = "python -m typer_bot"
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 10
+
+# Environment Configuration:
+# Set ENVIRONMENT=production in Railway variables for production deployments.
+# PR deployments without ENVIRONMENT=production will run in smoke test mode
+# (bot starts, validates config, then exits successfully without connecting to Discord).
+# This prevents race conditions when multiple deployments share the same token.

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -11,6 +11,7 @@ from dotenv import load_dotenv
 
 from typer_bot.database import Database
 from typer_bot.utils import format_for_discord, now
+from typer_bot.utils.config import IS_PRODUCTION
 from typer_bot.utils.logger import set_trace_id
 
 logger = logging.getLogger(__name__)
@@ -272,6 +273,12 @@ def main():
         sys.exit(1)
 
     logger.info(f"Token check: Token starts with '{token[:20]}...'")
+
+    if not IS_PRODUCTION:
+        logger.info("⚠️  ENVIRONMENT is not 'production' - running in smoke test mode")
+        logger.info("✅ Smoke test successful - deployment validated, exiting")
+        sys.exit(0)
+
     logger.info("Creating TyperBot instance...")
 
     try:

--- a/typer_bot/utils/config.py
+++ b/typer_bot/utils/config.py
@@ -2,6 +2,10 @@
 
 import os
 
+# Environment configuration - supports any platform (Railway, Coolify, local, etc.)
+ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+IS_PRODUCTION = ENVIRONMENT.lower() in ("production", "prod")
+
 DATA_DIR = os.getenv("DATA_DIR", "/app/data")
 DB_PATH = os.getenv("DB_PATH", f"{DATA_DIR}/typer.db")
 BACKUP_DIR = os.getenv("BACKUP_DIR", f"{DATA_DIR}/backups")


### PR DESCRIPTION
Add ENVIRONMENT variable to control bot behavior across platforms:
- Set ENVIRONMENT=production for full bot operation
- Defaults to smoke test mode (validates config, exits without connecting)
- Prevents race conditions when multiple deployments share Discord token

Changes:
- utils/config.py: Add ENVIRONMENT and IS_PRODUCTION variables
- bot.py: Exit early if not in production mode
- railway.toml: Document environment configuration
- .env.example: Add ENVIRONMENT with documentation
- AGENTS.md: Add deployment environment section