### PR TITLE
refactor: extract is_admin() to shared utility

### DIFF
--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -11,6 +11,7 @@ from typer_bot.handlers import FixtureCreationHandler, ResultsEntryHandler
 from typer_bot.utils import (
     calculate_points,
     format_standings,
+    is_admin,
     now,
 )
 from typer_bot.utils.config import BACKUP_DIR
@@ -21,17 +22,6 @@ _calculate_cooldowns: dict = {}
 CALCULATE_COOLDOWN = 30.0
 
 logger = logging.getLogger(__name__)
-
-
-def is_admin(interaction: discord.Interaction) -> bool:
-    """Check if interaction user has admin role on the originating guild."""
-    if not interaction.guild:
-        return False
-    member = interaction.guild.get_member(interaction.user.id)
-    if not member:
-        return False
-    admin_roles = {"admin", "typer-admin"}
-    return any(role.name.lower() in admin_roles for role in member.roles)
 
 
 def admin_only():

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -8,6 +8,7 @@ from typer_bot.database import Database
 from typer_bot.utils import (
     format_for_discord,
     format_standings,
+    is_admin,
     now,
     parse_line_predictions,
 )
@@ -196,7 +197,7 @@ class UserCommands(commands.Cog):
     @app_commands.command(name="help", description="Show help information")
     async def help(self, interaction: discord.Interaction):
         """Display help for users and admins."""
-        is_admin_user = self._is_admin(interaction)
+        is_admin_user = is_admin(interaction)
 
         user_help = """## 📖 User Commands
 
@@ -286,16 +287,6 @@ class UserCommands(commands.Cog):
 
         if is_admin_user:
             await interaction.followup.send(admin_help, ephemeral=True)
-
-    def _is_admin(self, interaction: discord.Interaction) -> bool:
-        """Check if interaction user has admin role on the originating guild."""
-        if not interaction.guild:
-            return False
-        member = interaction.guild.get_member(interaction.user.id)
-        if not member:
-            return False
-        admin_roles = {"admin", "typer-admin"}
-        return any(role.name.lower() in admin_roles for role in member.roles)
 
     @app_commands.command(name="fixtures", description="View this week's fixtures")
     async def fixtures(self, interaction: discord.Interaction):

--- a/typer_bot/utils/__init__.py
+++ b/typer_bot/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility functions and helpers."""
 
+from .permissions import is_admin
 from .prediction_parser import (
     ascii_username,
     format_standings,
@@ -11,6 +12,7 @@ from .timezone import APP_TZ, format_for_discord, now, parse_deadline, parse_iso
 
 __all__ = [
     "ascii_username",
+    "is_admin",
     "parse_predictions",
     "parse_line_predictions",
     "format_standings",

--- a/typer_bot/utils/permissions.py
+++ b/typer_bot/utils/permissions.py
@@ -1,0 +1,22 @@
+"""Permission checking utilities."""
+
+import discord
+
+
+def is_admin(interaction: discord.Interaction) -> bool:
+    """Check if interaction user has admin role on the originating guild.
+
+    Args:
+        interaction: The Discord interaction to check.
+
+    Returns:
+        True if the user has an admin role on the guild where the interaction
+        originated, False otherwise (including if called from DMs).
+    """
+    if not interaction.guild:
+        return False
+    member = interaction.guild.get_member(interaction.user.id)
+    if not member:
+        return False
+    admin_roles = {"admin", "typer-admin"}
+    return any(role.name.lower() in admin_roles for role in member.roles)


### PR DESCRIPTION
Move the is_admin() function from admin_commands.py and user_commands.py to a new shared utility module to eliminate code duplication.

**Changes:**
- Create typer_bot/utils/permissions.py with is_admin() function
- Export is_admin from typer_bot/utils/__init__.py
- Update both command files to import from utils
- Remove duplicate implementations

**Benefits:**
- Follows DRY principle - logic exists in one place
- Easier to maintain - role changes only need one update
- Cleaner command files

**Testing:**
- Code review completed by review agent
- Verified behavior is identical to previous implementation