### PR TITLE
Support concurrent open fixtures with explicit week targeting and guided DM prediction flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Bot requires:
 **Method 2: DM Predictions**
 1. Type `/predict` (or DM the bot directly) -> Bot DMs you the games
 2. Reply with scores (same format as above) -> Predictions saved immediately!
-3. To change, just send a new message
+3. If multiple fixtures are open, bot asks which week first and can guide you through the rest
+4. To change, just send a new message
 
 **Check**: `/mypredictions` to see what you sent.
 **Flex**: `/standings` to see the table.
@@ -48,11 +49,11 @@ You need a Discord role named `Admin` or `typer-admin`.
 
 **Fixture Management:**
 - `/admin fixture create` - Create a new fixture (DM workflow with games + deadline, auto-creates prediction thread)
-- `/admin fixture delete` - Delete the current fixture
+- `/admin fixture delete [week]` - Delete an open fixture (week required if multiple are open)
 
 **Results Management:**
-- `/admin results enter` - Enter actual game scores (DM workflow)
-- `/admin results calculate` - Calculate scores and post results (no mentions by default)
+- `/admin results enter [week]` - Enter actual game scores (DM workflow)
+- `/admin results calculate [week]` - Calculate scores and post results (no mentions by default)
 - `/admin results post` - Re-post results with option to mention users
 
 ## Hosting (The Easy Way)

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -298,3 +298,89 @@ class TestOnMessageListener:
         await admin_cog.on_message(mock_message)
 
         assert admin_cog.results_handler.has_session(user_id)
