### PR TITLE
fix: prevent duplicate ephemeral messages in /admin results post

### DIFF
--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -406,15 +406,18 @@ class PostResultsConfirmView(discord.ui.View):
         message = format_standings(self.standings, self.fixture_data)
 
         try:
-            await self.channel.send(message)
             await interaction.response.edit_message(
                 content="Results posted without mentions!", view=None
             )
+            await self.channel.send(message)
         except Exception as e:
             logger.error(f"Failed to post results: {e}")
-            await interaction.response.edit_message(
-                content=f"Failed to post results: {e}", view=None
-            )
+            if not interaction.response.is_done():
+                await interaction.response.edit_message(
+                    content=f"Failed to post results: {e}", view=None
+                )
+            else:
+                await interaction.followup.send(f"Failed to post results: {e}")
 
     @discord.ui.button(label="YES", style=discord.ButtonStyle.green)
     async def with_mentions(self, interaction: discord.Interaction, _button: discord.ui.Button):
@@ -429,15 +432,18 @@ class PostResultsConfirmView(discord.ui.View):
         message += f"\n\n**Participants:**\n{' '.join(mentions)}"
 
         try:
-            await self.channel.send(message)
             await interaction.response.edit_message(
                 content="Results posted with mentions!", view=None
             )
+            await self.channel.send(message)
         except Exception as e:
             logger.error(f"Failed to post results: {e}")
-            await interaction.response.edit_message(
-                content=f"Failed to post results: {e}", view=None
-            )
+            if not interaction.response.is_done():
+                await interaction.response.edit_message(
+                    content=f"Failed to post results: {e}", view=None
+                )
+            else:
+                await interaction.followup.send(f"Failed to post results: {e}")
 
 
 async def setup(bot: commands.Bot):


### PR DESCRIPTION
## Problem
The `/admin results post` command was posting ephemeral results messages twice due to a race condition with Discord's interaction acknowledgment timeout.

Discord requires interactions to be acknowledged within 3 seconds. The previous code called `channel.send()` before `interaction.response.edit_message()`, which could exceed this deadline and cause Discord to auto-acknowledge the interaction, resulting in duplicate ephemeral messages being displayed.

## Changes
- **Reordered operations**: Acknowledge the Discord interaction BEFORE calling `channel.send()` in both button handlers
- **Defensive error handling**: Added `interaction.response.is_done()` check to prevent "already responded" errors
- **Fixed both handlers**: Applied fix to both `no_mentions` and `with_mentions` button handlers in `PostResultsConfirmView`

## Files Changed
- `typer_bot/commands/admin_commands.py`

## Testing
- ✅ All 205 tests pass
- ✅ ruff linting passes
- ✅ ty type checking passes

## Related
This fix addresses the issue where clicking \"YES\" or \"NO\" on the results post confirmation would show the ephemeral message twice to the user.