### PR TITLE
fix: add missing send_message call in my_predictions command

### DIFF
--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -383,6 +383,8 @@ class UserCommands(commands.Cog):
             ]
         )
 
+        await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
 
 async def setup(bot: commands.Bot):
     """Add cog to bot."""


### PR DESCRIPTION
## Summary
- Fix `/mypredictions` command not sending response to user
- The `send_message` call was accidentally removed in commit 405d0ad when `PredictionConfirmView` class was deleted

## Test plan
- [x] All 218 tests pass
- [x] Ruff linting passes
- [x] Type checking passes
- [x] Code review completed (0 issues found)