### PR TITLE
reliability: Hardening batch - rate limits, error handling, token exposure

### DIFF
--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,7 +1,5 @@
 """Tests for scoring calculation utilities."""
 
-import pytest
-
 from typer_bot.utils.scoring import calculate_points
 
 
@@ -82,19 +80,18 @@ class TestCalculatePoints:
         assert result["points"] == 6  # 3 + 3
         assert result["exact_scores"] == 2
 
-    def test_colon_format_not_supported_directly(self):
-        """calculate_points expects normalized X-Y format from parser.
+    def test_colon_format_gracefully_handled(self):
+        """calculate_points gracefully handles invalid formats by skipping them.
 
-        Raw X:Y format would fail - normalization happens in prediction_parser.
-        This test documents the expected input contract.
+        Malformed data in DB is skipped rather than crashing the scoring.
         """
         # Normalized format from parser works
         result = calculate_points(["2-1"], ["2-1"])
         assert result["points"] == 3
 
-        # Raw colon format would raise ValueError (int("2:1") fails)
-        with pytest.raises(ValueError):
-            calculate_points(["2:1"], ["2:1"])
+        # Invalid formats are gracefully skipped (no crash)
+        result = calculate_points(["2:1"], ["2:1"])
+        assert result["points"] == 0  # Invalid format skipped
 
     def test_nullified_game_excluded_from_scoring(self):
         """Games marked with 'x' should be excluded from scoring calculations."""

--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -6,6 +6,13 @@ from unittest.mock import MagicMock
 import pytest
 
 from tests.conftest import MockMessage
+from typer_bot.handlers.thread_prediction_handler import _prediction_cooldowns
+
+
+@pytest.fixture(autouse=True)
+def clear_rate_limits():
+    """Clear rate limiting cooldowns before each test."""
+    _prediction_cooldowns.clear()
 
 
 class TestOnMessage:

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -1,5 +1,6 @@
 """Main Discord bot implementation."""
 
+import asyncio
 import logging
 import os
 import sys
@@ -175,9 +176,14 @@ class TyperBot(commands.Bot):
             for sql_file in archive_files:
                 logger.info(f"Importing {sql_file}...")
                 try:
-                    # Archive import is one-time startup operation, blocking I/O is acceptable
-                    with sql_file.open(encoding="utf-8") as f:  # noqa: ASYNC230
-                        sql_content = f.read()
+                    # Run file I/O in thread pool to avoid blocking event loop
+                    def _read_sql_file(file=sql_file):
+                        with file.open(encoding="utf-8") as f:
+                            return f.read()
+
+                    sql_content = await asyncio.get_event_loop().run_in_executor(
+                        None, _read_sql_file
+                    )
 
                     if not await self._validate_archive_sql(self.db.db_path, sql_content):
                         logger.error(
@@ -320,6 +326,9 @@ class TyperBot(commands.Bot):
                     if user:
                         await self.db.update_username(user_id, user.display_name)
                         updated += 1
+
+                    # Rate limiting: small delay between requests to avoid Discord API limits
+                    await asyncio.sleep(0.1)
                 except Exception as e:
                     logger.warning(f"Failed to update username for {user_id}: {e}")
                     failed += 1
@@ -433,7 +442,7 @@ def main():
         logger.error("Please update it with your actual bot token")
         sys.exit(1)
 
-    logger.info(f"Token check: Token starts with '{token[:20]}...'")
+    logger.info("✅ Token configured")
 
     if not IS_PRODUCTION:
         logger.info("⚠️  ENVIRONMENT is not 'production' - running in smoke test mode")

--- a/typer_bot/handlers/fixture_handler.py
+++ b/typer_bot/handlers/fixture_handler.py
@@ -11,11 +11,26 @@ from typer_bot.utils import APP_TZ, format_for_discord, now
 
 logger = logging.getLogger(__name__)
 
-# user_id -> {"channel_id": int, "guild_id": int, "games": list, "deadline": datetime, "step": str}
+# user_id -> {"channel_id": int, "guild_id": int, "games": list, "deadline": datetime, "step": str, "created_at": datetime}
 _pending_fixtures: dict = {}
 
 MAX_MESSAGE_LENGTH = 5000
 MAX_GAMES = 100
+SESSION_TIMEOUT_HOURS = 1
+
+
+def _cleanup_expired_sessions():
+    """Remove fixture sessions older than SESSION_TIMEOUT_HOURS."""
+    current_time = now()
+    expired = [
+        user_id
+        for user_id, state in _pending_fixtures.items()
+        if current_time - state.get("created_at", current_time)
+        > timedelta(hours=SESSION_TIMEOUT_HOURS)
+    ]
+    for user_id in expired:
+        _pending_fixtures.pop(user_id, None)
+        logger.debug(f"Cleaned up expired fixture session for {user_id}")
 
 
 class FixtureCreationHandler:
@@ -27,14 +42,17 @@ class FixtureCreationHandler:
 
     def start_session(self, user_id: str, channel_id: int, guild_id: int) -> None:
         """Initialize a new fixture creation session."""
+        _cleanup_expired_sessions()
         _pending_fixtures[user_id] = {
             "channel_id": channel_id,
             "guild_id": guild_id,
             "step": "games",
+            "created_at": now(),
         }
 
     def has_session(self, user_id: str) -> bool:
         """Check if user has an active fixture creation session."""
+        _cleanup_expired_sessions()
         return user_id in _pending_fixtures
 
     async def handle_dm(self, message: discord.Message, user_id: str, is_admin_fn) -> bool:

--- a/typer_bot/handlers/results_handler.py
+++ b/typer_bot/handlers/results_handler.py
@@ -1,19 +1,35 @@
 """Handler for results entry DM workflow."""
 
 import logging
+from datetime import timedelta
 
 import discord
 from discord import ui
 
 from typer_bot.database import Database
-from typer_bot.utils import parse_line_predictions
+from typer_bot.utils import now, parse_line_predictions
 
 logger = logging.getLogger(__name__)
 
-# user_id -> {"fixture_id": int, "guild_id": int}
+# user_id -> {"fixture_id": int, "guild_id": int, "created_at": datetime}
 _pending_results: dict = {}
 
 MAX_MESSAGE_LENGTH = 5000
+SESSION_TIMEOUT_HOURS = 1
+
+
+def _cleanup_expired_sessions():
+    """Remove results sessions older than SESSION_TIMEOUT_HOURS."""
+    current_time = now()
+    expired = [
+        user_id
+        for user_id, state in _pending_results.items()
+        if current_time - state.get("created_at", current_time)
+        > timedelta(hours=SESSION_TIMEOUT_HOURS)
+    ]
+    for user_id in expired:
+        _pending_results.pop(user_id, None)
+        logger.debug(f"Cleaned up expired results session for {user_id}")
 
 
 class ResultsEntryHandler:
@@ -25,13 +41,16 @@ class ResultsEntryHandler:
 
     def start_session(self, user_id: str, fixture_id: int, guild_id: int) -> None:
         """Initialize a new results entry session."""
+        _cleanup_expired_sessions()
         _pending_results[user_id] = {
             "fixture_id": fixture_id,
             "guild_id": guild_id,
+            "created_at": now(),
         }
 
     def has_session(self, user_id: str) -> bool:
         """Check if user has an active results entry session."""
+        _cleanup_expired_sessions()
         return user_id in _pending_results
 
     async def handle_dm(self, message: discord.Message, user_id: str, is_admin_fn) -> bool:

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -2,6 +2,7 @@
 
 import logging
 from contextlib import suppress
+from datetime import datetime, timedelta
 
 import discord
 
@@ -11,6 +12,10 @@ from typer_bot.utils import now, parse_line_predictions
 logger = logging.getLogger(__name__)
 
 MAX_MESSAGE_LENGTH = 5000
+
+# Rate limiting: user_id -> last prediction timestamp
+PREDICTION_RATE_LIMIT_SECONDS = 1
+_prediction_cooldowns: dict[str, datetime] = {}
 
 
 class ThreadPredictionHandler:
@@ -38,6 +43,21 @@ class ThreadPredictionHandler:
         fixture = await self.db.get_fixture_by_thread_id(thread_id)
         if not fixture:
             return False
+
+        # Rate limiting check - atomic update to prevent race conditions
+        user_id = str(message.author.id)
+        current_time = now()
+        last_time = _prediction_cooldowns.get(user_id)
+        _prediction_cooldowns[user_id] = current_time  # Always update atomically
+        if last_time and (current_time - last_time).total_seconds() < PREDICTION_RATE_LIMIT_SECONDS:
+            logger.debug(f"Rate limiting prediction from {user_id}")
+            return True  # Silently ignore rate-limited messages
+
+        # Cleanup old rate limit entries (prevent unbounded memory growth)
+        cutoff = current_time - timedelta(hours=1)
+        expired = [uid for uid, ts in list(_prediction_cooldowns.items()) if ts < cutoff]
+        for uid in expired:
+            _prediction_cooldowns.pop(uid, None)
 
         # Check message length
         if len(message.content) > MAX_MESSAGE_LENGTH:

--- a/typer_bot/utils/scoring.py
+++ b/typer_bot/utils/scoring.py
@@ -29,8 +29,14 @@ def calculate_points(
         if actual == "x":
             continue
 
-        pred_home, pred_away = map(int, pred.split("-"))
-        actual_home, actual_away = map(int, actual.split("-"))
+        parsed_pred = parse_result(pred)
+        parsed_actual = parse_result(actual)
+
+        if parsed_pred is None or parsed_actual is None:
+            continue
+
+        pred_home, pred_away = parsed_pred
+        actual_home, actual_away = parsed_actual
 
         if pred_home == actual_home and pred_away == actual_away:
             total_points += 3


### PR DESCRIPTION
## Summary
Addresses all reliability improvements from issue #57.

## Changes

### 1. Rate limiting on thread predictions
- 1 second cooldown per user
- Atomic update pattern prevents race conditions  
- Automatic cleanup of entries older than 1 hour

### 2. Rate limiting on username refresh
- 100ms delay between Discord API requests
- Prevents hitting rate limits during startup

### 3. Safe scoring with malformed data
- Uses parse_result() instead of direct int() conversion
- Gracefully skips invalid formats instead of crashing

### 4. Session memory leak prevention
- Added 1-hour timeout cleanup for fixture/results sessions
- Uses consistent timezone-aware timestamps

### 5. Token exposure fix
- Removed token[:20] partial logging
- Generic "Token configured" message instead

### 6. Async file I/O
- Archive SQL file reads use run_in_executor()
- Prevents blocking event loop during startup

## Verification
- All 108 tests pass
- Reviewed for race conditions and memory leaks

## Risk
Low. Defensive improvements only, no breaking changes.

Fixes #57