### PR TITLE
fix: Remove auto-delete for thread predictions (#46)

### DIFF
--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -216,56 +216,6 @@ class TestOnMessageEdit:
         assert "Invalid predictions" in mock_message.author.dm_sent[0]
 
 
-class TestOnMessageDelete:
-    """Test suite for on_message_delete handler."""
-
-    @pytest.mark.asyncio
-    async def test_ignores_bot_messages(self, handler, mock_message):
-        """Should ignore deletions from bots."""
-        mock_message.author.bot = True
-
-        result = await handler.on_message_delete(mock_message)
-
-        assert result is False
-
-    @pytest.mark.asyncio
-    async def test_deletes_prediction_and_notifies_user(
-        self, handler, fixture_with_thread, mock_message
-    ):
-        """Should delete prediction and DM user when message is deleted."""
-        mock_message.channel.id = 789012
-
-        # First, save a prediction
-        mock_message.content = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
-        await handler.on_message(mock_message)
-
-        # Verify prediction exists
-        predictions = await handler.db.get_all_predictions(fixture_with_thread["id"])
-        assert len(predictions) == 1
-
-        # Now delete the message
-        result = await handler.on_message_delete(mock_message)
-
-        assert result is True
-        assert len(mock_message.author.dm_sent) == 1
-        assert "deleted" in mock_message.author.dm_sent[0].lower()
-
-        # Verify prediction was deleted
-        predictions = await handler.db.get_all_predictions(fixture_with_thread["id"])
-        assert len(predictions) == 0
-
-    @pytest.mark.asyncio
-    @pytest.mark.usefixtures("fixture_with_thread")
-    async def test_handles_delete_when_no_prediction_exists(self, handler, mock_message):
-        """Should handle deletion gracefully when no prediction exists."""
-        mock_message.channel.id = 789012
-
-        result = await handler.on_message_delete(mock_message)
-
-        assert result is True
-        # Should not crash or send DM when no prediction exists
-
-
 class TestEdgeCases:
     """Test suite for edge cases and boundary conditions."""
 
@@ -434,10 +384,10 @@ class TestIntegration:
     """Integration tests for full workflow scenarios."""
 
     @pytest.mark.asyncio
-    async def test_full_workflow_create_predict_edit_delete(
+    async def test_full_workflow_create_predict_edit(
         self, handler, database, mock_message, sample_games
     ):
-        """Test complete workflow: create fixture → predict → edit → delete."""
+        """Test complete workflow: create fixture → predict → edit."""
         # Create fixture
         deadline = datetime.now(UTC) + timedelta(days=1)
         fixture_id = await database.create_fixture(1, sample_games, deadline)
@@ -464,13 +414,6 @@ class TestIntegration:
         predictions = await database.get_all_predictions(fixture_id)
         assert len(predictions) == 1
         # Prediction should be updated
-
-        # Step 3: Delete prediction
-        result = await handler.on_message_delete(mock_message)
-        assert result is True
-
-        predictions = await database.get_all_predictions(fixture_id)
-        assert len(predictions) == 0
 
     @pytest.mark.asyncio
     async def test_multiple_users_same_thread(

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -76,17 +76,11 @@ class TyperBot(commands.Bot):
         await super().on_message_edit(before, after)
 
     async def on_message_delete(self, message: discord.Message):
-        """Handle message deletions, including thread prediction removals."""
+        """Handle message deletions."""
         if message.author.bot:
             return
 
         set_trace_id(f"del-{message.id}")
-
-        # Handle thread prediction deletions
-        handled = await self.thread_handler.on_message_delete(message)
-        if handled:
-            return
-
         await super().on_message_delete(message)
 
     async def setup_hook(self):

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -218,47 +218,6 @@ class ThreadPredictionHandler:
             )
             return True
 
-    async def on_message_delete(self, message: discord.Message):
-        """Handle message deletions in fixture threads.
-
-        Returns True if message was handled, False otherwise.
-        """
-        # Ignore bot messages and DMs
-        if message.author.bot or message.guild is None:
-            return False
-
-        # Check if this is a thread
-        if not isinstance(message.channel, discord.Thread):
-            return False
-
-        # Check if this thread belongs to a fixture
-        thread_id = str(message.channel.id)
-        fixture = await self.db.get_fixture_by_thread_id(thread_id)
-        if not fixture:
-            return False
-
-        try:
-            # Delete the prediction
-            deleted = await self.db.delete_prediction(fixture["id"], str(message.author.id))
-
-            if deleted:
-                logger.info(
-                    f"Deleted prediction from {message.author.id} for fixture {fixture['id']}"
-                )
-
-                with suppress(discord.Forbidden):
-                    await message.author.send(
-                        f"🗑️ **Your prediction has been deleted.**\n\n"
-                        f"Week {fixture['week_number']} prediction removed. "
-                        "Submit a new prediction before the deadline if you want to participate."
-                    )
-
-            return True
-
-        except Exception as e:
-            logger.error(f"Error deleting thread prediction: {e}", exc_info=True)
-            return True
-
     async def _handle_error(self, message: discord.Message, error_text: str):
         """Handle errors by DMing the user and optionally reacting to the message."""
         with suppress(discord.Forbidden):


### PR DESCRIPTION
## Problem
`on_message_delete` handler unconditionally deleted predictions when ANY message was deleted in a fixture thread.

**Impact:** User posts "hey guys" then deletes it → their actual predictions are wiped.

Fixes #46

## Solution
Remove `on_message_delete` entirely. Users can overwrite predictions by posting a new message (already supported by `save_prediction`).

## Changes
- Removed `on_message_delete` method from `ThreadPredictionHandler`
- Removed handler call from `bot.py`
- Removed related tests (entire `TestOnMessageDelete` class + deletion step in integration test)

## Testing
- All 26 existing tests pass
- Verified no new lint errors introduced