### PR TITLE
fix: DM admin permission check fails with AttributeError

### DIFF
--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -12,6 +12,7 @@ from typer_bot.utils import (
     calculate_points,
     format_standings,
     is_admin,
+    is_admin_member,
     now,
 )
 from typer_bot.utils.config import BACKUP_DIR
@@ -63,12 +64,12 @@ class AdminCommands(commands.Cog):
 
         # Check if this is a fixture creation DM
         if self.fixture_handler.has_session(user_id):
-            await self.fixture_handler.handle_dm(message, user_id, is_admin)
+            await self.fixture_handler.handle_dm(message, user_id, is_admin_member)
             return
 
         # Check if this is a results entry DM
         if self.results_handler.has_session(user_id):
-            await self.results_handler.handle_dm(message, user_id, is_admin)
+            await self.results_handler.handle_dm(message, user_id, is_admin_member)
             return
 
     # Admin group

--- a/typer_bot/handlers/fixture_handler.py
+++ b/typer_bot/handlers/fixture_handler.py
@@ -1,6 +1,7 @@
 """Handler for fixture creation DM workflow."""
 
 import logging
+from collections.abc import Callable
 from datetime import datetime, timedelta
 
 import discord
@@ -55,7 +56,12 @@ class FixtureCreationHandler:
         _cleanup_expired_sessions()
         return user_id in _pending_fixtures
 
-    async def handle_dm(self, message: discord.Message, user_id: str, is_admin_fn) -> bool:
+    async def handle_dm(
+        self,
+        message: discord.Message,
+        user_id: str,
+        is_admin_fn: Callable[[discord.Member | None], bool],
+    ) -> bool:
         """Handle a DM message for fixture creation.
 
         Args:
@@ -90,7 +96,11 @@ class FixtureCreationHandler:
         return True
 
     async def _verify_admin(
-        self, message: discord.Message, user_id: str, guild_id: int | None, is_admin_fn
+        self,
+        message: discord.Message,
+        user_id: str,
+        guild_id: int | None,
+        is_admin_fn: Callable[[discord.Member | None], bool],
     ) -> bool:
         """Verify user is still an admin."""
         if not guild_id:

--- a/typer_bot/handlers/results_handler.py
+++ b/typer_bot/handlers/results_handler.py
@@ -1,6 +1,7 @@
 """Handler for results entry DM workflow."""
 
 import logging
+from collections.abc import Callable
 from datetime import timedelta
 
 import discord
@@ -53,7 +54,12 @@ class ResultsEntryHandler:
         _cleanup_expired_sessions()
         return user_id in _pending_results
 
-    async def handle_dm(self, message: discord.Message, user_id: str, is_admin_fn) -> bool:
+    async def handle_dm(
+        self,
+        message: discord.Message,
+        user_id: str,
+        is_admin_fn: Callable[[discord.Member | None], bool],
+    ) -> bool:
         """Handle a DM message for results entry.
 
         Args:
@@ -123,7 +129,11 @@ class ResultsEntryHandler:
         return True
 
     async def _verify_admin(
-        self, message: discord.Message, user_id: str, guild_id: int | None, is_admin_fn
+        self,
+        message: discord.Message,
+        user_id: str,
+        guild_id: int | None,
+        is_admin_fn: Callable[[discord.Member | None], bool],
     ) -> bool:
         """Verify user is still an admin."""
         if not guild_id:

--- a/typer_bot/utils/__init__.py
+++ b/typer_bot/utils/__init__.py
@@ -1,6 +1,6 @@
 """Utility functions and helpers."""
 
-from .permissions import is_admin
+from .permissions import is_admin, is_admin_member
 from .prediction_parser import (
     ascii_username,
     format_standings,
@@ -13,6 +13,7 @@ from .timezone import APP_TZ, format_for_discord, now, parse_deadline, parse_iso
 __all__ = [
     "ascii_username",
     "is_admin",
+    "is_admin_member",
     "parse_predictions",
     "parse_line_predictions",
     "format_standings",

--- a/typer_bot/utils/permissions.py
+++ b/typer_bot/utils/permissions.py
@@ -3,6 +3,12 @@
 import discord
 
 
+def _has_admin_role(member: discord.Member) -> bool:
+    """Check if member has an admin role."""
+    admin_roles = {"admin", "typer-admin"}
+    return any(role.name.lower() in admin_roles for role in member.roles)
+
+
 def is_admin(interaction: discord.Interaction) -> bool:
     """Check if interaction user has admin role on the originating guild.
 
@@ -16,7 +22,9 @@ def is_admin(interaction: discord.Interaction) -> bool:
     if not interaction.guild:
         return False
     member = interaction.guild.get_member(interaction.user.id)
-    if not member:
-        return False
-    admin_roles = {"admin", "typer-admin"}
-    return any(role.name.lower() in admin_roles for role in member.roles)
+    return _has_admin_role(member) if member else False
+
+
+def is_admin_member(member: discord.Member | None) -> bool:
+    """Check if member has admin role (for DM workflows)."""
+    return _has_admin_role(member) if member else False


### PR DESCRIPTION
**Issue:** Admin DM workflows crash when verifying permissions.

**Error:**
```
AttributeError: 'Member' object has no attribute 'user'
```

**Cause:** `is_admin()` expected `discord.Interaction` but handlers passed `discord.Member`.

**Fix:**
- Extract shared `_has_admin_role()` helper
- Add `is_admin_member()` for DM workflows (accepts Member)
- Keep `is_admin()` for interaction-based checks
- Add None guards and complete type annotations

**Files:**
- `permissions.py` - new helper + refactored functions
- `admin_commands.py` - use `is_admin_member` for DM handlers
- `fixture_handler.py`, `results_handler.py` - type hints