### PR TITLE
Fix standings table alignment for usernames with emojis

### DIFF
--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -1,9 +1,7 @@
 """Admin Discord commands."""
 
 import logging
-from datetime import datetime, timedelta
 
-import aiosqlite
 import discord
 from discord import app_commands
 from discord.ext import commands
@@ -11,10 +9,9 @@ from discord.ext import commands
 from typer_bot.database import Database
 from typer_bot.handlers import FixtureCreationHandler, ResultsEntryHandler
 from typer_bot.utils import (
-    APP_TZ,
     calculate_points,
-    format_for_discord,
     now,
+    visual_truncate,
 )
 from typer_bot.utils.config import BACKUP_DIR
 from typer_bot.utils.db_backup import cleanup_old_backups, create_backup
@@ -275,10 +272,10 @@ class AdminCommands(commands.Cog):
             lines.append("----  --------------------    -----  -------  ------")
 
             for i, score in enumerate(scores, 1):
-                user_name = score["user_name"][:20].ljust(20)
+                user_name = visual_truncate(score["user_name"], 20)
                 lines.append(
                     f"{i:4}  {user_name}  {score['exact_scores']:5}  "
-                    f"{score['correct_results']:7}  {score['points']}"
+                    f"{score['correct_results']:7}  {score['points']:>4}"
                 )
 
             lines.append("```")
@@ -302,7 +299,7 @@ class AdminCommands(commands.Cog):
                         last_week_points[score["user_id"]] = score["points"]
 
                 for i, user in enumerate(standings, 1):
-                    user_name = user["user_name"][:20].ljust(20)
+                    user_name = visual_truncate(user["user_name"], 20)
                     total_points = user["total_points"]
 
                     # Calculate delta from last week
@@ -312,7 +309,7 @@ class AdminCommands(commands.Cog):
 
                     lines.append(
                         f"{i:4}  {user_name}  {user['total_exact']:5}  "
-                        f"{user['total_correct']:7}  {total_points}{delta}"
+                        f"{user['total_correct']:7}  {total_points:>4}{delta}"
                     )
             else:
                 lines.append("No standings yet!")
@@ -359,10 +356,10 @@ class AdminCommands(commands.Cog):
         lines.append("----  --------------------    -----  -------  ------")
 
         for i, score in enumerate(fixture_data["scores"], 1):
-            user_name = score["user_name"][:20].ljust(20)
+            user_name = visual_truncate(score["user_name"], 20)
             lines.append(
                 f"{i:4}  {user_name}  {score['exact_scores']:5}  "
-                f"{score['correct_results']:7}  {score['points']}"
+                f"{score['correct_results']:7}  {score['points']:>4}"
             )
 
         lines.append("```")
@@ -440,10 +437,10 @@ class PostResultsConfirmView(discord.ui.View):
         lines.append("----  --------------------    -----  -------  ------")
 
         for i, score in enumerate(self.fixture_data["scores"], 1):
-            user_name = score["user_name"][:20].ljust(20)
+            user_name = visual_truncate(score["user_name"], 20)
             lines.append(
                 f"{i:4}  {user_name}  {score['exact_scores']:5}  "
-                f"{score['correct_results']:7}  {score['points']}"
+                f"{score['correct_results']:7}  {score['points']:>4}"
             )
 
         lines.append("```")
@@ -469,10 +466,10 @@ class PostResultsConfirmView(discord.ui.View):
         lines.append("----  --------------------    -----  -------  ------")
 
         for i, score in enumerate(self.fixture_data["scores"], 1):
-            user_name = score["user_name"][:20].ljust(20)
+            user_name = visual_truncate(score["user_name"], 20)
             lines.append(
                 f"{i:4}  {user_name}  {score['exact_scores']:5}  "
-                f"{score['correct_results']:7}  {score['points']}"
+                f"{score['correct_results']:7}  {score['points']:>4}"
             )
 
         lines.append("```")

--- a/typer_bot/utils/__init__.py
+++ b/typer_bot/utils/__init__.py
@@ -1,6 +1,11 @@
 """Utility functions and helpers."""
 
-from .prediction_parser import format_standings, parse_line_predictions, parse_predictions
+from .prediction_parser import (
+    format_standings,
+    parse_line_predictions,
+    parse_predictions,
+    visual_truncate,
+)
 from .scoring import calculate_points
 from .timezone import APP_TZ, format_for_discord, now, parse_deadline, parse_iso
 

--- a/typer_bot/utils/prediction_parser.py
+++ b/typer_bot/utils/prediction_parser.py
@@ -87,6 +87,20 @@ def parse_line_predictions(lines: list[str], games: list[str]) -> tuple[list[str
     return predictions, errors
 
 
+def visual_truncate(text: str, max_width: int = 20) -> str:
+    """Truncate text to fit visual display width, accounting for wide chars."""
+    width = 0
+    result = []
+    for char in text:
+        # Approximate: ASCII=1, CJK/emoji=2
+        char_width = 2 if ord(char) > 127 else 1
+        if width + char_width > max_width:
+            break
+        width += char_width
+        result.append(char)
+    return "".join(result).ljust(max_width)
+
+
 def format_standings(standings: list[dict], last_fixture: dict | None) -> str:
     """Format standings table for Discord using code blocks for proper alignment."""
     lines = []
@@ -107,7 +121,7 @@ def format_standings(standings: list[dict], last_fixture: dict | None) -> str:
                 last_week_points[score["user_id"]] = score["points"]
 
         for i, user in enumerate(standings, 1):
-            user_name = user["user_name"][:20].ljust(20)
+            user_name = visual_truncate(user["user_name"], 20)
             total_points = user["total_points"]
 
             # Calculate delta from last week
@@ -116,7 +130,7 @@ def format_standings(standings: list[dict], last_fixture: dict | None) -> str:
                 delta = f" (+{last_week_points[user['user_id']]})"
 
             lines.append(
-                f"{i:4}  {user_name}  {user['total_exact']:5}  {user['total_correct']:7}  {total_points}{delta}"
+                f"{i:4}  {user_name}  {user['total_exact']:5}  {user['total_correct']:7}  {total_points:>4}{delta}"
             )
 
     lines.append("```")
@@ -130,9 +144,9 @@ def format_standings(standings: list[dict], last_fixture: dict | None) -> str:
         lines.append("----  --------------------    -----  -------  ------")
 
         for i, score in enumerate(last_fixture["scores"], 1):
-            user_name = score["user_name"][:20].ljust(20)
+            user_name = visual_truncate(score["user_name"], 20)
             lines.append(
-                f"{i:4}  {user_name}  {score['exact_scores']:5}  {score['correct_results']:7}  {score['points']}"
+                f"{i:4}  {user_name}  {score['exact_scores']:5}  {score['correct_results']:7}  {score['points']:>4}"
             )
 
         lines.append("```")


### PR DESCRIPTION
- Add visual_truncate() helper to handle wide characters (emojis, CJK)
- Replace simple ljust(20) with visual_truncate() for consistent width
- Fix Points column alignment using right-align (>{width})
- Apply fixes across format_standings() and admin_commands.py