### PR TITLE
docs: add Create Public Threads permission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ You are working on `matchday-typer`, a Discord bot for football prediction leagu
 - **Parsing:** Use `utils.prediction_parser.parse_line_predictions` for all score parsing. Do NOT write ad-hoc regex.
 - **Logging:** Use `typer_bot.utils.logger.setup_logging()` early. Do not use `print()`.
 - **Timezones:** All datetime operations use timezone-aware objects. Use `utils.timezone.now()` instead of `datetime.now()`. Configure via `TZ` env var (default: Europe/Warsaw).
-- **Permissions:** Bot requires `Send Messages`, `Read Message History`, and `Add Reactions` (confirmations).
+- **Permissions:** Bot requires `Send Messages`, `Read Message History`, `Add Reactions`, and `Create Public Threads`.
 
 ## 3. Database Schema
 SQLite. Tables are initialized in `database.py`.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A Discord bot for running weekly football prediction games. I built this because
 Bot requires:
 - **Send Messages** & **Read Message History**
 - **Add Reactions**: To confirm predictions.
+- **Create Public Threads**: Auto-creates prediction threads on fixture announcements.
 - **Use Slash Commands**
 
 ## How to use


### PR DESCRIPTION
The bot auto-creates prediction threads when admins post fixtures via `/admin fixture create`. This requires the Create Public Threads permission, which was missing from the required permissions list.

Updated:
- README.md: Added permission with brief description
- AGENTS.md: Added to inline permissions list

Note: The bot handles missing permissions gracefully (logs warning, falls back to `/predict` command), but the docs should reflect actual requirements.