### PR TITLE
Fix: Remove invalid super() calls from event handlers causing AttributeError

### DIFF
--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -73,17 +73,12 @@ class TyperBot(commands.Bot):
         if handled:
             return
 
-        # discord.py typing quirk: super() doesn't resolve event handler methods
-        await super().on_message_edit(before, after)  # type: ignore
-
     async def on_message_delete(self, message: discord.Message):
         """Handle message deletions."""
         if message.author.bot:
             return
 
         set_trace_id(f"del-{message.id}")
-        # discord.py typing quirk: super() doesn't resolve event handler methods
-        await super().on_message_delete(message)  # type: ignore
 
     async def setup_hook(self):
         """Initialize database and load cogs."""


### PR DESCRIPTION
## Problem
The bot was crashing with `AttributeError: 'super' object has no attribute 'on_message_delete'` whenever messages were deleted or edited.

Root cause: `on_message_delete` and `on_message_edit` are event **callbacks** (hooks) that Discord.py calls, not inherited methods. The base `discord.Client` class does not implement these methods.

## Changes
- Remove `super().on_message_edit()` call from `on_message_edit()` method
- Remove `super().on_message_delete()` call from `on_message_delete()` method

## Why this is correct
Unlike `on_message()` which IS overridden by `commands.Bot` to process commands, `on_message_delete` and `on_message_edit` are pure event hooks. The parent class has no implementation to delegate to.

## Testing
- Pre-commit hooks pass (ruff check, ruff format)
- No behavior change other than fixing the crash