### PR TITLE
fix: Prevent admin predictions from being marked late during results entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ uv run pytest --tb=short         # Shorter traceback output
 ```
 
 ## 6. Known Quirks
+- **Handler Coordination:** The prediction handler (`user_commands.py`) checks `results_handler.has_results_session()` before processing DMs. This prevents admin's own predictions from being overwritten when they're entering results. Always check for conflicting sessions before processing DMs.
 - **Double Digits:** Scores like `10-0` are allowed.
 - **Format:** Users provide flexible separators (`-`, `:`, `–`).
 - **History:** `archive/` folder contains SQL files auto-imported on first run (empty DB).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,14 @@ import discord
 import pytest
 
 from typer_bot.database import Database
+from typer_bot.handlers.results_handler import _pending_results
 from typer_bot.handlers.thread_prediction_handler import ThreadPredictionHandler
+
+
+@pytest.fixture(autouse=True)
+def clear_results_sessions():
+    _pending_results.clear()
+    yield
 
 
 @pytest.fixture

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -31,6 +31,26 @@ class TestOnMessage:
         assert len(mock_message.author.dm_sent) == 0
 
     @pytest.mark.asyncio
+    async def test_ignores_dms_during_results_entry(self, user_commands, mock_message):
+        """Prevent admin's existing predictions being marked late during results entry."""
+        from typer_bot.handlers.results_handler import _pending_results
+
+        mock_message.guild = None  # DM message
+        user_id = str(mock_message.author.id)
+
+        # Simulate active results entry session for this user
+        _pending_results[user_id] = {
+            "fixture_id": 1,
+            "guild_id": 123456,
+            "created_at": datetime.now(UTC),
+        }
+
+        await user_commands.on_message(mock_message)
+
+        # Should not send any response - message is handled by results handler
+        assert len(mock_message.author.dm_sent) == 0
+
+    @pytest.mark.asyncio
     async def test_rejects_message_too_long(self, user_commands, mock_message):
         mock_message.guild = None  # DM message
         mock_message.content = "x" * 5001

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -7,6 +7,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from typer_bot.database import Database
+from typer_bot.handlers.results_handler import has_results_session
 from typer_bot.utils import (
     format_for_discord,
     format_standings,
@@ -35,6 +36,10 @@ class UserCommands(commands.Cog):
             return
 
         user_id = str(message.author.id)
+
+        # Prevent admin's existing predictions being marked late during results entry
+        if has_results_session(user_id):
+            return
 
         # Check message length first (before fetching fixture)
         if len(message.content) > MAX_MESSAGE_LENGTH:

--- a/typer_bot/handlers/results_handler.py
+++ b/typer_bot/handlers/results_handler.py
@@ -34,6 +34,19 @@ def _cleanup_expired_sessions():
         logger.debug(f"Cleaned up expired results session for {user_id}")
 
 
+def has_results_session(user_id: str) -> bool:
+    """Check if user has an active results entry session.
+
+    Used by prediction handler to distinguish admin entering results
+    from regular predictions. Prevents bug where admin's own predictions
+    would be overwritten and marked late during results entry.
+
+    Side effect: Cleans up expired sessions older than SESSION_TIMEOUT_HOURS.
+    """
+    _cleanup_expired_sessions()
+    return user_id in _pending_results
+
+
 class ResultsEntryHandler:
     """Handles the DM workflow for entering results."""
 
@@ -61,8 +74,7 @@ class ResultsEntryHandler:
 
     def has_session(self, user_id: str) -> bool:
         """Check if user has an active results entry session."""
-        _cleanup_expired_sessions()
-        return user_id in _pending_results
+        return has_results_session(user_id)  # Delegate to module function
 
     async def handle_dm(
         self,


### PR DESCRIPTION
When admins entered results via `/admin results enter`, their DMs were processed by both the results handler and the prediction handler. Since results are typically entered after the deadline, the prediction handler would overwrite the admin's existing predictions with `is_late=True`, causing them to receive 0 points.

## Solution
Add coordination between handlers by checking `has_results_session()` in the prediction handler before processing DMs. If the user has an active results entry session, skip prediction processing entirely.

## Changes
- Add module-level `has_results_session()` function for clean state checking
- Skip DMs in prediction handler when user has active results session
- Add test isolation fixture to prevent state leakage between tests
- Add regression test for this specific scenario
- Document handler coordination pattern in AGENTS.md

## Testing
- 205/205 tests passing
- New regression test covers the exact failure scenario