### PR TITLE
Enable Members intent to fix admin permission checks

### DIFF
--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -30,6 +30,7 @@ class TyperBot(commands.Bot):
         logger.info("Initializing TyperBot...")
         intents = discord.Intents.default()
         intents.message_content = True
+        intents.members = True
 
         super().__init__(command_prefix="!", intents=intents, help_command=None)
 


### PR DESCRIPTION
The bot needs to access guild member roles to verify admin permissions. Without the Members intent, guild.get_member() returns None, causing permission denied errors even for users with the correct role.

Requires Server Members Intent to be enabled in Discord Developer Portal.