+
+
+class TestMultiOpenFixtureTargeting:
+    """Test suite for explicit week targeting when multiple fixtures are open."""
+
+    @pytest.fixture
+    def admin_cog(self, mock_bot, database):
+        mock_bot.db = database
+        return AdminCommands(mock_bot)
+
+    @pytest.mark.asyncio
+    async def test_fixture_delete_requires_week_when_multiple_open(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        """Delete command blocks ambiguous actions when multiple fixtures are open."""
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        await admin_cog.db.create_fixture(1, sample_games, deadline)
+        await admin_cog.db.create_fixture(2, sample_games, deadline)
+
+        await admin_cog.fixture_delete.callback(admin_cog, mock_interaction_admin, None)
+
+        assert len(mock_interaction_admin.response_sent) == 1
+        content = mock_interaction_admin.response_sent[0]["content"]
+        assert "Multiple fixtures are currently open" in content
+        assert "Open weeks: 1, 2" in content
+
+    @pytest.mark.asyncio
+    async def test_results_enter_targets_explicit_week(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        """Results entry session starts for the requested open fixture week."""
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        fixture_week_1 = await admin_cog.db.create_fixture(1, sample_games, deadline)
+        await admin_cog.db.create_fixture(2, sample_games, deadline)
+
+        mock_interaction_admin.guild_id = mock_interaction_admin.guild.id
+
+        await admin_cog.results_enter.callback(admin_cog, mock_interaction_admin, 1)
+
+        user_id = str(mock_interaction_admin.user.id)
+        assert _pending_results[user_id]["fixture_id"] == fixture_week_1
+        assert "Check your DMs" in mock_interaction_admin.response_sent[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_results_calculate_requires_week_when_multiple_open(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        """Calculate command requires explicit week when more than one fixture is open."""
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        await admin_cog.db.create_fixture(1, sample_games, deadline)
+        await admin_cog.db.create_fixture(2, sample_games, deadline)
+
+        user_id = str(mock_interaction_admin.user.id)
+        await admin_cog.results_calculate.callback(admin_cog, mock_interaction_admin, None)
+
+        assert len(mock_interaction_admin.response_sent) == 1
+        content = mock_interaction_admin.response_sent[0]["content"]
+        assert "Multiple fixtures are currently open" in content
+        assert user_id not in _calculate_cooldowns
+
+    @pytest.mark.asyncio
+    async def test_results_enter_rejects_duplicate_open_week_numbers(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        """Duplicate open week numbers are rejected to avoid targeting wrong fixture."""
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        await admin_cog.db.create_fixture(5, sample_games, deadline)
+        await admin_cog.db.create_fixture(5, sample_games, deadline)
+
+        await admin_cog.results_enter.callback(admin_cog, mock_interaction_admin, 5)
+
+        assert len(mock_interaction_admin.response_sent) == 1
+        content = mock_interaction_admin.response_sent[0]["content"]
+        assert "More than one open fixture was found for week 5" in content

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -214,19 +214,16 @@ class TestReminderSystem:
         current_time = deadline - timedelta(hours=24)
         mock_now.return_value = current_time
 
-        bot_instance.db.get_current_fixture = AsyncMock(
-            return_value={
-                "id": 1,
-                "deadline": deadline,
-                "week_number": 1,
-            }
-        )
+        fixture = {
+            "id": 1,
+            "deadline": deadline,
+            "week_number": 1,
+        }
+        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
 
         await bot_instance.reminder_task()
 
-        bot_instance.send_reminder.assert_called_once_with(
-            bot_instance.db.get_current_fixture.return_value, "24 hours remaining"
-        )
+        bot_instance.send_reminder.assert_called_once_with(fixture, "24 hours remaining")
 
     @pytest.mark.asyncio
     @patch("typer_bot.bot.now")
@@ -236,19 +233,16 @@ class TestReminderSystem:
         current_time = deadline - timedelta(hours=1)
         mock_now.return_value = current_time
 
-        bot_instance.db.get_current_fixture = AsyncMock(
-            return_value={
-                "id": 1,
-                "deadline": deadline,
-                "week_number": 1,
-            }
-        )
+        fixture = {
+            "id": 1,
+            "deadline": deadline,
+            "week_number": 1,
+        }
+        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
 
         await bot_instance.reminder_task()
 
-        bot_instance.send_reminder.assert_called_once_with(
-            bot_instance.db.get_current_fixture.return_value, "1 hour remaining"
-        )
+        bot_instance.send_reminder.assert_called_once_with(fixture, "1 hour remaining")
 
     @pytest.mark.asyncio
     async def test_reminder_sent_at_exact_time(self, bot_instance):
@@ -258,13 +252,12 @@ class TestReminderSystem:
         deadline = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
         current_time = deadline - timedelta(hours=24)
 
-        bot_instance.db.get_current_fixture = AsyncMock(
-            return_value={
-                "id": 1,
-                "deadline": deadline,
-                "week_number": 1,
-            }
-        )
+        fixture = {
+            "id": 1,
+            "deadline": deadline,
+            "week_number": 1,
+        }
+        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
 
         with freeze_time(current_time):
             await bot_instance.reminder_task()
@@ -279,11 +272,26 @@ class TestReminderSystem:
     async def test_reminder_skips_if_no_fixture(self, mock_now, bot_instance):
         """Reminders are skipped when no fixture is active."""
         mock_now.return_value = datetime.now(UTC)
-        bot_instance.db.get_current_fixture = AsyncMock(return_value=None)
+        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[])
 
         await bot_instance.reminder_task()
 
         bot_instance.send_reminder.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("typer_bot.bot.now")
+    async def test_reminder_checks_all_open_fixtures(self, mock_now, bot_instance):
+        """Reminder loop should evaluate all concurrently open fixtures."""
+        deadline = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+        mock_now.return_value = deadline - timedelta(hours=24)
+
+        fixture_a = {"id": 1, "deadline": deadline, "week_number": 1}
+        fixture_b = {"id": 2, "deadline": deadline, "week_number": 2}
+        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture_a, fixture_b])
+
+        await bot_instance.reminder_task()
+
+        assert bot_instance.send_reminder.call_count == 2
 
 
 class TestSendReminder:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -74,6 +74,73 @@ class TestGetMaxWeekNumber:
         assert result == 10
 
 
+class TestOpenFixturesQueries:
+    """Test suite for multi-open fixture query helpers."""
+
+    @pytest.mark.asyncio
+    async def test_get_open_fixtures_returns_all_open_ordered(self, temp_db_path):
+        """Open fixtures are returned in week order for deterministic selection prompts."""
+        db = Database(temp_db_path)
+        await db.initialize()
+
+        fixture_week_2 = await db.create_fixture(2, ["Team C - Team D"], datetime.now(UTC))
+        fixture_week_1 = await db.create_fixture(1, ["Team A - Team B"], datetime.now(UTC))
+        fixture_week_3 = await db.create_fixture(3, ["Team E - Team F"], datetime.now(UTC))
+
+        # Close week 3 fixture so only weeks 1 and 2 remain open
+        await db.save_scores(fixture_week_3, [])
+
+        open_fixtures = await db.get_open_fixtures()
+        open_ids = [fixture["id"] for fixture in open_fixtures]
+        open_weeks = [fixture["week_number"] for fixture in open_fixtures]
+
+        assert fixture_week_3 not in open_ids
+        assert set(open_ids) == {fixture_week_1, fixture_week_2}
+        assert open_weeks == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_get_open_fixture_by_week_ignores_closed_fixtures(self, temp_db_path):
+        """Week resolver should only return fixtures that are still open."""
+        db = Database(temp_db_path)
+        await db.initialize()
+
+        open_fixture_id = await db.create_fixture(7, ["Team A - Team B"], datetime.now(UTC))
+        closed_fixture_id = await db.create_fixture(8, ["Team C - Team D"], datetime.now(UTC))
+        await db.save_scores(closed_fixture_id, [])
+
+        open_fixture = await db.get_open_fixture_by_week(7)
+        closed_fixture = await db.get_open_fixture_by_week(8)
+
+        assert open_fixture is not None
+        assert open_fixture["id"] == open_fixture_id
+        assert closed_fixture is None
+
+    @pytest.mark.asyncio
+    async def test_create_next_fixture_allocates_incrementing_weeks(self, temp_db_path):
+        """Atomic allocator should issue increasing week numbers."""
+        db = Database(temp_db_path)
+        await db.initialize()
+
+        fixture_one_id, week_one = await db.create_next_fixture(
+            ["Team A - Team B"],
+            datetime.now(UTC),
+        )
+        fixture_two_id, week_two = await db.create_next_fixture(
+            ["Team C - Team D"],
+            datetime.now(UTC),
+        )
+
+        fixture_one = await db.get_fixture_by_id(fixture_one_id)
+        fixture_two = await db.get_fixture_by_id(fixture_two_id)
+
+        assert week_one == 1
+        assert week_two == 2
+        assert fixture_one is not None
+        assert fixture_one["week_number"] == 1
+        assert fixture_two is not None
+        assert fixture_two["week_number"] == 2
+
+
 class TestDefensiveColumnAccess:
     """Test suite for defensive .get() column access patterns."""
 

--- a/tests/test_fixture_handler.py
+++ b/tests/test_fixture_handler.py
@@ -343,7 +343,7 @@ class TestCreateFixture:
         _pending_fixtures["123456"] = {"some": "data"}
 
         deadline = datetime.now(UTC)
-        await handler.create_fixture("123456", 1, ["Game 1", "Game 2"], deadline)
+        await handler.create_fixture("123456", ["Game 1", "Game 2"], deadline)
 
         fixture = await database.get_current_fixture()
         assert fixture is not None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -184,6 +184,40 @@ class TestEdgeCases:
         max_week = await database.get_max_week_number()
         assert max_week == 5
 
+    @pytest.mark.asyncio
+    async def test_calculating_one_fixture_keeps_other_fixture_open(self, database):
+        """Closing one fixture should not block another concurrently open fixture."""
+        games = ["Team A - Team B", "Team C - Team D"]
+        deadline = datetime.now(UTC) + timedelta(days=1)
+
+        fixture_one_id = await database.create_fixture(1, games, deadline)
+        fixture_two_id = await database.create_fixture(2, games, deadline)
+
+        await database.save_prediction(fixture_one_id, "user1", "User1", ["2-1", "1-1"], False)
+        await database.save_results(fixture_one_id, ["2-1", "1-1"])
+        await database.save_scores(
+            fixture_one_id,
+            [
+                {
+                    "user_id": "user1",
+                    "user_name": "User1",
+                    "points": 6,
+                    "exact_scores": 2,
+                    "correct_results": 0,
+                }
+            ],
+        )
+
+        fixture_one = await database.get_fixture_by_id(fixture_one_id)
+        fixture_two = await database.get_fixture_by_id(fixture_two_id)
+        open_fixtures = await database.get_open_fixtures()
+
+        assert fixture_one is not None
+        assert fixture_one["status"] == "closed"
+        assert fixture_two is not None
+        assert fixture_two["status"] == "open"
+        assert [fixture["id"] for fixture in open_fixtures] == [fixture_two_id]
+
 
 class TestDatabaseIntegrity:
     """Test database integrity constraints."""

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -186,3 +186,146 @@ class TestEdgeCases:
         assert len(mock_message.author.dm_sent) == 2  # Processing + error
         error_msg = mock_message.author.dm_sent[-1]
         assert "Error processing predictions" in error_msg
+
+
+class TestMultiOpenPredictionFlow:
+    """Tests for DM guidance when multiple fixtures are open."""
+
+    @pytest.mark.asyncio
+    async def test_predict_command_prompts_week_selection_when_multiple_open(
+        self,
+        user_commands,
+        mock_interaction,
+        sample_games,
+    ):
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        await user_commands.db.create_fixture(1, sample_games, deadline)
+        await user_commands.db.create_fixture(2, sample_games, deadline)
+
+        await user_commands.predict.callback(user_commands, mock_interaction)
+
+        assert len(mock_interaction.response_sent) == 1
+        assert "Check your DMs" in mock_interaction.response_sent[0]["content"]
+        assert len(mock_interaction.user.dm_sent) == 1
+        assert "Multiple fixtures are open" in mock_interaction.user.dm_sent[0]
+
+        session = user_commands._prediction_sessions.get(str(mock_interaction.user.id))
+        assert session is not None
+        assert session["step"] == "select"
+
+    @pytest.mark.asyncio
+    async def test_direct_dm_with_multiple_open_requests_week_first(
+        self,
+        user_commands,
+        mock_message,
+        sample_games,
+    ):
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        await user_commands.db.create_fixture(1, sample_games, deadline)
+        await user_commands.db.create_fixture(2, sample_games, deadline)
+
+        mock_message.guild = None
+        mock_message.content = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        await user_commands.on_message(mock_message)
+
+        assert len(mock_message.author.dm_sent) == 1
+        assert "Multiple fixtures are open" in mock_message.author.dm_sent[0]
+
+        session = user_commands._prediction_sessions.get(str(mock_message.author.id))
+        assert session is not None
+        assert session["step"] == "select"
+
+    @pytest.mark.asyncio
+    async def test_saving_one_fixture_prompts_for_another_when_open(
+        self,
+        user_commands,
+        mock_message,
+        sample_games,
+    ):
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        fixture_one_id = await user_commands.db.create_fixture(1, sample_games, deadline)
+        await user_commands.db.create_fixture(2, sample_games, deadline)
+
+        user_id = str(mock_message.author.id)
+        user_commands._set_prediction_session(
+            user_id,
+            step="predict",
+            fixture_id=fixture_one_id,
+            completed_fixture_ids=[],
+        )
+
+        mock_message.guild = None
+        mock_message.content = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        await user_commands.on_message(mock_message)
+
+        assert "Would you like to predict another open fixture" in mock_message.author.dm_sent[-1]
+        session = user_commands._prediction_sessions.get(user_id)
+        assert session is not None
+        assert session["step"] == "continue"
+
+        predictions = await user_commands.db.get_all_predictions(fixture_one_id)
+        assert len(predictions) == 1
+
+    @pytest.mark.asyncio
+    async def test_continue_yes_moves_to_remaining_fixture(
+        self,
+        user_commands,
+        mock_message,
+        sample_games,
+    ):
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        fixture_one_id = await user_commands.db.create_fixture(1, sample_games, deadline)
+        fixture_two_id = await user_commands.db.create_fixture(2, sample_games, deadline)
+
+        user_id = str(mock_message.author.id)
+        user_commands._set_prediction_session(
+            user_id,
+            step="continue",
+            fixture_ids=[fixture_two_id],
+            completed_fixture_ids=[fixture_one_id],
+        )
+
+        mock_message.guild = None
+        mock_message.content = "yes"
+
+        await user_commands.on_message(mock_message)
+
+        assert "Week 2 - Submit Your Predictions" in mock_message.author.dm_sent[-1]
+        session = user_commands._prediction_sessions.get(user_id)
+        assert session is not None
+        assert session["step"] == "predict"
+        assert session["fixture_id"] == fixture_two_id
+
+    @pytest.mark.asyncio
+    async def test_selected_fixture_closed_mid_flow_does_not_auto_route(
+        self,
+        user_commands,
+        mock_message,
+        sample_games,
+    ):
+        """If a selected fixture closes mid-flow, user must reselect instead of silent reroute."""
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        fixture_one_id = await user_commands.db.create_fixture(1, sample_games, deadline)
+        fixture_two_id = await user_commands.db.create_fixture(2, sample_games, deadline)
+
+        user_id = str(mock_message.author.id)
+        user_commands._set_prediction_session(
+            user_id,
+            step="predict",
+            fixture_id=fixture_one_id,
+            completed_fixture_ids=[],
+        )
+
+        # Close the selected fixture before the user submits
+        await user_commands.db.save_scores(fixture_one_id, [])
+
+        mock_message.guild = None
+        mock_message.content = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        await user_commands.on_message(mock_message)
+
+        assert "no longer open" in mock_message.author.dm_sent[-1]
+        predictions = await user_commands.db.get_all_predictions(fixture_two_id)
+        assert len(predictions) == 0

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -261,28 +261,29 @@ class TyperBot(commands.Bot):
 
     @tasks.loop(minutes=1)
     async def reminder_task(self):
-        """Send reminders 24h and 1h before fixture deadline."""
+        """Send reminders 24h and 1h before each open fixture deadline."""
         current_time = now()
-        fixture = await self.db.get_current_fixture()
+        open_fixtures = await self.db.get_open_fixtures()
 
-        if not fixture:
+        if not open_fixtures:
             return
-
-        deadline = fixture["deadline"]
 
         # Compare minute-level precision to avoid double-sending
         def is_same_minute(t1, t2):
             return t1.replace(second=0, microsecond=0) == t2.replace(second=0, microsecond=0)
 
-        reminder_24h = deadline - timedelta(hours=24)
-        if is_same_minute(current_time, reminder_24h):
-            logger.info("Sending 24h reminder...")
-            await self.send_reminder(fixture, "24 hours remaining")
+        for fixture in open_fixtures:
+            deadline = fixture["deadline"]
 
-        reminder_1h = deadline - timedelta(hours=1)
-        if is_same_minute(current_time, reminder_1h):
-            logger.info("Sending 1h reminder...")
-            await self.send_reminder(fixture, "1 hour remaining")
+            reminder_24h = deadline - timedelta(hours=24)
+            if is_same_minute(current_time, reminder_24h):
+                logger.info(f"Sending 24h reminder for week {fixture['week_number']}...")
+                await self.send_reminder(fixture, "24 hours remaining")
+
+            reminder_1h = deadline - timedelta(hours=1)
+            if is_same_minute(current_time, reminder_1h):
+                logger.info(f"Sending 1h reminder for week {fixture['week_number']}...")
+                await self.send_reminder(fixture, "1 hour remaining")
 
     async def send_reminder(self, fixture: dict, time_description: str):
         """Send prediction reminder to configured channel."""
@@ -318,40 +319,48 @@ class TyperBot(commands.Bot):
         logger.info("Verifying fixture announcement...")
 
         try:
-            fixture = await self.db.get_current_fixture()
-            if not fixture:
+            open_fixtures = await self.db.get_open_fixtures()
+            if not open_fixtures:
                 logger.info("No open fixture found, skipping verification")
                 return
 
-            message_id = fixture.get("message_id")
-            if not message_id:
-                logger.info(f"Fixture {fixture['id']} has no message_id, skipping verification")
-                return
+            for fixture in open_fixtures:
+                message_id = fixture.get("message_id")
+                if not message_id:
+                    logger.info(f"Fixture {fixture['id']} has no message_id, skipping verification")
+                    continue
 
-            # Search channels for the announcement message
-            for guild in self.guilds:
-                for channel in guild.text_channels:
-                    try:
-                        message = await channel.fetch_message(int(message_id))
-                        if message.thread:
-                            logger.info(f"Fixture {fixture['id']} has thread {message.thread.id}")
-                        else:
-                            logger.info(
-                                f"Fixture {fixture['id']} has no thread (users can use /predict)"
-                            )
-                        return
-                    except discord.NotFound:
-                        continue
-                    except discord.Forbidden:
-                        logger.warning(f"No permission to read channel {channel.id}")
-                        continue
-                    except Exception as e:
-                        logger.warning(f"Could not verify fixture in {channel.id}: {e}")
-                        continue
+                found = False
+                # Search channels for the announcement message
+                for guild in self.guilds:
+                    for channel in guild.text_channels:
+                        try:
+                            message = await channel.fetch_message(int(message_id))
+                            if message.thread:
+                                logger.info(
+                                    f"Fixture {fixture['id']} has thread {message.thread.id}"
+                                )
+                            else:
+                                logger.info(
+                                    f"Fixture {fixture['id']} has no thread (users can use /predict)"
+                                )
+                            found = True
+                            break
+                        except discord.NotFound:
+                            continue
+                        except discord.Forbidden:
+                            logger.warning(f"No permission to read channel {channel.id}")
+                            continue
+                        except Exception as e:
+                            logger.warning(f"Could not verify fixture in {channel.id}: {e}")
+                            continue
+                    if found:
+                        break
 
-            logger.warning(
-                f"Could not find announcement message {message_id} for fixture {fixture['id']}"
-            )
+                if not found:
+                    logger.warning(
+                        f"Could not find announcement message {message_id} for fixture {fixture['id']}"
+                    )
 
         except Exception as e:
             logger.exception(f"Error during fixture verification: {e}")

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -64,6 +64,62 @@ class AdminCommands(commands.Cog):
         self.fixture_handler = FixtureCreationHandler(bot, self.db)
         self.results_handler = ResultsEntryHandler(bot, self.db)
 
+    @staticmethod
+    def _format_open_weeks(open_fixtures: list[dict]) -> str:
+        """Format open fixture weeks for short user-facing messages."""
+        return ", ".join(str(fixture["week_number"]) for fixture in open_fixtures)
+
+    async def _resolve_open_fixture(
+        self,
+        interaction: discord.Interaction,
+        week: int | None,
+        command_example: str,
+    ) -> dict | None:
+        """Resolve target open fixture for admin commands.
+
+        If multiple fixtures are open and no week is provided, the command is
+        rejected to avoid acting on the wrong fixture.
+        """
+        open_fixtures = await self.db.get_open_fixtures()
+
+        if not open_fixtures:
+            await interaction.response.send_message("No open fixtures found!", ephemeral=True)
+            return None
+
+        if week is None:
+            if len(open_fixtures) == 1:
+                return open_fixtures[0]
+
+            open_weeks = self._format_open_weeks(open_fixtures)
+            await interaction.response.send_message(
+                "Multiple fixtures are currently open. "
+                "Please specify the `week` argument to choose one.\n"
+                f"Open weeks: {open_weeks}\n"
+                f"Example: `{command_example}`",
+                ephemeral=True,
+            )
+            return None
+
+        matching = [
+            open_fixture for open_fixture in open_fixtures if open_fixture["week_number"] == week
+        ]
+        if len(matching) == 1:
+            return matching[0]
+        if len(matching) > 1:
+            await interaction.response.send_message(
+                f"More than one open fixture was found for week {week}. "
+                "Please resolve duplicate week numbers in the database before continuing.",
+                ephemeral=True,
+            )
+            return None
+
+        open_weeks = self._format_open_weeks(open_fixtures)
+        await interaction.response.send_message(
+            f"No open fixture found for week {week}.\nOpen weeks: {open_weeks}",
+            ephemeral=True,
+        )
+        return None
+
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
         """Listen for DMs from admins."""
@@ -125,15 +181,16 @@ class AdminCommands(commands.Cog):
                 ephemeral=True,
             )
 
-    @fixture.command(name="delete", description="Delete the current fixture")
+    @fixture.command(name="delete", description="Delete an open fixture")
     @admin_only()
-    async def fixture_delete(self, interaction: discord.Interaction):
-        """Delete current fixture."""
-        fixture = await self.db.get_current_fixture()
+    async def fixture_delete(self, interaction: discord.Interaction, week: int | None = None):
+        """Delete a selected open fixture."""
+        fixture = await self._resolve_open_fixture(
+            interaction,
+            week,
+            "/admin fixture delete week:12",
+        )
         if not fixture:
-            await interaction.response.send_message(
-                "No active fixture found to delete!", ephemeral=True
-            )
             return
 
         view = DeleteConfirmView(
@@ -154,22 +211,23 @@ class AdminCommands(commands.Cog):
     # Results subgroup
     results = app_commands.Group(name="results", description="Manage results", parent=admin)
 
-    @results.command(
-        name="enter", description="Enter results for the current fixture (DM workflow)"
-    )
+    @results.command(name="enter", description="Enter results for an open fixture (DM workflow)")
     @admin_only()
-    async def results_enter(self, interaction: discord.Interaction):
+    async def results_enter(self, interaction: discord.Interaction, week: int | None = None):
         """Initiate results entry via DM."""
-        fixture = await self.db.get_current_fixture()
+        fixture = await self._resolve_open_fixture(
+            interaction,
+            week,
+            "/admin results enter week:12",
+        )
         if not fixture:
-            await interaction.response.send_message("No active fixture found!", ephemeral=True)
             return
 
         existing_results = await self.db.get_results(fixture["id"])
         if existing_results:
             await interaction.response.send_message(
                 "Results already entered for this fixture!\n"
-                "Use `/admin results calculate` to calculate scores.",
+                f"Use `/admin results calculate week:{fixture['week_number']}` to calculate scores.",
                 ephemeral=True,
             )
             return
@@ -215,8 +273,8 @@ class AdminCommands(commands.Cog):
 
     @results.command(name="calculate", description="Calculate scores and post results")
     @admin_only()
-    async def results_calculate(self, interaction: discord.Interaction):
-        """Calculate scores for current fixture and post results."""
+    async def results_calculate(self, interaction: discord.Interaction, week: int | None = None):
+        """Calculate scores for a selected open fixture and post results."""
         _cleanup_expired_cooldowns()
 
         user_id = str(interaction.user.id)
@@ -232,12 +290,15 @@ class AdminCommands(commands.Cog):
                 )
                 return
 
-        _calculate_cooldowns[user_id] = current_time
-
-        fixture = await self.db.get_current_fixture()
+        fixture = await self._resolve_open_fixture(
+            interaction,
+            week,
+            "/admin results calculate week:12",
+        )
         if not fixture:
-            await interaction.response.send_message("No active fixture found!", ephemeral=True)
             return
+
+        _calculate_cooldowns[user_id] = current_time
 
         results = await self.db.get_results(fixture["id"])
         if not results:

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -1,6 +1,8 @@
 """User-facing Discord commands."""
 
 import logging
+import re
+from datetime import timedelta
 
 import discord
 from discord import app_commands
@@ -20,6 +22,10 @@ from typer_bot.utils.logger import LogContextManager, log_event
 logger = logging.getLogger(__name__)
 
 MAX_MESSAGE_LENGTH = 5000
+SESSION_TIMEOUT_HOURS = 1
+WEEK_SELECTION_PATTERN = re.compile(r"^\s*(?:week\s+)?(\d+)\s*$", re.IGNORECASE)
+YES_REPLIES = {"y", "yes"}
+NO_REPLIES = {"n", "no"}
 
 
 class UserCommands(commands.Cog):
@@ -29,6 +35,166 @@ class UserCommands(commands.Cog):
         self.bot = bot
         # TyperBot sets db attr dynamically; discord.py typing doesn't track custom attrs
         self.db: Database = bot.db  # type: ignore
+        self._prediction_sessions: dict[str, dict] = {}
+
+    def _cleanup_expired_prediction_sessions(self):
+        """Remove prediction sessions older than SESSION_TIMEOUT_HOURS."""
+        current_time = now()
+        expiry = timedelta(hours=SESSION_TIMEOUT_HOURS)
+        expired_users = [
+            user_id
+            for user_id, state in self._prediction_sessions.items()
+            if current_time - state.get("created_at", current_time) > expiry
+        ]
+
+        for user_id in expired_users:
+            self._prediction_sessions.pop(user_id, None)
+
+    def _get_prediction_session(self, user_id: str) -> dict | None:
+        """Get active prediction session for a user."""
+        self._cleanup_expired_prediction_sessions()
+        return self._prediction_sessions.get(user_id)
+
+    def _set_prediction_session(
+        self,
+        user_id: str,
+        *,
+        step: str,
+        fixture_ids: list[int] | None = None,
+        fixture_id: int | None = None,
+        completed_fixture_ids: list[int] | None = None,
+    ):
+        """Create or update prediction flow state for a user."""
+        self._prediction_sessions[user_id] = {
+            "step": step,
+            "fixture_ids": fixture_ids or [],
+            "fixture_id": fixture_id,
+            "completed_fixture_ids": completed_fixture_ids or [],
+            "created_at": now(),
+        }
+
+    def _clear_prediction_session(self, user_id: str):
+        """Clear prediction flow state for a user."""
+        self._prediction_sessions.pop(user_id, None)
+
+    @staticmethod
+    def _parse_week_selection(content: str) -> tuple[int | None, str]:
+        """Parse a week selection from DM text.
+
+        Accepts first-line values like "12" or "week 12".
+        Returns the selected week and any remaining text after the first line.
+        """
+        lines = [line.strip() for line in content.split("\n") if line.strip()]
+        if not lines:
+            return None, ""
+
+        match = WEEK_SELECTION_PATTERN.fullmatch(lines[0])
+        if not match:
+            return None, ""
+
+        remainder = "\n".join(lines[1:]).strip()
+        return int(match.group(1)), remainder
+
+    def _build_fixture_selection_prompt(self, fixtures: list[dict], intro: str) -> str:
+        """Build DM prompt asking user which fixture/week to target."""
+        lines = [intro, ""]
+
+        for fixture in fixtures:
+            deadline_str = format_for_discord(fixture["deadline"], "F")
+            relative_str = format_for_discord(fixture["deadline"], "R")
+            lines.append(
+                f"• Week {fixture['week_number']} - Deadline: {deadline_str} ({relative_str})"
+            )
+
+        lines.extend(
+            [
+                "",
+                "Reply with the week number (for example: `12`).",
+            ]
+        )
+        return "\n".join(lines)
+
+    def _build_prediction_prompt(self, fixture: dict) -> str:
+        """Build DM instructions for submitting one fixture's predictions."""
+        lines = [
+            f"**Week {fixture['week_number']} - Submit Your Predictions**",
+            "",
+            "Reply with your predictions in this format (one per line OR comma-separated):",
+            "```",
+        ]
+        for game in fixture["games"]:
+            lines.append(f"{game} 2:0")
+
+        deadline_str = format_for_discord(fixture["deadline"], "F")
+        relative_str = format_for_discord(fixture["deadline"], "R")
+        lines.extend(
+            [
+                "```",
+                "",
+                "Or comma-separated:",
+                "```",
+            ]
+        )
+
+        example_games = fixture["games"][:2] if len(fixture["games"]) >= 2 else fixture["games"]
+        example_preds = [f"{game} 2:0" for game in example_games]
+        if len(fixture["games"]) > 2:
+            lines.append(", ".join(example_preds) + ", ...")
+        else:
+            lines.append(", ".join(example_preds))
+
+        lines.extend(
+            [
+                "```",
+                "",
+                "Add your score (e.g., 2:0 or 2-1) at the end of each game.",
+                f"\n**Deadline:** {deadline_str} ({relative_str})",
+            ]
+        )
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _chunk_message(content: str, limit: int = 2000) -> list[str]:
+        """Split long responses into Discord-safe chunks."""
+        if len(content) <= limit:
+            return [content]
+
+        chunks: list[str] = []
+        current = ""
+        for line in content.split("\n"):
+            candidate = f"{current}\n{line}" if current else line
+            if len(candidate) <= limit:
+                current = candidate
+                continue
+
+            if current:
+                chunks.append(current)
+
+            if len(line) <= limit:
+                current = line
+                continue
+
+            start = 0
+            while start < len(line):
+                end = min(start + limit, len(line))
+                chunks.append(line[start:end])
+                start = end
+            current = ""
+
+        if current:
+            chunks.append(current)
+        return chunks
+
+    async def _send_chunked_ephemeral(self, interaction: discord.Interaction, content: str):
+        """Send an ephemeral response split across followups if needed."""
+        chunks = self._chunk_message(content)
+        if not chunks:
+            return
+
+        await interaction.response.send_message(chunks[0], ephemeral=True)
+        for chunk in chunks[1:]:
+            await interaction.followup.send(chunk, ephemeral=True)
 
     async def _process_prediction_message(self, message: discord.Message):
         """Process predictions from DMs."""
@@ -46,16 +212,160 @@ class UserCommands(commands.Cog):
             await message.author.send(f"❌ Message too long! (max {MAX_MESSAGE_LENGTH} characters)")
             return
 
-        fixture = await self.db.get_current_fixture()
-        if not fixture:
+        open_fixtures = await self.db.get_open_fixtures()
+        if not open_fixtures:
+            self._clear_prediction_session(user_id)
             await message.author.send(
                 "ℹ️ No active fixture at the moment. "
                 "Ask an admin to create one, or check back later!"
             )
             return
 
-        games = fixture["games"]
-        fixture_id = fixture["id"]
+        fixture_by_id = {fixture["id"]: fixture for fixture in open_fixtures}
+        session = self._get_prediction_session(user_id)
+        message_content = message.content.strip()
+
+        # Continue prompt: user chooses whether to predict additional open fixtures.
+        if session and session.get("step") == "continue":
+            reply = message_content.lower()
+            completed_fixture_ids = session.get("completed_fixture_ids", [])
+            remaining_fixture_ids = session.get("fixture_ids", [])
+            remaining_open_fixtures = [
+                fixture for fixture in open_fixtures if fixture["id"] in remaining_fixture_ids
+            ]
+
+            if reply in YES_REPLIES:
+                if not remaining_open_fixtures:
+                    self._clear_prediction_session(user_id)
+                    await message.author.send("ℹ️ There are no other open fixtures right now.")
+                    return
+
+                if len(remaining_open_fixtures) == 1:
+                    next_fixture = remaining_open_fixtures[0]
+                    self._set_prediction_session(
+                        user_id,
+                        step="predict",
+                        fixture_id=next_fixture["id"],
+                        completed_fixture_ids=completed_fixture_ids,
+                    )
+                    await message.author.send(self._build_prediction_prompt(next_fixture))
+                    return
+
+                self._set_prediction_session(
+                    user_id,
+                    step="select",
+                    fixture_ids=[fixture["id"] for fixture in remaining_open_fixtures],
+                    completed_fixture_ids=completed_fixture_ids,
+                )
+                await message.author.send(
+                    self._build_fixture_selection_prompt(
+                        remaining_open_fixtures,
+                        "Multiple fixtures are still open. Which week do you want to predict next?",
+                    )
+                )
+                return
+
+            if reply in NO_REPLIES:
+                self._clear_prediction_session(user_id)
+                await message.author.send("👍 Got it. You're done for now.")
+                return
+
+            await message.author.send("Please reply with `yes` or `no`.")
+            return
+
+        target_fixture: dict | None = None
+        content_for_parsing = message.content
+        completed_fixture_ids: list[int] = []
+
+        if session and session.get("step") == "select":
+            allowed_fixture_ids = set(session.get("fixture_ids", []))
+            completed_fixture_ids = session.get("completed_fixture_ids", [])
+            selected_week, inline_predictions = self._parse_week_selection(message_content)
+
+            selectable_fixtures = [
+                fixture
+                for fixture in open_fixtures
+                if not allowed_fixture_ids or fixture["id"] in allowed_fixture_ids
+            ]
+
+            if selected_week is None:
+                await message.author.send(
+                    self._build_fixture_selection_prompt(
+                        selectable_fixtures,
+                        "Please choose which week you want to predict.",
+                    )
+                )
+                return
+
+            target_fixture = next(
+                (
+                    fixture
+                    for fixture in selectable_fixtures
+                    if fixture["week_number"] == selected_week
+                ),
+                None,
+            )
+
+            if not target_fixture:
+                await message.author.send(
+                    self._build_fixture_selection_prompt(
+                        selectable_fixtures,
+                        f"Week {selected_week} is not currently available. Please choose one of these open weeks:",
+                    )
+                )
+                return
+
+            self._set_prediction_session(
+                user_id,
+                step="predict",
+                fixture_id=target_fixture["id"],
+                completed_fixture_ids=completed_fixture_ids,
+            )
+
+            if inline_predictions:
+                content_for_parsing = inline_predictions
+            else:
+                await message.author.send(self._build_prediction_prompt(target_fixture))
+                return
+
+        elif session and session.get("step") == "predict":
+            completed_fixture_ids = session.get("completed_fixture_ids", [])
+            target_fixture = fixture_by_id.get(session.get("fixture_id"))
+            if not target_fixture:
+                self._set_prediction_session(
+                    user_id,
+                    step="select",
+                    fixture_ids=[fixture["id"] for fixture in open_fixtures],
+                    completed_fixture_ids=completed_fixture_ids,
+                )
+                await message.author.send(
+                    self._build_fixture_selection_prompt(
+                        open_fixtures,
+                        "The fixture you selected is no longer open. Please choose another open week.",
+                    )
+                )
+                return
+
+        if target_fixture is None:
+            if len(open_fixtures) == 1:
+                target_fixture = open_fixtures[0]
+            else:
+                self._set_prediction_session(
+                    user_id,
+                    step="select",
+                    fixture_ids=[fixture["id"] for fixture in open_fixtures],
+                    completed_fixture_ids=completed_fixture_ids,
+                )
+                await message.author.send(
+                    self._build_fixture_selection_prompt(
+                        open_fixtures,
+                        "Multiple fixtures are open. Which week do you want to predict first?",
+                    )
+                )
+                return
+
+        games = target_fixture["games"]
+        fixture_id = target_fixture["id"]
 
         with LogContextManager(user_id=user_id, fixture_id=fixture_id, source="dm"):
             logger.debug(f"Processing DM from user {user_id}")
@@ -64,9 +374,9 @@ class UserCommands(commands.Cog):
 
             try:
                 current_time = now()
-                is_late = current_time > fixture["deadline"]
+                is_late = current_time > target_fixture["deadline"]
 
-                predictions, errors = parse_line_predictions(message.content, games)
+                predictions, errors = parse_line_predictions(content_for_parsing, games)
 
                 if errors:
                     error_msg = "\n".join(errors)
@@ -111,8 +421,8 @@ class UserCommands(commands.Cog):
                 for i, (game, pred) in enumerate(zip(games, predictions, strict=False), 1):
                     preview_lines.append(f"{i}. {game} **{pred}**")
 
-                deadline_str = format_for_discord(fixture["deadline"], "F")
-                relative_str = format_for_discord(fixture["deadline"], "R")
+                deadline_str = format_for_discord(target_fixture["deadline"], "F")
+                relative_str = format_for_discord(target_fixture["deadline"], "R")
                 preview_lines.append(f"\n**Deadline:** {deadline_str} ({relative_str})")
 
                 late_warning = ""
@@ -123,7 +433,30 @@ class UserCommands(commands.Cog):
 
                 preview_text = "\n".join(preview_lines)
 
-                await processing_msg.edit(content=f"{preview_text}{late_warning}", view=None)
+                completed = set(completed_fixture_ids)
+                completed.add(fixture_id)
+                remaining_fixture_ids = [
+                    fixture["id"] for fixture in open_fixtures if fixture["id"] not in completed
+                ]
+
+                if remaining_fixture_ids:
+                    self._set_prediction_session(
+                        user_id,
+                        step="continue",
+                        fixture_ids=remaining_fixture_ids,
+                        completed_fixture_ids=sorted(completed),
+                    )
+                    await processing_msg.edit(
+                        content=(
+                            f"{preview_text}{late_warning}\n\n"
+                            "Would you like to predict another open fixture? "
+                            "Reply `yes` or `no`."
+                        ),
+                        view=None,
+                    )
+                else:
+                    self._clear_prediction_session(user_id)
+                    await processing_msg.edit(content=f"{preview_text}{late_warning}", view=None)
 
             except Exception as e:
                 logger.error(
@@ -146,58 +479,46 @@ class UserCommands(commands.Cog):
         """Listen for DMs with predictions."""
         await self._process_prediction_message(message)
 
-    @app_commands.command(
-        name="predict", description="Submit your predictions for this week's fixtures"
-    )
+    @app_commands.command(name="predict", description="Submit your predictions for open fixtures")
     @app_commands.checks.cooldown(1, 1.0)
     async def predict(self, interaction: discord.Interaction):
         """Send fixture list to user via DM."""
-        fixture = await self.db.get_current_fixture()
-        if not fixture:
+        open_fixtures = await self.db.get_open_fixtures()
+        if not open_fixtures:
             await interaction.response.send_message(
                 "❌ No active fixture found! Ask an admin to create one.", ephemeral=True
             )
             return
 
         await interaction.response.send_message(
-            "📩 Check your DMs! I've sent you the fixture list to predict.", ephemeral=True
-        )
-
-        lines = [
-            f"**Week {fixture['week_number']} - Submit Your Predictions**",
-            "",
-            "Reply with your predictions in this format (one per line OR comma-separated):",
-            "```",
-        ]
-        for game in fixture["games"]:
-            lines.append(f"{game} 2:0")
-        deadline_str = format_for_discord(fixture["deadline"], "F")
-        relative_str = format_for_discord(fixture["deadline"], "R")
-        lines.extend(
-            [
-                "```",
-                "",
-                "Or comma-separated:",
-                "```",
-            ]
-        )
-        example_games = fixture["games"][:2] if len(fixture["games"]) >= 2 else fixture["games"]
-        example_preds = [f"{game} 2:0" for game in example_games]
-        if len(fixture["games"]) > 2:
-            lines.append(", ".join(example_preds) + ", ...")
-        else:
-            lines.append(", ".join(example_preds))
-        lines.extend(
-            [
-                "```",
-                "",
-                "Add your score (e.g., 2:0 or 2-1) at the end of each game.",
-                f"\n**Deadline:** {deadline_str} ({relative_str})",
-            ]
+            "📩 Check your DMs! I've sent you the prediction flow.", ephemeral=True
         )
 
         try:
-            await interaction.user.send("\n".join(lines))
+            user_id = str(interaction.user.id)
+
+            if len(open_fixtures) == 1:
+                fixture = open_fixtures[0]
+                self._set_prediction_session(
+                    user_id,
+                    step="predict",
+                    fixture_id=fixture["id"],
+                    completed_fixture_ids=[],
+                )
+                await interaction.user.send(self._build_prediction_prompt(fixture))
+            else:
+                self._set_prediction_session(
+                    user_id,
+                    step="select",
+                    fixture_ids=[fixture["id"] for fixture in open_fixtures],
+                    completed_fixture_ids=[],
+                )
+                await interaction.user.send(
+                    self._build_fixture_selection_prompt(
+                        open_fixtures,
+                        "Multiple fixtures are open. Which week do you want to predict first?",
+                    )
+                )
         except discord.Forbidden:
             await interaction.followup.send(
                 "❌ I can't send you DMs. Please enable DMs from server members and try again.",
@@ -213,9 +534,9 @@ class UserCommands(commands.Cog):
 
 **For Players:**
 • `/predict` - Submit predictions via DM
-• `/fixtures` - View this week's games
+• `/fixtures` - View all open fixtures
 • `/standings` - See overall leaderboard
-• `/mypredictions` - Check your submitted predictions
+• `/mypredictions` - Check your submitted predictions for open fixtures
 
 **How to Predict (Two Methods):**
 
@@ -231,8 +552,9 @@ class UserCommands(commands.Cog):
 
 **Method 2: DM Predictions**
 1. Type `/predict` in the channel (or DM the bot directly)
-2. Bot sends you a DM with the fixture list
-3. Reply with your predictions - they are saved immediately!
+2. If multiple fixtures are open, bot asks which week you want first
+3. Reply with your predictions - they are saved immediately
+4. Bot can guide you through other open fixtures in the same DM flow
 
 **Scoring:**
 • Exact score: 3 points
@@ -249,11 +571,11 @@ class UserCommands(commands.Cog):
 **For Admins:**
 **Fixture Management:**
 • `/admin fixture create` - Create new fixture (DM workflow, auto-creates thread)
-• `/admin fixture delete` - Delete current fixture
+• `/admin fixture delete [week]` - Delete an open fixture
 
 **Results Management:**
-• `/admin results enter` - Enter actual scores (DM workflow)
-• `/admin results calculate` - Calculate and post scores
+• `/admin results enter [week]` - Enter actual scores (DM workflow)
+• `/admin results calculate [week]` - Calculate and post scores
 • `/admin results post` - Re-post results with optional mentions
 
 **Admin Workflow:**
@@ -266,7 +588,7 @@ class UserCommands(commands.Cog):
    - Bot auto-creates thread for predictions
 
 2. **Enter Results:**
-   - `/admin results enter`
+   - `/admin results enter` (add `week:` if multiple fixtures are open)
    - Bot DMs you
    - Send actual scores:
      ```
@@ -277,7 +599,7 @@ class UserCommands(commands.Cog):
    - Confirm
 
 3. **Calculate Scores:**
-   - `/admin results calculate`
+   - `/admin results calculate` (add `week:` if multiple fixtures are open)
    - Bot posts results (overall + week) to channel
 
 4. **Re-post Results:**
@@ -296,25 +618,37 @@ class UserCommands(commands.Cog):
         if is_admin_user:
             await interaction.followup.send(admin_help, ephemeral=True)
 
-    @app_commands.command(name="fixtures", description="View this week's fixtures")
+    @app_commands.command(name="fixtures", description="View open fixtures")
     async def fixtures(self, interaction: discord.Interaction):
         """Display current fixtures."""
-        fixture = await self.db.get_current_fixture()
+        open_fixtures = await self.db.get_open_fixtures()
 
-        if not fixture:
+        if not open_fixtures:
             await interaction.response.send_message("❌ No active fixture found!", ephemeral=True)
             return
 
-        lines = [f"### Week {fixture['week_number']} Fixtures\n"]
+        if len(open_fixtures) == 1:
+            fixture = open_fixtures[0]
+            lines = [f"### Week {fixture['week_number']} Fixtures\n"]
 
-        for i, game in enumerate(fixture["games"], 1):
-            lines.append(f"{i}. {game}")
+            for i, game in enumerate(fixture["games"], 1):
+                lines.append(f"{i}. {game}")
 
-        deadline_str = format_for_discord(fixture["deadline"], "F")
-        relative_str = format_for_discord(fixture["deadline"], "R")
-        lines.append(f"\n**Deadline:** {deadline_str} ({relative_str})")
+            deadline_str = format_for_discord(fixture["deadline"], "F")
+            relative_str = format_for_discord(fixture["deadline"], "R")
+            lines.append(f"\n**Deadline:** {deadline_str} ({relative_str})")
+        else:
+            lines = ["### Open Fixtures\n"]
+            for fixture in open_fixtures:
+                lines.append(f"**Week {fixture['week_number']}**")
+                for i, game in enumerate(fixture["games"], 1):
+                    lines.append(f"{i}. {game}")
+                deadline_str = format_for_discord(fixture["deadline"], "F")
+                relative_str = format_for_discord(fixture["deadline"], "R")
+                lines.append(f"Deadline: {deadline_str} ({relative_str})")
+                lines.append("")
 
-        await interaction.response.send_message("\n".join(lines), ephemeral=True)
+        await self._send_chunked_ephemeral(interaction, "\n".join(lines))
 
     @app_commands.command(
         name="standings", description="View overall standings and last week's results"
@@ -328,45 +662,84 @@ class UserCommands(commands.Cog):
 
         await interaction.response.send_message(message, ephemeral=True)
 
-    @app_commands.command(name="mypredictions", description="View your predictions for this week")
+    @app_commands.command(
+        name="mypredictions", description="View your predictions for open fixtures"
+    )
     async def my_predictions(self, interaction: discord.Interaction):
         """Show user's current predictions."""
-        fixture = await self.db.get_current_fixture()
+        open_fixtures = await self.db.get_open_fixtures()
 
-        if not fixture:
+        if not open_fixtures:
             await interaction.response.send_message("❌ No active fixture found!", ephemeral=True)
             return
 
-        prediction = await self.db.get_prediction(fixture["id"], str(interaction.user.id))
+        if len(open_fixtures) == 1:
+            fixture = open_fixtures[0]
+            prediction = await self.db.get_prediction(fixture["id"], str(interaction.user.id))
 
-        if not prediction:
-            await interaction.response.send_message(
-                "You haven't submitted predictions for this week yet!\n"
-                "Use `/predict` to enter your scores.",
-                ephemeral=True,
+            if not prediction:
+                await interaction.response.send_message(
+                    "You haven't submitted predictions for this week yet!\n"
+                    "Use `/predict` to enter your scores.",
+                    ephemeral=True,
+                )
+                return
+
+            lines = ["**Your Predictions:**\n"]
+            for i, (game, pred) in enumerate(
+                zip(fixture["games"], prediction["predictions"], strict=False), 1
+            ):
+                lines.append(f"{i}. {game} **{pred}**")
+
+            late_status = "⚠️ **LATE**" if prediction["is_late"] else "✅ On time"
+            submitted = format_for_discord(prediction["submitted_at"], "f")
+            deadline_str = format_for_discord(fixture["deadline"], "F")
+            relative_str = format_for_discord(fixture["deadline"], "R")
+
+            lines.extend(
+                [
+                    f"\n**Deadline:** {deadline_str} ({relative_str})",
+                    f"**Status:** {late_status}",
+                    f"**Submitted:** {submitted}",
+                ]
             )
+
+            await self._send_chunked_ephemeral(interaction, "\n".join(lines))
             return
 
-        lines = ["**Your Predictions:**\n"]
-        for i, (game, pred) in enumerate(
-            zip(fixture["games"], prediction["predictions"], strict=False), 1
-        ):
-            lines.append(f"{i}. {game} **{pred}**")
+        user_id = str(interaction.user.id)
+        lines = ["**Your Predictions (Open Fixtures):**", ""]
+        has_any_prediction = False
 
-        late_status = "⚠️ **LATE**" if prediction["is_late"] else "✅ On time"
-        submitted = format_for_discord(prediction["submitted_at"], "f")
-        deadline_str = format_for_discord(fixture["deadline"], "F")
-        relative_str = format_for_discord(fixture["deadline"], "R")
+        for fixture in open_fixtures:
+            prediction = await self.db.get_prediction(fixture["id"], user_id)
+            deadline_str = format_for_discord(fixture["deadline"], "F")
+            relative_str = format_for_discord(fixture["deadline"], "R")
 
-        lines.extend(
-            [
-                f"\n**Deadline:** {deadline_str} ({relative_str})",
-                f"**Status:** {late_status}",
-                f"**Submitted:** {submitted}",
-            ]
-        )
+            lines.append(f"**Week {fixture['week_number']}**")
+            lines.append(f"Deadline: {deadline_str} ({relative_str})")
 
-        await interaction.response.send_message("\n".join(lines), ephemeral=True)
+            if not prediction:
+                lines.append("No prediction submitted yet.")
+                lines.append("")
+                continue
+
+            has_any_prediction = True
+            for i, (game, pred) in enumerate(
+                zip(fixture["games"], prediction["predictions"], strict=False), 1
+            ):
+                lines.append(f"{i}. {game} **{pred}**")
+
+            late_status = "⚠️ **LATE**" if prediction["is_late"] else "✅ On time"
+            submitted = format_for_discord(prediction["submitted_at"], "f")
+            lines.append(f"Status: {late_status}")
+            lines.append(f"Submitted: {submitted}")
+            lines.append("")
+
+        if not has_any_prediction:
+            lines.append("Use `/predict` to submit your scores.")
+
+        await self._send_chunked_ephemeral(interaction, "\n".join(lines))
 
 
 async def setup(bot: commands.Bot):

--- a/typer_bot/database/database.py
+++ b/typer_bot/database/database.py
@@ -119,6 +119,52 @@ class Database:
             )
             return cursor.lastrowid
 
+    async def create_next_fixture(self, games: list[str], deadline: datetime) -> tuple[int, int]:
+        """Create a new fixture with the next available week number atomically.
+
+        Returns:
+            Tuple of (fixture_id, allocated_week_number).
+        """
+        if deadline.tzinfo is None:
+            from typer_bot.utils import APP_TZ
+
+            deadline = deadline.replace(tzinfo=APP_TZ)
+
+        start_time = time.perf_counter()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                async with db.execute(
+                    "SELECT COALESCE(MAX(week_number), 0) FROM fixtures"
+                ) as cursor:
+                    row = await cursor.fetchone()
+                    next_week = int(row[0]) + 1 if row else 1
+
+                insert_cursor = await db.execute(
+                    "INSERT INTO fixtures (week_number, games, deadline) VALUES (?, ?, ?)",
+                    (next_week, "\n".join(games), deadline.isoformat()),
+                )
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+
+            if insert_cursor.lastrowid is None:
+                raise RuntimeError("Failed to create fixture: lastrowid is None")
+
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            logger.debug(
+                "db.create_next_fixture completed",
+                extra={
+                    "operation": "db.create_next_fixture",
+                    "week_number": next_week,
+                    "fixture_id": insert_cursor.lastrowid,
+                    "duration_ms": round(duration_ms, 2),
+                    "games_count": len(games),
+                },
+            )
+            return insert_cursor.lastrowid, next_week
+
     def _row_to_fixture(self, row: aiosqlite.Row) -> dict:
         """Convert database row to fixture dictionary."""
         row_dict = dict(row)
@@ -133,11 +179,36 @@ class Database:
         }
 
     async def get_current_fixture(self) -> dict | None:
-        """Get the current open fixture."""
+        """Get the most recently created open fixture.
+
+        Kept for backward compatibility with older call sites that assume a
+        single active fixture.
+        """
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
                 "SELECT * FROM fixtures WHERE status = 'open' ORDER BY id DESC LIMIT 1"
+            ) as cursor:
+                row = await cursor.fetchone()
+                return self._row_to_fixture(row) if row else None
+
+    async def get_open_fixtures(self) -> list[dict]:
+        """Get all open fixtures ordered by week and creation order."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM fixtures WHERE status = 'open' ORDER BY week_number ASC, id ASC"
+            ) as cursor:
+                rows = await cursor.fetchall()
+                return [self._row_to_fixture(row) for row in rows]
+
+    async def get_open_fixture_by_week(self, week_number: int) -> dict | None:
+        """Get an open fixture by week number."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM fixtures WHERE status = 'open' AND week_number = ? ORDER BY id DESC LIMIT 1",
+                (week_number,),
             ) as cursor:
                 row = await cursor.fetchone()
                 return self._row_to_fixture(row) if row else None

--- a/typer_bot/handlers/fixture_handler.py
+++ b/typer_bot/handlers/fixture_handler.py
@@ -232,6 +232,18 @@ class FixtureCreationHandler:
         week_number = max_week + 1
         state["week_number"] = week_number
 
+        preview_text = self._build_fixture_preview_text(week_number, games, deadline)
+        state["preview"] = preview_text
+        state["step"] = "confirm"
+
+        view = FixtureConfirmView(
+            self, user_id, week_number, games, deadline, channel, preview_text
+        )
+        await user.send(f"{preview_text}\n\nCreate this fixture?", view=view)
+
+    @staticmethod
+    def _build_fixture_preview_text(week_number: int, games: list[str], deadline: datetime) -> str:
+        """Build a fixture preview block for DMs and announcements."""
         lines = [f"**Week {week_number} Fixture Preview**\n"]
         for i, game in enumerate(games, 1):
             lines.append(f"{i}. {game}")
@@ -240,34 +252,27 @@ class FixtureCreationHandler:
         relative_str = format_for_discord(deadline, "R")
         lines.append(f"\n**Deadline:** {deadline_str} ({relative_str})")
 
-        warning = ""
         if len(games) != 9:
-            warning = f"\n\n⚠️ **Warning:** Expected 9 games, got {len(games)}"
+            lines.append(f"\n⚠️ **Warning:** Expected 9 games, got {len(games)}")
 
-        preview_text = "\n".join(lines)
-        state["preview"] = preview_text + warning
-        state["step"] = "confirm"
-
-        view = FixtureConfirmView(
-            self, user_id, week_number, games, deadline, channel, preview_text + warning
-        )
-        await user.send(f"{preview_text}{warning}\n\nCreate this fixture?", view=view)
+        return "\n".join(lines)
 
     async def create_fixture(
-        self, user_id: str, week_number: int, games: list, deadline: datetime
-    ) -> None:
-        """Create the fixture in the database."""
-        fixture_id = await self.db.create_fixture(week_number, games, deadline)
+        self, user_id: str, games: list, deadline: datetime
+    ) -> tuple[int, int]:
+        """Create the fixture in the database and return ID + allocated week."""
+        fixture_id, allocated_week = await self.db.create_next_fixture(games, deadline)
         _pending_fixtures.pop(user_id, None)
         log_event(
             logger,
             event_type="fixture.created",
-            message=f"Fixture created: Week {week_number}",
+            message=f"Fixture created: Week {allocated_week}",
             user_id=user_id,
             fixture_id=fixture_id,
-            week_number=week_number,
+            week_number=allocated_week,
             games_count=len(games),
         )
+        return fixture_id, allocated_week
 
     def cancel_session(self, user_id: str, reason: str = "cancelled") -> None:
         """Cancel the fixture creation session."""
@@ -343,33 +348,49 @@ class FixtureConfirmView(ui.View):
     @ui.button(label="Create Fixture", style=discord.ButtonStyle.green)
     async def confirm(self, interaction: discord.Interaction, _button: ui.Button):
         """Save fixture to database and announce."""
-        await self.handler.create_fixture(self.user_id, self.week_number, self.games, self.deadline)
+        fixture_id, allocated_week = await self.handler.create_fixture(
+            self.user_id,
+            self.games,
+            self.deadline,
+        )
+
+        final_preview = self.handler._build_fixture_preview_text(
+            allocated_week,
+            self.games,
+            self.deadline,
+        )
+
+        created_text = f"**Week {allocated_week} Fixture Created!**\n\n{final_preview}"
+        if allocated_week != self.week_number:
+            created_text += (
+                "\n\nℹ️ Week number was adjusted automatically because another "
+                "fixture was created at the same time."
+            )
 
         await interaction.response.edit_message(
-            content=f"**Week {self.week_number} Fixture Created!**\n\n{self.preview}", view=None
+            content=created_text,
+            view=None,
         )
 
         try:
             # Send announcement message
             announcement = await self.channel.send(
-                f"**Week {self.week_number} Fixture is now open!**\n\n"
-                f"{self.preview}\n\n"
+                f"**Week {allocated_week} Fixture is now open!**\n\n"
+                f"{final_preview}\n\n"
                 f"💬 **How to predict:**\n"
                 f"• Reply in this thread with your scores (one per line)\n"
                 f"• Or use `/predict` for DM mode"
             )
 
-            fixture = await self.handler.db.get_current_fixture()
-            if fixture:
-                await self.handler.db.update_fixture_announcement(
-                    fixture["id"],
-                    message_id=str(announcement.id),
-                )
+            await self.handler.db.update_fixture_announcement(
+                fixture_id,
+                message_id=str(announcement.id),
+            )
 
             # Create a thread for predictions
             try:
                 thread = await announcement.create_thread(
-                    name=f"Week {self.week_number} Predictions",
+                    name=f"Week {allocated_week} Predictions",
                     auto_archive_duration=1440,  # 24 hours
                 )
                 await thread.send(


### PR DESCRIPTION
## Why

The bot previously assumed a single "current fixture", which made admin actions and DM prediction flow ambiguous once more than one fixture was open.
This PR removes that bottleneck so fixtures can run concurrently without one workflow monopolizing the others.

## What Changed

- Added multi-open fixture queries in `Database`:
  - `get_open_fixtures()`
  - `get_open_fixture_by_week()`
  - kept `get_current_fixture()` for backward compatibility.
- Added atomic week allocation via `create_next_fixture()` (`BEGIN IMMEDIATE` + `MAX(week_number)+1` + insert) to prevent duplicate week races during concurrent fixture creation.
- Updated fixture creation flow to use allocated week at save time and to bind announcement updates to the created `fixture_id` directly.

### Admin workflow

- `/admin fixture delete`, `/admin results enter`, and `/admin results calculate` now support optional `week` targeting.
- If multiple fixtures are open and `week` is omitted, command is rejected with clear disambiguation and open-week list.
- Added defensive rejection when duplicate open fixtures exist for the same week.

### Player DM workflow

- `/predict` now guides users when multiple fixtures are open:
  - asks which week to predict first,
  - saves predictions immediately,
  - asks whether to predict another open fixture.
- Direct DM prediction submissions are now disambiguated the same way (no silent fallback to newest fixture).
- If a selected fixture closes mid-flow, user must reselect; predictions are not rerouted silently.

### Bot internals

- Reminder loop now evaluates all open fixtures (24h and 1h reminders), not only one.
- Startup fixture announcement/thread verification now checks all open fixtures.

### UX hardening

- Added chunked ephemeral output for `/fixtures` and `/mypredictions` to stay within Discord message limits.
- Updated README and in-bot help text to reflect multi-open behavior and `week` disambiguation.

## Validation

- `uv run ruff check .`
- `uv run pytest` (219 passed, 1 skipped)
