### PR TITLE
Refactor: Drop 'Manage Messages' permission requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ You are working on `matchday-typer`, a Discord bot for football prediction leagu
 - **Parsing:** Use `utils.prediction_parser.parse_line_predictions` for all score parsing. Do NOT write ad-hoc regex.
 - **Logging:** Use `typer_bot.utils.logger.setup_logging()` early. Do not use `print()`.
 - **Timezones:** All datetime operations use timezone-aware objects. Use `utils.timezone.now()` instead of `datetime.now()`. Configure via `TZ` env var (default: Europe/Warsaw).
-- **Permissions:** Bot requires `Send Messages`, `Read Message History`, `Add Reactions` (confirmations), and `Manage Messages` (cleanup).
+- **Permissions:** Bot requires `Send Messages`, `Read Message History`, and `Add Reactions` (confirmations).
 
 ## 3. Database Schema
 SQLite. Tables are initialized in `database.py`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ A Discord bot for running weekly football prediction games. I built this because
 Bot requires:
 - **Send Messages** & **Read Message History**
 - **Add Reactions**: To confirm predictions.
-- **Manage Messages**: To clear reactions on edit.
 - **Use Slash Commands**
 
 ## How to use

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,12 @@ class MockMessage:
         self._clear_reactions_count += 1
         self.reactions_added.clear()
 
+    async def remove_reaction(self, emoji: str, member):
+        """Mock remove reaction method - tracks removed reactions."""
+        if not hasattr(self, "reactions_removed"):
+            self.reactions_removed = []
+        self.reactions_removed.append((emoji, member.id if hasattr(member, "id") else member))
+
 
 @pytest.fixture
 def mock_user():

--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -172,10 +172,11 @@ class TestOnMessageEdit:
         result = await handler.on_message_edit(mock_message, edited_message)
 
         assert result is True
-        # Verify clear_reactions was called on the edited message
-        assert edited_message.reactions_cleared is True
-        assert edited_message._clear_reactions_count == 1
-        # After clearing, only the new ✅ should be present
+        # Verify remove_reaction was called for bot's reactions
+        assert len(edited_message.reactions_removed) == 2
+        removed_emojis = {emoji for emoji, _ in edited_message.reactions_removed}
+        assert removed_emojis == {"✅", "❌"}
+        # After removing, only the new ✅ should be present
         assert len(edited_message.reactions_added) == 1
         assert "✅" in edited_message.reactions_added
 

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -406,7 +406,6 @@ class TyperBot(commands.Bot):
             ("send_messages", "Send Messages"),
             ("read_message_history", "Read Message History"),
             ("add_reactions", "Add Reactions"),
-            ("manage_messages", "Manage Messages"),
         ]
 
         for guild in self.guilds:

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -177,9 +177,10 @@ class ThreadPredictionHandler:
                 is_late,
             )
 
-            # Remove any existing reactions and add success reaction
-            with suppress(discord.Forbidden):
-                await after.clear_reactions()
+            # Remove bot's own reactions and add success reaction
+            for emoji in ["✅", "❌"]:
+                with suppress(discord.Forbidden):
+                    await after.remove_reaction(emoji, self.bot.user)
 
             try:
                 await after.add_reaction("✅")


### PR DESCRIPTION
## Summary
- Replaced `message.clear_reactions()` with explicit `message.remove_reaction()` targeting the bot's own reactions.
- `clear_reactions()` requires **Manage Messages** (privileged), whereas `remove_reaction()` for self only requires **Read Message History** + **Add Reactions**.
- Updated `bot.py` startup checks, `README.md`, and `AGENTS.md` to remove the permission requirement.
- Updated tests to mock `remove_reaction` instead of `clear_reactions`.

## Benefits
- Bot now runs with fewer permissions (Principle of Least Privilege).
- Easier for server admins to invite/configure.

## Verification
- `uv run pytest tests/test_thread_prediction_handler.py` passed.
- Full test suite passed.