### PR TITLE
feat: add fallback DM when reaction permission missing (fixes #38)

### DIFF
--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -358,6 +358,51 @@ class TestEdgeCases:
         assert "❌" in mock_message.reactions_added
         assert "Invalid predictions" in mock_message.author.dm_sent[0]
 
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_thread")
+    async def test_sends_fallback_dm_on_reaction_permission_error(
+        self, handler, mock_message, monkeypatch
+    ):
+        """Should send DM when adding reaction fails (Fallback logic)."""
+        import discord
+
+        mock_message.channel.id = 789012
+        mock_message.content = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        async def raise_forbidden(*_args, **_kwargs):
+            raise discord.Forbidden(MagicMock(), "Missing permissions")
+
+        monkeypatch.setattr(mock_message, "add_reaction", raise_forbidden)
+
+        result = await handler.on_message(mock_message)
+
+        assert result is True
+        predictions = await handler.db.get_all_predictions(1)
+        assert len(predictions) == 1
+        assert len(mock_message.author.dm_sent) == 1
+        assert "Prediction saved" in mock_message.author.dm_sent[0]
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_thread")
+    async def test_survives_double_permission_failure(self, handler, mock_message, monkeypatch):
+        """Should not crash if both Reaction and DM fail (Degraded UX)."""
+        import discord
+
+        mock_message.channel.id = 789012
+        mock_message.content = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        async def raise_forbidden(*_args, **_kwargs):
+            raise discord.Forbidden(MagicMock(), "Missing permissions")
+
+        monkeypatch.setattr(mock_message, "add_reaction", raise_forbidden)
+        monkeypatch.setattr(mock_message.author, "send", raise_forbidden)
+
+        result = await handler.on_message(mock_message)
+
+        assert result is True
+        predictions = await handler.db.get_all_predictions(1)
+        assert len(predictions) == 1
+
 
 class TestIntegration:
     """Integration tests for full workflow scenarios."""

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -231,6 +231,9 @@ class TyperBot(commands.Bot):
         for guild in self.guilds:
             logger.info(f"  - {guild.name} (ID: {guild.id})")
 
+        # Check bot permissions on all guilds
+        await self._check_permissions()
+
         # Auto-refresh usernames on startup
         await self._refresh_usernames()
 
@@ -393,6 +396,37 @@ class TyperBot(commands.Bot):
 
         except Exception as e:
             logger.exception(f"Error during thread sync: {e}")
+
+    async def _check_permissions(self):
+        """Check bot permissions on all guilds.
+
+        Logs warnings if the bot is missing critical permissions.
+        """
+        required_permissions = [
+            ("send_messages", "Send Messages"),
+            ("read_message_history", "Read Message History"),
+            ("add_reactions", "Add Reactions"),
+            ("manage_messages", "Manage Messages"),
+        ]
+
+        for guild in self.guilds:
+            me = guild.me
+            if not me:
+                logger.warning(f"Bot not found in guild {guild.name} (ID: {guild.id})")
+                continue
+
+            missing = []
+            for perm_attr, perm_name in required_permissions:
+                if not getattr(me.guild_permissions, perm_attr, False):
+                    missing.append(perm_name)
+
+            if missing:
+                logger.warning(
+                    f"⚠️  Guild '{guild.name}' (ID: {guild.id}): "
+                    f"Missing permissions: {', '.join(missing)}"
+                )
+            else:
+                logger.info(f"✓ Guild '{guild.name}': All required permissions present")
 
 
 def main():

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -81,7 +81,20 @@ class ThreadPredictionHandler:
             )
 
             # Add success reaction
-            await message.add_reaction("✅")
+            try:
+                await message.add_reaction("✅")
+            except discord.Forbidden:
+                logger.warning(
+                    f"Could not add reaction to thread prediction from {message.author.id}. "
+                    "Missing 'Add Reactions' permission."
+                )
+                # Fallback: DM the user so they know it worked
+                with suppress(discord.Forbidden):
+                    await message.author.send(
+                        "✅ **Prediction saved!**\n"
+                        "(I couldn't react to your message in the thread due to missing permissions, "
+                        "but your prediction has been recorded.)"
+                    )
 
             logger.info(
                 f"Saved thread prediction from {message.author.id} for fixture {fixture['id']}"
@@ -168,7 +181,20 @@ class ThreadPredictionHandler:
             with suppress(discord.Forbidden):
                 await after.clear_reactions()
 
-            await after.add_reaction("✅")
+            try:
+                await after.add_reaction("✅")
+            except discord.Forbidden:
+                logger.warning(
+                    f"Could not add reaction to updated prediction from {after.author.id}. "
+                    "Missing 'Add Reactions' permission."
+                )
+                # Fallback: DM the user so they know it worked
+                with suppress(discord.Forbidden):
+                    await after.author.send(
+                        "✅ **Prediction updated!**\n"
+                        "(I couldn't react to your message in the thread due to missing permissions, "
+                        "but your update has been recorded.)"
+                    )
 
             logger.info(
                 f"Updated thread prediction from {after.author.id} for fixture {fixture['id']}"


### PR DESCRIPTION
## Summary
- Modified `on_message` and `on_message_edit` in `ThreadPredictionHandler` to wrap `add_reaction` in try/except.
- If reaction fails due to missing `Add Reactions` permission, logs a warning and sends a fallback DM to the user.
- Added `_check_permissions` method to `TyperBot` that runs on startup to verify critical permissions (`send_messages`, `add_reactions`, `read_message_history`, `manage_messages`) and warn admins if missing.
- Added 2 new tests to `test_thread_prediction_handler.py`:
  - `test_sends_fallback_dm_on_reaction_permission_error`: Verifies DM is sent when reaction fails.
  - `test_survives_double_permission_failure`: Verifies bot doesn't crash if both reaction and DM fail.

## Fixes
Resolves #38