### PR TITLE
feat: Add refresh_usernames admin command and update results display

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ A Discord bot for running weekly football prediction games with your friends. I 
 You need a Discord role named `Admin` or `typer-admin`.
 1. **Create Fixture**: `/admin fixture` -> DM the list of games -> Set deadline.
 2. **Game Over**: `/admin results` -> Enter the actual scores.
-3. **Calc**: `/admin calculate` -> Bot does the math and posts the results.
+3. **Calc**: `/admin calculate` -> Bot does the math and posts the results to the channel.
+4. **Refresh Usernames**: `/admin refresh_usernames` -> Updates all usernames from Discord (useful after importing historical data).
 
 ## Hosting (The Easy Way)
 

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -329,6 +329,7 @@ class AdminCommands(commands.Cog):
             app_commands.Choice(name="results", value="results"),
             app_commands.Choice(name="calculate", value="calculate"),
             app_commands.Choice(name="delete", value="delete"),
+            app_commands.Choice(name="refresh_usernames", value="refresh_usernames"),
         ]
     )
     async def admin(self, interaction: discord.Interaction, action: app_commands.Choice[str]):
@@ -347,6 +348,8 @@ class AdminCommands(commands.Cog):
             await self._calculate_scores(interaction)
         elif action.value == "delete":
             await self._delete_fixture(interaction)
+        elif action.value == "refresh_usernames":
+            await self._refresh_usernames(interaction)
 
     async def _create_fixture(self, interaction: discord.Interaction):
         """Initiate fixture creation via DM."""
@@ -432,7 +435,7 @@ class AdminCommands(commands.Cog):
             )
 
     async def _calculate_scores(self, interaction: discord.Interaction):
-        """Calculate scores for current fixture."""
+        """Calculate scores for current fixture and post to channel."""
         user_id = str(interaction.user.id)
         current_time = now().timestamp()
 
@@ -469,13 +472,13 @@ class AdminCommands(commands.Cog):
             )
             return
 
+        # Calculate scores
         scores = []
         for pred in predictions:
             score_data = calculate_points(pred["predictions"], results, pred["is_late"])
             scores.append(
                 {
                     "user_id": pred["user_id"],
-                    "user_name": pred["user_name"],
                     "points": score_data["points"],
                     "exact_scores": score_data["exact_scores"],
                     "correct_results": score_data["correct_results"],
@@ -484,6 +487,8 @@ class AdminCommands(commands.Cog):
 
         scores.sort(key=lambda x: x["points"], reverse=True)
         await self.db.save_scores(fixture["id"], scores)
+
+        # Create backup
         try:
             await self.bot.loop.run_in_executor(
                 None, lambda: create_backup(self.db.db_path, BACKUP_DIR)
@@ -493,14 +498,34 @@ class AdminCommands(commands.Cog):
             )
         except Exception as e:
             logger.warning(f"Backup failed but calculation succeeded: {e}")
+
+        # Build results message with mentions
         lines = [f"🏆 **Week {fixture['week_number']} Results**\n"]
         for i, score in enumerate(scores, 1):
             lines.append(
-                f"{i}. **{score['user_name']}**: {score['points']} pts "
+                f"{i}. <@{score['user_id']}>: {score['points']} pts "
                 f"({score['exact_scores']} exact, {score['correct_results']} correct)"
             )
 
-        await interaction.response.send_message("\n".join(lines))
+        results_message = "\n".join(lines)
+
+        # Post to channel
+        channel = interaction.channel
+        if channel:
+            try:
+                await channel.send(results_message)
+                await interaction.response.send_message(
+                    f"✅ Week {fixture['week_number']} results posted to this channel!",
+                    ephemeral=True,
+                )
+            except Exception as e:
+                logger.error(f"Failed to post results to channel: {e}")
+                await interaction.response.send_message(
+                    f"✅ Scores calculated but failed to post to channel.\n\n{results_message}",
+                    ephemeral=True,
+                )
+        else:
+            await interaction.response.send_message(results_message, ephemeral=True)
 
     @app_commands.command(name="health", description="Check bot health status")
     async def health_check(self, interaction: discord.Interaction):
@@ -553,6 +578,56 @@ class AdminCommands(commands.Cog):
             view=view,
             ephemeral=True,
         )
+
+    async def _refresh_usernames(self, interaction: discord.Interaction):
+        """Refresh all usernames in the database from Discord."""
+        if not self.is_admin(interaction.user):
+            await interaction.response.send_message(
+                "❌ You don't have permission to use this command.", ephemeral=True
+            )
+            return
+
+        await interaction.response.send_message(
+            "🔄 Refreshing usernames from Discord...", ephemeral=True
+        )
+
+        try:
+            user_ids = await self.db.get_all_user_ids()
+            updated = 0
+            failed = 0
+            not_found = []
+
+            for user_id in user_ids:
+                try:
+                    user = self.bot.get_user(int(user_id))
+                    if not user:
+                        # Try to fetch from API if not in cache
+                        try:
+                            user = await self.bot.fetch_user(int(user_id))
+                        except discord.NotFound:
+                            not_found.append(user_id)
+                            failed += 1
+                            continue
+
+                    if user:
+                        await self.db.update_username(user_id, user.display_name)
+                        updated += 1
+                except Exception as e:
+                    logger.warning(f"Failed to update username for {user_id}: {e}")
+                    failed += 1
+
+            # Build summary message
+            lines = ["✅ **Username Refresh Complete**\n"]
+            lines.append(f"Updated: {updated}")
+            lines.append(f"Failed: {failed}")
+            if not_found:
+                lines.append(f"\nUsers not found: {len(not_found)}")
+
+            await interaction.edit_original_response(content="\n".join(lines))
+
+        except Exception as e:
+            logger.exception("Error refreshing usernames")
+            await interaction.edit_original_response(content=f"❌ Error refreshing usernames: {e}")
 
 
 class DeadlineChoiceView(discord.ui.View):

--- a/typer_bot/database/database.py
+++ b/typer_bot/database/database.py
@@ -292,3 +292,26 @@ class Database:
             await db.execute("DELETE FROM predictions WHERE fixture_id = ?", (fixture_id,))
             await db.execute("DELETE FROM fixtures WHERE id = ?", (fixture_id,))
             await db.commit()
+
+    async def get_all_user_ids(self) -> list[str]:
+        """Get all unique user IDs from predictions and scores."""
+        async with aiosqlite.connect(self.db_path) as db:
+            user_ids = set()
+            async with db.execute("SELECT DISTINCT user_id FROM predictions") as cursor:
+                async for row in cursor:
+                    user_ids.add(row[0])
+            async with db.execute("SELECT DISTINCT user_id FROM scores") as cursor:
+                async for row in cursor:
+                    user_ids.add(row[0])
+            return list(user_ids)
+
+    async def update_username(self, user_id: str, user_name: str):
+        """Update username for a user across all tables."""
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "UPDATE predictions SET user_name = ? WHERE user_id = ?", (user_name, user_id)
+            )
+            await db.execute(
+                "UPDATE scores SET user_name = ? WHERE user_id = ?", (user_name, user_id)
+            )
+            await db.commit()


### PR DESCRIPTION
- Add /admin refresh_usernames command to update all usernames from Discord
- Update /admin calculate to post results to the channel instead of ephemeral reply
- Change results display to use Discord mentions (@user) instead of stored usernames
- Add database methods: get_all_user_ids() and update_username()
- Update README with new admin command documentation

This fixes the issue where imported historical data showed truncated usernames like 'User_12345' instead of actual Discord display names.