### PR TITLE
feat: add safe admin override panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Bot requires:
    Team E - Team F 3:2
    ...
    ```
- 3. Bot reacts ✅ when saved. To change, just post again.
+ 3. Bot reacts ✅ when saved. Thread submissions are one-shot; use `/predict` or DM the bot to replace an existing prediction.
 
 **Method 2: DM Predictions**
 1. Type `/predict` (or DM the bot directly) -> Bot DMs you the games
@@ -48,6 +48,7 @@ Bot requires:
 You need a Discord role named `Admin` or `typer-admin`.
 
 **Fixture Management:**
+- `/admin panel` - Open the admin hub for fixture deletion, prediction overrides, waivers, and result correction
 - `/admin fixture create` - Create a new fixture (DM workflow with games + deadline, auto-creates prediction thread)
 - `/admin fixture delete [week]` - Delete an open fixture (week required if multiple are open)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,6 +276,8 @@ class MockInteraction:
         self.response = MagicMock()
         self.response.is_done.return_value = False
         self.response.send_message = self._response_send_message
+        self.response.edit_message = self._response_edit_message
+        self.response.send_modal = self._response_send_modal
 
         self.followup = MagicMock()
         self.followup.send = self._followup_send
@@ -289,6 +291,14 @@ class MockInteraction:
         msg = {"content": content}
         msg.update(kwargs)
         self.followup_sent.append(msg)
+
+    async def _response_edit_message(self, content: str = None, **kwargs):
+        msg = {"content": content}
+        msg.update(kwargs)
+        self.response_sent.append(msg)
+
+    async def _response_send_modal(self, modal, **kwargs):
+        self.modal_sent = {"modal": modal, **kwargs}
 
     async def response_send_message(self, content: str = None, **kwargs):
         msg = {"content": content}

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1,0 +1,319 @@
+"""Tests for admin panel interactions."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from tests.conftest import MockInteraction, MockUser
+from typer_bot.commands.admin_commands import (
+    AdminCommands,
+    AdminPanelHomeView,
+    CorrectResultsModal,
+    PredictionsPanelView,
+    ReplacePredictionModal,
+    ResultsPanelView,
+)
+
+
+class TestAdminPanelCommand:
+    """The slash entrypoint should open the panel."""
+
+    @pytest.fixture
+    def admin_cog(self, mock_bot, database):
+        mock_bot.db = database
+        return AdminCommands(mock_bot)
+
+    @pytest.mark.asyncio
+    async def test_panel_command_returns_view(self, admin_cog, mock_interaction_admin):
+        await admin_cog.panel.callback(admin_cog, mock_interaction_admin)
+
+        response = mock_interaction_admin.response_sent[0]
+        assert "Admin Panel" in response["content"]
+        assert response["ephemeral"] is True
+        assert response["view"] is not None
+
+
+class TestPredictionPanelFlows:
+    """Prediction override flow should stay targeted and owner-restricted."""
+
+    @pytest.fixture
+    def admin_cog(self, mock_bot, database):
+        mock_bot.db = database
+        return AdminCommands(mock_bot)
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_blocks_non_owner(self, admin_cog, mock_interaction_admin):
+        view = PredictionsPanelView(admin_cog, str(mock_interaction_admin.user.id))
+        outsider = MockInteraction(
+            user=MockUser(user_id="999999", name="Outsider"),
+            guild=mock_interaction_admin.guild,
+            channel=mock_interaction_admin.channel,
+        )
+
+        allowed = await view.interaction_check(outsider)
+
+        assert allowed is False
+        assert outsider.response_sent[0]["ephemeral"] is True
+        assert "permission" in outsider.response_sent[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_rechecks_admin_role(self, admin_cog, mock_interaction_admin):
+        view = PredictionsPanelView(admin_cog, str(mock_interaction_admin.user.id))
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.roles = []
+
+        allowed = await view.interaction_check(mock_interaction_admin)
+
+        assert allowed is False
+        assert "no longer have permission" in mock_interaction_admin.response_sent[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_replace_opens_modal(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-2"],
+            False,
+        )
+
+        view = PredictionsPanelView(admin_cog, str(mock_interaction_admin.user.id))
+        await view.load_fixture_options()
+
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["user-1"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        replace_button = next(
+            child
+            for child in view.children
+            if getattr(child, "label", None) == "Replace Prediction"
+        )
+        await replace_button.callback(mock_interaction_admin)
+
+        assert mock_interaction_admin.modal_sent["modal"].title == "Replace Week 1 Prediction"
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_toggle_waiver_updates_status(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            2, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-2"],
+            True,
+        )
+
+        view = PredictionsPanelView(admin_cog, str(mock_interaction_admin.user.id))
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["user-1"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        toggle_button = next(
+            child
+            for child in view.children
+            if getattr(child, "label", None) == "Toggle Late Waiver"
+        )
+        await toggle_button.callback(mock_interaction_admin)
+
+        prediction = await admin_cog.db.get_prediction(fixture_id, "user-1")
+        assert prediction is not None
+        assert prediction["late_penalty_waived"] == 1
+        assert "waiver enabled" in mock_interaction_admin.response_sent[-1]["content"].lower()
+
+
+class TestFixturePanelFlows:
+    """Fixture panel should load current open fixtures before deletion."""
+
+    @pytest.fixture
+    def admin_cog(self, mock_bot, database):
+        mock_bot.db = database
+        return AdminCommands(mock_bot)
+
+    @pytest.mark.asyncio
+    async def test_fixture_button_populates_open_fixture_options(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        await admin_cog.db.create_fixture(4, sample_games, datetime.now(UTC) + timedelta(days=1))
+
+        view = AdminPanelHomeView(admin_cog, str(mock_interaction_admin.user.id))
+        fixture_button = next(
+            child for child in view.children if getattr(child, "label", None) == "Fixtures"
+        )
+        await fixture_button.callback(mock_interaction_admin)
+
+        edited_view = mock_interaction_admin.response_sent[-1]["view"]
+        assert edited_view.fixture_select.disabled is False
+        assert edited_view.fixture_select.options[0].label == "Week 4 [OPEN]"
+
+
+class TestResultsPanelFlows:
+    """Result correction panel should target a fixture before editing."""
+
+    @pytest.fixture
+    def admin_cog(self, mock_bot, database):
+        mock_bot.db = database
+        return AdminCommands(mock_bot)
+
+    @pytest.mark.asyncio
+    async def test_results_panel_correct_opens_modal(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            3, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+
+        view = ResultsPanelView(admin_cog, str(mock_interaction_admin.user.id))
+        await view.load_fixture_options()
+
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        correct_button = next(
+            child for child in view.children if getattr(child, "label", None) == "Correct Results"
+        )
+        await correct_button.callback(mock_interaction_admin)
+
+        assert mock_interaction_admin.modal_sent["modal"].title == "Correct Week 3 Results"
+
+    @pytest.mark.asyncio
+    async def test_results_panel_requires_existing_results(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            5, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+
+        view = ResultsPanelView(admin_cog, str(mock_interaction_admin.user.id))
+        await view.load_fixture_options()
+
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        correct_button = next(
+            child for child in view.children if getattr(child, "label", None) == "Correct Results"
+        )
+        await correct_button.callback(mock_interaction_admin)
+
+        assert (
+            "Use `/admin results enter` first"
+            in mock_interaction_admin.response_sent[-1]["content"]
+        )
+
+
+class TestAdminPanelModals:
+    """Modal submit paths should reject stale permissions."""
+
+    @pytest.fixture
+    def admin_cog(self, mock_bot, database):
+        mock_bot.db = database
+        return AdminCommands(mock_bot)
+
+    @pytest.mark.asyncio
+    async def test_replace_prediction_modal_rechecks_admin_permission(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-0"],
+            False,
+        )
+        view = PredictionsPanelView(admin_cog, str(mock_interaction_admin.user.id))
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        prediction = await admin_cog.db.get_prediction(fixture_id, "user-1")
+        assert fixture is not None
+        assert prediction is not None
+
+        modal = ReplacePredictionModal(view, fixture, prediction)
+        modal.predictions_input._value = (
+            "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+        )
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.roles = []
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "no longer have permission" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_correct_results_modal_rechecks_admin_permission(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            2, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+        view = ResultsPanelView(admin_cog, str(mock_interaction_admin.user.id))
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = CorrectResultsModal(view, fixture)
+        modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.roles = []
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "no longer have permission" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_correct_results_modal_handles_deleted_fixture(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            6, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+        view = ResultsPanelView(admin_cog, str(mock_interaction_admin.user.id))
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = CorrectResultsModal(view, fixture)
+        modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+        await admin_cog.db.delete_fixture(fixture_id)
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "Fixture not found" in mock_interaction_admin.response_sent[-1]["content"]

--- a/tests/test_admin_service.py
+++ b/tests/test_admin_service.py
@@ -1,0 +1,309 @@
+"""Tests for shared admin service workflows."""
+
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+import pytest
+
+from typer_bot.services import AdminService
+
+
+class TestLatePenaltyWaiver:
+    """Late waivers should only change penalty application."""
+
+    @pytest.mark.asyncio
+    async def test_toggle_late_penalty_waiver_recalculates_closed_fixture(
+        self,
+        database,
+        sample_games,
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            1, sample_games, datetime.now(UTC) - timedelta(hours=2)
+        )
+
+        await database.save_prediction(
+            fixture_id,
+            "late-user",
+            "Late User",
+            ["2-1", "1-1", "0-2"],
+            True,
+        )
+        await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
+        await service.calculate_fixture_scores(fixture_id)
+
+        standings = await database.get_standings()
+        assert standings[0]["total_points"] == 0
+
+        fixture, prediction, recalculation = await service.toggle_late_penalty_waiver(
+            fixture_id,
+            "late-user",
+        )
+
+        assert fixture["week_number"] == 1
+        assert prediction["late_penalty_waived"] == 1
+        assert recalculation is not None
+
+        standings = await database.get_standings()
+        assert standings[0]["total_points"] == 9
+
+    @pytest.mark.asyncio
+    async def test_toggle_late_waiver_rolls_back_if_recalculation_fails(
+        self,
+        database,
+        sample_games,
+        monkeypatch,
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            1, sample_games, datetime.now(UTC) - timedelta(hours=2)
+        )
+
+        await database.save_prediction(
+            fixture_id,
+            "late-user",
+            "Late User",
+            ["2-1", "1-1", "0-2"],
+            True,
+        )
+        await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
+        await service.calculate_fixture_scores(fixture_id)
+
+        async def raise_recalc_error(*_args, **_kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(database, "_recalculate_scores_in_connection", raise_recalc_error)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await service.toggle_late_penalty_waiver(fixture_id, "late-user")
+
+        prediction = await database.get_prediction(fixture_id, "late-user")
+        assert prediction is not None
+        assert prediction["late_penalty_waived"] == 0
+
+
+class TestPredictionReplacement:
+    """Admin edits should preserve original timing facts."""
+
+    @pytest.mark.asyncio
+    async def test_replace_prediction_preserves_original_timing_metadata(
+        self,
+        database,
+        sample_games,
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+
+        await database.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-0"],
+            True,
+        )
+
+        original = await database.get_prediction(fixture_id, "user-1")
+        assert original is not None
+
+        fixture, updated_prediction, recalculation = await service.replace_prediction(
+            fixture_id,
+            "user-1",
+            "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2",
+            "admin-1",
+        )
+
+        assert fixture["week_number"] == 1
+        assert recalculation is None
+        assert updated_prediction["predictions"] == ["2-1", "1-1", "0-2"]
+        assert updated_prediction["submitted_at"] == original["submitted_at"]
+        assert updated_prediction["is_late"] == original["is_late"]
+        assert updated_prediction["admin_edited_by"] == "admin-1"
+        assert updated_prediction["admin_edited_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_replace_prediction_rolls_back_if_recalculation_fails(
+        self,
+        database,
+        sample_games,
+        monkeypatch,
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+
+        await database.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-0"],
+            False,
+        )
+        await database.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+        await service.calculate_fixture_scores(fixture_id)
+
+        async def raise_recalc_error(*_args, **_kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(database, "_recalculate_scores_in_connection", raise_recalc_error)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await service.replace_prediction(
+                fixture_id,
+                "user-1",
+                "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2",
+                "admin-1",
+            )
+
+        prediction = await database.get_prediction(fixture_id, "user-1")
+        assert prediction is not None
+        assert prediction["predictions"] == ["1-0", "1-1", "0-0"]
+        assert prediction["admin_edited_by"] is None
+
+    @pytest.mark.asyncio
+    async def test_replace_prediction_recalculates_scored_fixture(
+        self,
+        database,
+        sample_games,
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+
+        await database.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-0"],
+            False,
+        )
+        await database.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+        await service.calculate_fixture_scores(fixture_id)
+
+        before = await database.get_standings()
+        assert before[0]["total_points"] == 9
+
+        _fixture, updated_prediction, recalculation = await service.replace_prediction(
+            fixture_id,
+            "user-1",
+            "Team A - Team B 2-1\nTeam C - Team D 2-2\nTeam E - Team F 1-0",
+            "admin-1",
+        )
+
+        assert updated_prediction["admin_edited_by"] == "admin-1"
+        assert recalculation is not None
+
+        after = await database.get_standings()
+        assert after[0]["total_points"] == 2
+
+
+class TestResultCorrection:
+    """Result correction should refresh saved scores and standings."""
+
+    @pytest.mark.asyncio
+    async def test_correct_results_recalculates_fixture_scores_and_standings(
+        self,
+        database,
+        sample_games,
+    ):
+        service = AdminService(database)
+        fixture1_id = await database.create_fixture(
+            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        fixture2_id = await database.create_fixture(
+            2, sample_games, datetime.now(UTC) + timedelta(days=2)
+        )
+
+        await database.save_prediction(
+            fixture1_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-2"],
+            False,
+        )
+        await database.save_prediction(
+            fixture1_id,
+            "user-2",
+            "User Two",
+            ["2-1", "1-1", "0-2"],
+            False,
+        )
+        await database.save_results(fixture1_id, ["1-0", "1-1", "0-2"])
+        await service.calculate_fixture_scores(fixture1_id)
+
+        await database.save_prediction(
+            fixture2_id,
+            "user-1",
+            "User One",
+            ["2-0", "0-0", "1-1"],
+            False,
+        )
+        await database.save_results(fixture2_id, ["2-0", "0-0", "1-1"])
+        await service.calculate_fixture_scores(fixture2_id)
+
+        before = await database.get_standings()
+        assert before[0]["user_id"] == "user-1"
+        assert before[0]["total_points"] == 18
+        assert before[1]["total_points"] == 7
+
+        fixture, results, recalculation = await service.correct_results(
+            fixture1_id,
+            "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2",
+        )
+
+        assert fixture["week_number"] == 1
+        assert results == ["2-1", "1-1", "0-2"]
+        assert recalculation is not None
+
+        after = await database.get_standings()
+        assert after[0]["user_id"] == "user-1"
+        assert after[0]["total_points"] == 16
+        assert after[1]["user_id"] == "user-2"
+        assert after[1]["total_points"] == 9
+
+        async with (
+            aiosqlite.connect(database.db_path) as conn,
+            conn.execute(
+                "SELECT COUNT(*) FROM results WHERE fixture_id = ?", (fixture1_id,)
+            ) as cursor,
+        ):
+            row = await cursor.fetchone()
+            assert row is not None
+            assert row[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_correct_results_rolls_back_if_recalculation_fails(
+        self,
+        database,
+        sample_games,
+        monkeypatch,
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await database.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-0"],
+            False,
+        )
+        await database.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+        await service.calculate_fixture_scores(fixture_id)
+
+        async def raise_recalc_error(*_args, **_kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(database, "_recalculate_scores_in_connection", raise_recalc_error)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await service.correct_results(
+                fixture_id,
+                "Team A - Team B 2-1\nTeam C - Team D 2-2\nTeam E - Team F 1-0",
+            )
+
+        assert await database.get_results(fixture_id) == ["1-0", "1-1", "0-0"]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -218,3 +218,141 @@ class TestSchemaMigration:
         fixture = await db.get_current_fixture()
         assert fixture is not None
         assert "message_id" in fixture
+
+    @pytest.mark.asyncio
+    async def test_initialize_migrates_legacy_results_to_unique_latest_row(self, temp_db_path):
+        """Legacy duplicate result rows should collapse to the newest saved value."""
+        async with aiosqlite.connect(temp_db_path) as conn:
+            await conn.execute(
+                """
+                CREATE TABLE fixtures (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    week_number INTEGER NOT NULL,
+                    games TEXT NOT NULL,
+                    deadline DATETIME NOT NULL,
+                    status TEXT DEFAULT 'open'
+                )
+                """
+            )
+            await conn.execute(
+                """
+                CREATE TABLE predictions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    fixture_id INTEGER NOT NULL,
+                    user_id TEXT NOT NULL,
+                    user_name TEXT NOT NULL,
+                    predictions TEXT NOT NULL,
+                    submitted_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    is_late BOOLEAN DEFAULT FALSE,
+                    UNIQUE(fixture_id, user_id)
+                )
+                """
+            )
+            await conn.execute(
+                """
+                CREATE TABLE results (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    fixture_id INTEGER NOT NULL,
+                    results TEXT NOT NULL,
+                    calculated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            await conn.execute(
+                "INSERT INTO fixtures (id, week_number, games, deadline, status) VALUES (1, 1, 'A - B', ?, 'open')",
+                (datetime.now(UTC).isoformat(),),
+            )
+            await conn.execute(
+                "INSERT INTO results (fixture_id, results, calculated_at) VALUES (1, '1-0', '2024-01-01T10:00:00+00:00')"
+            )
+            await conn.execute(
+                "INSERT INTO results (fixture_id, results, calculated_at) VALUES (1, '2-0', '2024-01-01T12:00:00+00:00')"
+            )
+            await conn.commit()
+
+        db = Database(temp_db_path)
+        await db.initialize()
+
+        assert await db.get_results(1) == ["2-0"]
+
+        async with (
+            aiosqlite.connect(temp_db_path) as conn,
+            conn.execute("SELECT COUNT(*) FROM results WHERE fixture_id = 1") as cursor,
+        ):
+            row = await cursor.fetchone()
+            assert row is not None
+            assert row[0] == 1
+
+        await db.save_results(1, ["3-0"])
+        assert await db.get_results(1) == ["3-0"]
+
+        async with (
+            aiosqlite.connect(temp_db_path) as conn,
+            conn.execute("SELECT COUNT(*) FROM results WHERE fixture_id = 1") as cursor,
+        ):
+            row = await cursor.fetchone()
+            assert row is not None
+            assert row[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_initialize_adds_prediction_override_columns_with_safe_defaults(
+        self, temp_db_path
+    ):
+        """Legacy prediction rows should gain admin-override fields without mutating existing facts."""
+        async with aiosqlite.connect(temp_db_path) as conn:
+            await conn.execute(
+                """
+                CREATE TABLE fixtures (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    week_number INTEGER NOT NULL,
+                    games TEXT NOT NULL,
+                    deadline DATETIME NOT NULL,
+                    status TEXT DEFAULT 'open'
+                )
+                """
+            )
+            await conn.execute(
+                """
+                CREATE TABLE predictions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    fixture_id INTEGER NOT NULL,
+                    user_id TEXT NOT NULL,
+                    user_name TEXT NOT NULL,
+                    predictions TEXT NOT NULL,
+                    submitted_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    is_late BOOLEAN DEFAULT FALSE,
+                    UNIQUE(fixture_id, user_id)
+                )
+                """
+            )
+            await conn.execute(
+                """
+                CREATE TABLE results (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    fixture_id INTEGER NOT NULL,
+                    results TEXT NOT NULL,
+                    calculated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+            await conn.execute(
+                "INSERT INTO fixtures (id, week_number, games, deadline, status) VALUES (1, 1, 'A - B', ?, 'open')",
+                (datetime.now(UTC).isoformat(),),
+            )
+            await conn.execute(
+                """
+                INSERT INTO predictions (fixture_id, user_id, user_name, predictions, submitted_at, is_late)
+                VALUES (1, 'user-1', 'User One', '1-0', '2024-01-01T10:00:00+00:00', 1)
+                """
+            )
+            await conn.commit()
+
+        db = Database(temp_db_path)
+        await db.initialize()
+
+        prediction = await db.get_prediction(1, "user-1")
+        assert prediction is not None
+        assert prediction["is_late"] == 1
+        assert prediction["late_penalty_waived"] == 0
+        assert prediction["admin_edited_at"] is None
+        assert prediction["admin_edited_by"] is None

--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -135,6 +135,35 @@ class TestOnMessage:
         assert predictions[0]["is_late"]
         assert "Late prediction" in mock_message.author.dm_sent[0]
 
+    @pytest.mark.asyncio
+    async def test_rejects_thread_resubmission_without_overwriting_prediction(
+        self,
+        handler,
+        fixture_with_thread,
+        mock_message,
+    ):
+        """Thread reposts stay one-shot and preserve the original stored prediction."""
+        mock_message.channel.id = 789012
+        mock_message.content = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+        await handler.on_message(mock_message)
+        _prediction_cooldowns.clear()
+
+        second_message = type(mock_message)(
+            content="Team A - Team B 0-0\nTeam C - Team D 0-0\nTeam E - Team F 0-0",
+            message_id="777777",
+            author=mock_message.author,
+            channel=mock_message.channel,
+            guild=mock_message.guild,
+        )
+        second_message.channel.id = 789012
+
+        result = await handler.on_message(second_message)
+
+        assert result is True
+        predictions = await handler.db.get_all_predictions(fixture_with_thread["id"])
+        assert predictions[0]["predictions"] == ["2-1", "1-1", "0-2"]
+        assert "Use `/predict`" in second_message.author.dm_sent[-1]
+
 
 class TestEdgeCases:
     """Test suite for edge cases and boundary conditions."""

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -1,6 +1,9 @@
 """Admin Discord commands."""
 
+from __future__ import annotations
+
 import logging
+from dataclasses import dataclass
 
 import discord
 from discord import app_commands
@@ -8,25 +11,22 @@ from discord.ext import commands
 
 from typer_bot.database import Database
 from typer_bot.handlers import FixtureCreationHandler, ResultsEntryHandler
-from typer_bot.utils import (
-    calculate_points,
-    format_standings,
-    is_admin,
-    is_admin_member,
-    now,
-)
+from typer_bot.services import AdminService
+from typer_bot.services.admin_service import FixtureScoreResult
+from typer_bot.utils import format_standings, is_admin, is_admin_member, now
 from typer_bot.utils.config import BACKUP_DIR
 from typer_bot.utils.db_backup import cleanup_old_backups, create_backup
 
 # Rate limiting: user_id -> timestamp
-_calculate_cooldowns: dict = {}
+_calculate_cooldowns: dict[str, float] = {}
 CALCULATE_COOLDOWN = 30.0
-COOLDOWN_EXPIRY_HOURS = 1  # Cleanup entries older than this
+COOLDOWN_EXPIRY_HOURS = 1
+MAX_SELECT_OPTIONS = 25
 
 logger = logging.getLogger(__name__)
 
 
-def _cleanup_expired_cooldowns():
+def _cleanup_expired_cooldowns() -> None:
     """Remove cooldown entries older than COOLDOWN_EXPIRY_HOURS."""
     current_time = now().timestamp()
     cutoff = current_time - (COOLDOWN_EXPIRY_HOURS * 3600)
@@ -54,19 +54,49 @@ def admin_only():
     return app_commands.check(predicate)
 
 
+def _fixture_select_label(fixture: dict) -> str:
+    status = fixture["status"].upper()
+    return f"Week {fixture['week_number']} [{status}]"
+
+
+def _fixture_select_description(fixture: dict) -> str:
+    games_count = len(fixture["games"])
+    return f"{games_count} matches"
+
+
+def _format_prediction_line(index: int, game: str, prediction: str) -> str:
+    return f"{index}. {game} {prediction}"
+
+
+def _prediction_status_text(prediction: dict) -> str:
+    if not prediction["is_late"]:
+        return "on time"
+    if prediction["late_penalty_waived"]:
+        return "late, waiver active"
+    return "late, penalty active"
+
+
+@dataclass(slots=True)
+class PanelSelectionState:
+    """Shared selection state for admin panel flows."""
+
+    fixture_id: int | None = None
+    user_id: str | None = None
+    status_message: str = ""
+
+
 class AdminCommands(commands.Cog):
     """Commands for admins."""
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        # TyperBot sets db attr dynamically; discord.py typing doesn't track custom attrs
         self.db: Database = bot.db  # type: ignore
+        self.service = AdminService(self.db)
         self.fixture_handler = FixtureCreationHandler(bot, self.db)
         self.results_handler = ResultsEntryHandler(bot, self.db)
 
     @staticmethod
     def _format_open_weeks(open_fixtures: list[dict]) -> str:
-        """Format open fixture weeks for short user-facing messages."""
         return ", ".join(str(fixture["week_number"]) for fixture in open_fixtures)
 
     async def _resolve_open_fixture(
@@ -75,11 +105,6 @@ class AdminCommands(commands.Cog):
         week: int | None,
         command_example: str,
     ) -> dict | None:
-        """Resolve target open fixture for admin commands.
-
-        If multiple fixtures are open and no week is provided, the command is
-        rejected to avoid acting on the wrong fixture.
-        """
         open_fixtures = await self.db.get_open_fixtures()
 
         if not open_fixtures:
@@ -100,9 +125,7 @@ class AdminCommands(commands.Cog):
             )
             return None
 
-        matching = [
-            open_fixture for open_fixture in open_fixtures if open_fixture["week_number"] == week
-        ]
+        matching = [fixture for fixture in open_fixtures if fixture["week_number"] == week]
         if len(matching) == 1:
             return matching[0]
         if len(matching) > 1:
@@ -120,36 +143,76 @@ class AdminCommands(commands.Cog):
         )
         return None
 
+    async def _create_backup(self) -> None:
+        try:
+            await self.bot.loop.run_in_executor(
+                None, lambda: create_backup(self.db.db_path, BACKUP_DIR)
+            )
+            await self.bot.loop.run_in_executor(
+                None, lambda: cleanup_old_backups(BACKUP_DIR, keep=10)
+            )
+        except Exception as exc:
+            logger.warning(f"Backup failed but calculation succeeded: {exc}")
+
+    async def _post_calculation_to_channel(
+        self,
+        interaction: discord.Interaction,
+        score_result: FixtureScoreResult,
+    ) -> None:
+        channel = interaction.channel
+        if not isinstance(channel, (discord.TextChannel, discord.Thread, discord.DMChannel)):
+            await interaction.response.send_message(
+                "Could not find channel to post in.", ephemeral=True
+            )
+            return
+
+        message = format_standings(score_result.standings, score_result.last_fixture)
+
+        try:
+            await channel.send(message)
+            await interaction.response.send_message(
+                f"Week {score_result.fixture['week_number']} results calculated and posted!",
+                ephemeral=True,
+            )
+        except Exception as exc:
+            logger.error(f"Failed to post results to channel: {exc}")
+            await interaction.response.send_message(
+                "Scores calculated but failed to post to channel.", ephemeral=True
+            )
+
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
-        """Listen for DMs from admins."""
         if message.author.bot or message.guild is not None:
             return
 
         user_id = str(message.author.id)
 
-        # Check if this is a fixture creation DM
         if self.fixture_handler.has_session(user_id):
             await self.fixture_handler.handle_dm(message, user_id, is_admin_member)
             return
 
-        # Check if this is a results entry DM
         if self.results_handler.has_session(user_id):
             await self.results_handler.handle_dm(message, user_id, is_admin_member)
             return
 
-    # Admin group
     admin = app_commands.Group(name="admin", description="Admin commands for managing fixtures")
-
-    # Fixture subgroup
     fixture = app_commands.Group(name="fixture", description="Manage fixtures", parent=admin)
+    results = app_commands.Group(name="results", description="Manage results", parent=admin)
+
+    @admin.command(name="panel", description="Open the admin management panel")
+    @admin_only()
+    async def panel(self, interaction: discord.Interaction):
+        view = AdminPanelHomeView(self, str(interaction.user.id))
+        await interaction.response.send_message(
+            "**Admin Panel**\nChoose the workflow you want to manage.",
+            view=view,
+            ephemeral=True,
+        )
 
     @fixture.command(name="create", description="Create a new fixture (DM workflow)")
     @admin_only()
     async def fixture_create(self, interaction: discord.Interaction):
-        """Initiate fixture creation via DM."""
         user_id = str(interaction.user.id)
-        # admin_only() decorator ensures guild context, so these should always exist
         if interaction.channel_id is None or interaction.guild_id is None:
             await interaction.response.send_message(
                 "Error: Invalid interaction context.", ephemeral=True
@@ -184,7 +247,6 @@ class AdminCommands(commands.Cog):
     @fixture.command(name="delete", description="Delete an open fixture")
     @admin_only()
     async def fixture_delete(self, interaction: discord.Interaction, week: int | None = None):
-        """Delete a selected open fixture."""
         fixture = await self._resolve_open_fixture(
             interaction,
             week,
@@ -194,12 +256,15 @@ class AdminCommands(commands.Cog):
             return
 
         view = DeleteConfirmView(
-            self.db, str(interaction.user.id), fixture["id"], fixture["week_number"]
+            self.db,
+            str(interaction.user.id),
+            fixture["id"],
+            fixture["week_number"],
         )
 
         lines = [f"**Delete Week {fixture['week_number']}?**\n"]
-        for i, game in enumerate(fixture["games"], 1):
-            lines.append(f"{i}. {game}")
+        for index, game in enumerate(fixture["games"], 1):
+            lines.append(f"{index}. {game}")
 
         await interaction.response.send_message(
             "\n".join(lines)
@@ -208,13 +273,9 @@ class AdminCommands(commands.Cog):
             ephemeral=True,
         )
 
-    # Results subgroup
-    results = app_commands.Group(name="results", description="Manage results", parent=admin)
-
     @results.command(name="enter", description="Enter results for an open fixture (DM workflow)")
     @admin_only()
     async def results_enter(self, interaction: discord.Interaction, week: int | None = None):
-        """Initiate results entry via DM."""
         fixture = await self._resolve_open_fixture(
             interaction,
             week,
@@ -226,14 +287,13 @@ class AdminCommands(commands.Cog):
         existing_results = await self.db.get_results(fixture["id"])
         if existing_results:
             await interaction.response.send_message(
-                "Results already entered for this fixture!\n"
-                f"Use `/admin results calculate week:{fixture['week_number']}` to calculate scores.",
+                "Results already entered for this fixture. "
+                "Use `/admin panel` to correct them or `/admin results calculate` to post scores.",
                 ephemeral=True,
             )
             return
 
         user_id = str(interaction.user.id)
-        # admin_only() decorator ensures guild context, so this should always exist
         if interaction.guild_id is None:
             await interaction.response.send_message(
                 "Error: Invalid interaction context.", ephemeral=True
@@ -274,16 +334,13 @@ class AdminCommands(commands.Cog):
     @results.command(name="calculate", description="Calculate scores and post results")
     @admin_only()
     async def results_calculate(self, interaction: discord.Interaction, week: int | None = None):
-        """Calculate scores for a selected open fixture and post results."""
         _cleanup_expired_cooldowns()
 
         user_id = str(interaction.user.id)
         current_time = now().timestamp()
-
         if user_id in _calculate_cooldowns:
-            last_used = _calculate_cooldowns[user_id]
-            if current_time - last_used < CALCULATE_COOLDOWN:
-                remaining = CALCULATE_COOLDOWN - (current_time - last_used)
+            remaining = CALCULATE_COOLDOWN - (current_time - _calculate_cooldowns[user_id])
+            if remaining > 0:
                 await interaction.response.send_message(
                     f"Please wait {remaining:.1f}s before calculating again.",
                     ephemeral=True,
@@ -300,83 +357,18 @@ class AdminCommands(commands.Cog):
 
         _calculate_cooldowns[user_id] = current_time
 
-        results = await self.db.get_results(fixture["id"])
-        if not results:
-            await interaction.response.send_message(
-                "No results entered for this fixture!\nUse `/admin results enter` first.",
-                ephemeral=True,
-            )
-            return
-
-        predictions = await self.db.get_all_predictions(fixture["id"])
-
-        if not predictions:
-            await interaction.response.send_message(
-                "No predictions found for this fixture!", ephemeral=True
-            )
-            return
-
-        # Calculate scores
-        scores = []
-        for pred in predictions:
-            score_data = calculate_points(pred["predictions"], results, pred["is_late"])
-            scores.append(
-                {
-                    "user_id": pred["user_id"],
-                    "user_name": pred["user_name"],
-                    "points": score_data["points"],
-                    "exact_scores": score_data["exact_scores"],
-                    "correct_results": score_data["correct_results"],
-                }
-            )
-
-        scores.sort(key=lambda x: x["points"], reverse=True)
-        await self.db.save_scores(fixture["id"], scores)
-
-        # Create backup
         try:
-            await self.bot.loop.run_in_executor(
-                None, lambda: create_backup(self.db.db_path, BACKUP_DIR)
-            )
-            await self.bot.loop.run_in_executor(
-                None, lambda: cleanup_old_backups(BACKUP_DIR, keep=10)
-            )
-        except Exception as e:
-            logger.warning(f"Backup failed but calculation succeeded: {e}")
+            score_result = await self.service.calculate_fixture_scores(fixture["id"])
+        except ValueError as exc:
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
 
-        # Post results to channel (without mentions by default)
-        channel = interaction.channel
-        if channel:
-            # Get overall standings and format the complete message
-            standings = await self.db.get_standings()
-            last_fixture = await self.db.get_last_fixture_scores()
-
-            # Use format_standings to generate both overall and last week results
-            message = format_standings(standings, last_fixture)
-
-            try:
-                # Send the complete standings message
-                await channel.send(message)
-
-                await interaction.response.send_message(
-                    f"Week {fixture['week_number']} results calculated and posted!",
-                    ephemeral=True,
-                )
-            except Exception as e:
-                logger.error(f"Failed to post results to channel: {e}")
-                await interaction.response.send_message(
-                    "Scores calculated but failed to post to channel.", ephemeral=True
-                )
-        else:
-            await interaction.response.send_message(
-                "Could not find channel to post in.", ephemeral=True
-            )
+        await self._create_backup()
+        await self._post_calculation_to_channel(interaction, score_result)
 
     @results.command(name="post", description="Post results with optional user mentions")
     @admin_only()
     async def results_post(self, interaction: discord.Interaction):
-        """Post the latest fixture results to the channel with mention confirmation."""
-        # Get the latest closed fixture scores and overall standings
         fixture_data = await self.db.get_last_fixture_scores()
         standings = await self.db.get_standings()
 
@@ -386,7 +378,6 @@ class AdminCommands(commands.Cog):
             )
             return
 
-        # Show preview with confirmation buttons using format_standings
         preview = format_standings(standings, fixture_data)
 
         if not isinstance(interaction.channel, discord.TextChannel):
@@ -396,11 +387,555 @@ class AdminCommands(commands.Cog):
             return
 
         view = PostResultsConfirmView(self.db, fixture_data, standings, interaction.channel)
-
         await interaction.response.send_message(
             f"{preview}\n\nMention users in this post?",
             view=view,
             ephemeral=True,
+        )
+
+
+class OwnerRestrictedView(discord.ui.View):
+    """View base class that restricts interactions to one admin."""
+
+    def __init__(self, admin_cog: AdminCommands, owner_user_id: str, timeout: float = 180):
+        super().__init__(timeout=timeout)
+        self.admin_cog = admin_cog
+        self.owner_user_id = owner_user_id
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if str(interaction.user.id) != self.owner_user_id:
+            await interaction.response.send_message(
+                "You don't have permission to do this!", ephemeral=True
+            )
+            return False
+        if not is_admin(interaction):
+            await interaction.response.send_message(
+                "You no longer have permission to use admin commands.", ephemeral=True
+            )
+            return False
+        return True
+
+
+class AdminPanelHomeView(OwnerRestrictedView):
+    @discord.ui.button(label="Fixtures", style=discord.ButtonStyle.secondary)
+    async def fixtures(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        view = FixturesPanelView(self.admin_cog, self.owner_user_id)
+        await view.load_fixture_options()
+        await interaction.response.edit_message(content=view.render_content(), view=view)
+
+    @discord.ui.button(label="Predictions", style=discord.ButtonStyle.primary)
+    async def predictions(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        view = PredictionsPanelView(self.admin_cog, self.owner_user_id)
+        await view.load_fixture_options()
+        await interaction.response.edit_message(content=view.render_content(), view=view)
+
+    @discord.ui.button(label="Results", style=discord.ButtonStyle.success)
+    async def results(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        view = ResultsPanelView(self.admin_cog, self.owner_user_id)
+        await view.load_fixture_options()
+        await interaction.response.edit_message(content=view.render_content(), view=view)
+
+
+class FixturesPanelView(OwnerRestrictedView):
+    """Panel for fixture deletion and workflow guidance."""
+
+    def __init__(self, admin_cog: AdminCommands, owner_user_id: str):
+        super().__init__(admin_cog, owner_user_id)
+        self.selection = PanelSelectionState()
+        self.fixture_select = FixtureSelect(self, open_only=True)
+        self._refresh_items()
+
+    def _refresh_items(self) -> None:
+        self.clear_items()
+        self.add_item(self.fixture_select)
+        self.add_item(FixturesDeleteButton(self))
+        self.add_item(BackButton(self))
+
+    async def load_fixture_options(self) -> None:
+        fixtures = await self.admin_cog.db.get_open_fixtures()
+        self.fixture_select.update_options(fixtures)
+
+    def render_content(self) -> str:
+        status = (
+            self.selection.status_message
+            or "Select an open fixture to delete, or use `/admin fixture create` for new fixtures."
+        )
+        return "**Admin Panel - Fixtures**\n" + status
+
+
+class PredictionsPanelView(OwnerRestrictedView):
+    """Panel for prediction lookup and override actions."""
+
+    def __init__(self, admin_cog: AdminCommands, owner_user_id: str):
+        super().__init__(admin_cog, owner_user_id)
+        self.selection = PanelSelectionState()
+        self.fixture_select = FixtureSelect(self)
+        self.user_select = PredictionUserSelect(self)
+        self._refresh_items()
+
+    def _refresh_items(self) -> None:
+        self.clear_items()
+        self.add_item(self.fixture_select)
+        self.add_item(self.user_select)
+        self.add_item(ViewPredictionsButton(self))
+        self.add_item(ReplacePredictionButton(self))
+        self.add_item(ToggleWaiverButton(self))
+        self.add_item(BackButton(self))
+
+    async def load_fixture_options(self) -> None:
+        fixtures = await self.admin_cog.service.get_recent_fixtures(MAX_SELECT_OPTIONS)
+        self.fixture_select.update_options(fixtures)
+
+    async def load_user_options(self) -> None:
+        if self.selection.fixture_id is None:
+            self.user_select.update_options([])
+            return
+        predictions = await self.admin_cog.db.get_all_predictions(self.selection.fixture_id)
+        self.user_select.update_options(predictions)
+
+    def render_content(self) -> str:
+        status = self.selection.status_message or (
+            "Select a fixture, then pick a user to view or override a stored prediction."
+        )
+        return "**Admin Panel - Predictions**\n" + status
+
+
+class ResultsPanelView(OwnerRestrictedView):
+    """Panel for result correction workflows."""
+
+    def __init__(self, admin_cog: AdminCommands, owner_user_id: str):
+        super().__init__(admin_cog, owner_user_id)
+        self.selection = PanelSelectionState()
+        self.fixture_select = FixtureSelect(self)
+        self._refresh_items()
+
+    def _refresh_items(self) -> None:
+        self.clear_items()
+        self.add_item(self.fixture_select)
+        self.add_item(ViewResultsButton(self))
+        self.add_item(CorrectResultsButton(self))
+        self.add_item(BackButton(self))
+
+    async def load_fixture_options(self) -> None:
+        fixtures = await self.admin_cog.service.get_recent_fixtures(MAX_SELECT_OPTIONS)
+        self.fixture_select.update_options(fixtures)
+
+    def render_content(self) -> str:
+        status = (
+            self.selection.status_message or "Select a fixture to inspect or correct saved results."
+        )
+        return "**Admin Panel - Results**\n" + status
+
+
+class FixtureSelect(discord.ui.Select):
+    def __init__(
+        self,
+        parent_view: FixturesPanelView | PredictionsPanelView | ResultsPanelView,
+        open_only: bool = False,
+    ):
+        self.parent_view = parent_view
+        self.open_only = open_only
+        super().__init__(
+            placeholder="Select fixture",
+            min_values=1,
+            max_values=1,
+            disabled=True,
+        )
+
+    def update_options(self, fixtures: list[dict]) -> None:
+        if self.open_only:
+            fixtures = [fixture for fixture in fixtures if fixture["status"] == "open"]
+
+        if not fixtures:
+            self.options = [discord.SelectOption(label="No fixtures available", value="none")]
+            self.disabled = True
+            return
+
+        self.options = [
+            discord.SelectOption(
+                label=_fixture_select_label(fixture),
+                value=str(fixture["id"]),
+                description=_fixture_select_description(fixture),
+            )
+            for fixture in fixtures[:MAX_SELECT_OPTIONS]
+        ]
+        self.disabled = False
+
+    async def callback(self, interaction: discord.Interaction):
+        if self.values[0] == "none":
+            await interaction.response.send_message("No fixtures available.", ephemeral=True)
+            return
+
+        fixture_id = int(self.values[0])
+        self.parent_view.selection.fixture_id = fixture_id
+        self.parent_view.selection.user_id = None
+
+        fixture = await self.parent_view.admin_cog.db.get_fixture_by_id(fixture_id)
+        if fixture is None:
+            self.parent_view.selection.status_message = "Fixture no longer exists."
+        else:
+            self.parent_view.selection.status_message = (
+                f"Selected week {fixture['week_number']} ({fixture['status']})."
+            )
+
+        if isinstance(self.parent_view, PredictionsPanelView):
+            await self.parent_view.load_user_options()
+
+        await interaction.response.edit_message(
+            content=self.parent_view.render_content(),
+            view=self.parent_view,
+        )
+
+
+class PredictionUserSelect(discord.ui.Select):
+    """Select a user who already has a prediction for the chosen fixture."""
+
+    def __init__(self, parent_view: PredictionsPanelView):
+        self.parent_view = parent_view
+        super().__init__(
+            placeholder="Select user",
+            min_values=1,
+            max_values=1,
+            disabled=True,
+        )
+
+    def update_options(self, predictions: list[dict]) -> None:
+        if not predictions:
+            self.options = [discord.SelectOption(label="No predictions available", value="none")]
+            self.disabled = True
+            return
+
+        ordered = sorted(predictions, key=lambda prediction: prediction["user_name"].lower())
+        self.options = [
+            discord.SelectOption(
+                label=prediction["user_name"][:100],
+                value=prediction["user_id"],
+                description=_prediction_status_text(prediction)[:100],
+            )
+            for prediction in ordered[:MAX_SELECT_OPTIONS]
+        ]
+        self.disabled = False
+
+    async def callback(self, interaction: discord.Interaction):
+        if self.values[0] == "none":
+            await interaction.response.send_message("No predictions available.", ephemeral=True)
+            return
+
+        self.parent_view.selection.user_id = self.values[0]
+        fixture_id = self.parent_view.selection.fixture_id
+        if fixture_id is None:
+            await interaction.response.send_message("Select a fixture first.", ephemeral=True)
+            return
+
+        prediction = await self.parent_view.admin_cog.db.get_prediction(
+            fixture_id,
+            self.values[0],
+        )
+        if prediction is None:
+            self.parent_view.selection.status_message = "Prediction no longer exists."
+        else:
+            self.parent_view.selection.status_message = (
+                f"Selected {prediction['user_name']} ({_prediction_status_text(prediction)})."
+            )
+
+        await interaction.response.edit_message(
+            content=self.parent_view.render_content(),
+            view=self.parent_view,
+        )
+
+
+class BackButton(discord.ui.Button):
+    def __init__(self, parent_view: OwnerRestrictedView):
+        self.parent_view = parent_view
+        super().__init__(label="Back", style=discord.ButtonStyle.secondary)
+
+    async def callback(self, interaction: discord.Interaction):
+        view = AdminPanelHomeView(self.parent_view.admin_cog, self.parent_view.owner_user_id)
+        await interaction.response.edit_message(
+            content="**Admin Panel**\nChoose the workflow you want to manage.",
+            view=view,
+        )
+
+
+class FixturesDeleteButton(discord.ui.Button):
+    def __init__(self, parent_view: FixturesPanelView):
+        self.parent_view = parent_view
+        super().__init__(label="Delete Fixture", style=discord.ButtonStyle.danger)
+
+    async def callback(self, interaction: discord.Interaction):
+        fixture_id = self.parent_view.selection.fixture_id
+        if fixture_id is None:
+            await interaction.response.send_message("Select an open fixture first.", ephemeral=True)
+            return
+
+        fixture = await self.parent_view.admin_cog.db.get_fixture_by_id(fixture_id)
+        if fixture is None or fixture["status"] != "open":
+            await interaction.response.send_message(
+                "Only open fixtures can be deleted from the panel.", ephemeral=True
+            )
+            return
+
+        confirm_view = DeleteConfirmView(
+            self.parent_view.admin_cog.db,
+            self.parent_view.owner_user_id,
+            fixture_id,
+            fixture["week_number"],
+        )
+        await interaction.response.send_message(
+            f"Delete week {fixture['week_number']} and all related predictions/results/scores?",
+            view=confirm_view,
+            ephemeral=True,
+        )
+
+
+class ViewPredictionsButton(discord.ui.Button):
+    def __init__(self, parent_view: PredictionsPanelView):
+        self.parent_view = parent_view
+        super().__init__(label="View Predictions", style=discord.ButtonStyle.secondary)
+
+    async def callback(self, interaction: discord.Interaction):
+        fixture_id = self.parent_view.selection.fixture_id
+        if fixture_id is None:
+            await interaction.response.send_message("Select a fixture first.", ephemeral=True)
+            return
+
+        try:
+            (
+                fixture,
+                predictions,
+            ) = await self.parent_view.admin_cog.service.get_fixture_prediction_summary(fixture_id)
+        except ValueError as exc:
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
+
+        lines = [f"**Week {fixture['week_number']} Predictions**"]
+        for prediction in predictions:
+            status = _prediction_status_text(prediction)
+            scores = ", ".join(prediction["predictions"])
+            lines.append(f"- {prediction['user_name']}: {scores} ({status})")
+
+        await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
+
+class ReplacePredictionButton(discord.ui.Button):
+    def __init__(self, parent_view: PredictionsPanelView):
+        self.parent_view = parent_view
+        super().__init__(label="Replace Prediction", style=discord.ButtonStyle.primary)
+
+    async def callback(self, interaction: discord.Interaction):
+        fixture_id = self.parent_view.selection.fixture_id
+        user_id = self.parent_view.selection.user_id
+        if fixture_id is None or user_id is None:
+            await interaction.response.send_message(
+                "Select both fixture and user first.", ephemeral=True
+            )
+            return
+
+        fixture = await self.parent_view.admin_cog.db.get_fixture_by_id(fixture_id)
+        prediction = await self.parent_view.admin_cog.db.get_prediction(fixture_id, user_id)
+        if fixture is None or prediction is None:
+            await interaction.response.send_message(
+                "That prediction is no longer available.", ephemeral=True
+            )
+            return
+
+        modal = ReplacePredictionModal(self.parent_view, fixture, prediction)
+        await interaction.response.send_modal(modal)
+
+
+class ToggleWaiverButton(discord.ui.Button):
+    def __init__(self, parent_view: PredictionsPanelView):
+        self.parent_view = parent_view
+        super().__init__(label="Toggle Late Waiver", style=discord.ButtonStyle.success)
+
+    async def callback(self, interaction: discord.Interaction):
+        fixture_id = self.parent_view.selection.fixture_id
+        user_id = self.parent_view.selection.user_id
+        if fixture_id is None or user_id is None:
+            await interaction.response.send_message(
+                "Select both fixture and user first.", ephemeral=True
+            )
+            return
+
+        try:
+            (
+                fixture,
+                prediction,
+                recalculation,
+            ) = await self.parent_view.admin_cog.service.toggle_late_penalty_waiver(
+                fixture_id,
+                user_id,
+            )
+        except ValueError as exc:
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
+
+        status = "enabled" if prediction["late_penalty_waived"] else "disabled"
+        self.parent_view.selection.status_message = (
+            f"Late waiver {status} for {prediction['user_name']} in week {fixture['week_number']}."
+        )
+        if recalculation is not None:
+            self.parent_view.selection.status_message += " Scores were recalculated."
+
+        await self.parent_view.load_user_options()
+        await interaction.response.edit_message(
+            content=self.parent_view.render_content(),
+            view=self.parent_view,
+        )
+
+
+class ViewResultsButton(discord.ui.Button):
+    def __init__(self, parent_view: ResultsPanelView):
+        self.parent_view = parent_view
+        super().__init__(label="View Results", style=discord.ButtonStyle.secondary)
+
+    async def callback(self, interaction: discord.Interaction):
+        fixture_id = self.parent_view.selection.fixture_id
+        if fixture_id is None:
+            await interaction.response.send_message("Select a fixture first.", ephemeral=True)
+            return
+
+        fixture = await self.parent_view.admin_cog.db.get_fixture_by_id(fixture_id)
+        results = await self.parent_view.admin_cog.db.get_results(fixture_id)
+        if fixture is None:
+            await interaction.response.send_message("Fixture not found.", ephemeral=True)
+            return
+        if not results:
+            await interaction.response.send_message(
+                "No results saved for that fixture yet.", ephemeral=True
+            )
+            return
+
+        lines = [f"**Week {fixture['week_number']} Results**"]
+        for index, (game, result) in enumerate(zip(fixture["games"], results, strict=False), 1):
+            lines.append(_format_prediction_line(index, game, result))
+        await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
+
+class CorrectResultsButton(discord.ui.Button):
+    def __init__(self, parent_view: ResultsPanelView):
+        self.parent_view = parent_view
+        super().__init__(label="Correct Results", style=discord.ButtonStyle.primary)
+
+    async def callback(self, interaction: discord.Interaction):
+        fixture_id = self.parent_view.selection.fixture_id
+        if fixture_id is None:
+            await interaction.response.send_message("Select a fixture first.", ephemeral=True)
+            return
+
+        fixture = await self.parent_view.admin_cog.db.get_fixture_by_id(fixture_id)
+        if fixture is None:
+            await interaction.response.send_message("Fixture not found.", ephemeral=True)
+            return
+        if not await self.parent_view.admin_cog.db.get_results(fixture_id):
+            await interaction.response.send_message(
+                "No results are stored for that fixture yet. Use `/admin results enter` first.",
+                ephemeral=True,
+            )
+            return
+
+        modal = CorrectResultsModal(self.parent_view, fixture)
+        await interaction.response.send_modal(modal)
+
+
+class ReplacePredictionModal(discord.ui.Modal):
+    def __init__(self, parent_view: PredictionsPanelView, fixture: dict, prediction: dict):
+        super().__init__(title=f"Replace Week {fixture['week_number']} Prediction")
+        self.parent_view = parent_view
+        self.fixture = fixture
+        self.prediction = prediction
+        self.predictions_input = discord.ui.TextInput(
+            label="Predictions",
+            style=discord.TextStyle.paragraph,
+            placeholder="One line per match, e.g. Team A - Team B 2:1",
+            default="\n".join(
+                _format_prediction_line(index, game, result)
+                for index, (game, result) in enumerate(
+                    zip(fixture["games"], prediction["predictions"], strict=False),
+                    1,
+                )
+            ),
+            required=True,
+            max_length=4000,
+        )
+        self.add_item(self.predictions_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        if not is_admin(interaction):
+            await interaction.response.send_message(
+                "You no longer have permission to use admin commands.", ephemeral=True
+            )
+            return
+
+        try:
+            (
+                fixture,
+                updated_prediction,
+                recalculation,
+            ) = await self.parent_view.admin_cog.service.replace_prediction(
+                self.fixture["id"],
+                self.prediction["user_id"],
+                self.predictions_input.value,
+                str(interaction.user.id),
+            )
+        except ValueError as exc:
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
+
+        self.parent_view.selection.status_message = f"Replaced {updated_prediction['user_name']}'s prediction in week {fixture['week_number']}."
+        if recalculation is not None:
+            self.parent_view.selection.status_message += " Scores were recalculated."
+
+        await self.parent_view.load_user_options()
+        await interaction.response.edit_message(
+            content=self.parent_view.render_content(),
+            view=self.parent_view,
+        )
+
+
+class CorrectResultsModal(discord.ui.Modal):
+    def __init__(self, parent_view: ResultsPanelView, fixture: dict):
+        super().__init__(title=f"Correct Week {fixture['week_number']} Results")
+        self.parent_view = parent_view
+        self.fixture = fixture
+        self.results_input = discord.ui.TextInput(
+            label="Results",
+            style=discord.TextStyle.paragraph,
+            placeholder="One line per match, e.g. Team A - Team B 2:1",
+            required=True,
+            max_length=4000,
+        )
+        self.add_item(self.results_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        if not is_admin(interaction):
+            await interaction.response.send_message(
+                "You no longer have permission to use admin commands.", ephemeral=True
+            )
+            return
+
+        try:
+            (
+                fixture,
+                _results,
+                recalculation,
+            ) = await self.parent_view.admin_cog.service.correct_results(
+                self.fixture["id"],
+                self.results_input.value,
+            )
+        except ValueError as exc:
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
+
+        self.parent_view.selection.status_message = (
+            f"Saved corrected results for week {fixture['week_number']}."
+        )
+        if recalculation is not None:
+            self.parent_view.selection.status_message += " Scores were recalculated."
+
+        await interaction.response.edit_message(
+            content=self.parent_view.render_content(),
+            view=self.parent_view,
         )
 
 
@@ -414,35 +949,41 @@ class DeleteConfirmView(discord.ui.View):
         self.fixture_id = fixture_id
         self.week_number = week_number
 
-    async def on_timeout(self):
-        pass
-
     @discord.ui.button(label="Yes, Delete", style=discord.ButtonStyle.red)
     async def confirm(self, interaction: discord.Interaction, _button: discord.ui.Button):
-        """Delete fixture from database."""
         if str(interaction.user.id) != self.user_id:
             await interaction.response.send_message(
                 "You don't have permission to do this!", ephemeral=True
+            )
+            return
+        if not is_admin(interaction):
+            await interaction.response.send_message(
+                "You no longer have permission to use admin commands.", ephemeral=True
             )
             return
 
         await self.db.delete_fixture(self.fixture_id)
-
         await interaction.response.edit_message(
-            content=f"**Week {self.week_number} Fixture Deleted!**", view=None
+            content=f"**Week {self.week_number} Fixture Deleted!**",
+            view=None,
         )
 
     @discord.ui.button(label="Cancel", style=discord.ButtonStyle.gray)
     async def cancel(self, interaction: discord.Interaction, _button: discord.ui.Button):
-        """Cancel deletion."""
         if str(interaction.user.id) != self.user_id:
             await interaction.response.send_message(
                 "You don't have permission to do this!", ephemeral=True
             )
             return
+        if not is_admin(interaction):
+            await interaction.response.send_message(
+                "You no longer have permission to use admin commands.", ephemeral=True
+            )
+            return
 
         await interaction.response.edit_message(
-            content="Deletion cancelled. The fixture is still active.", view=None
+            content="Deletion cancelled. The fixture is still active.",
+            view=None,
         )
 
 
@@ -450,7 +991,11 @@ class PostResultsConfirmView(discord.ui.View):
     """View for confirming results posting with mentions."""
 
     def __init__(
-        self, db: Database, fixture_data: dict, standings: list[dict], channel: discord.TextChannel
+        self,
+        db: Database,
+        fixture_data: dict,
+        standings: list[dict],
+        channel: discord.TextChannel,
     ):
         super().__init__(timeout=60)
         self.db = db
@@ -458,53 +1003,47 @@ class PostResultsConfirmView(discord.ui.View):
         self.standings = standings
         self.channel = channel
 
-    async def on_timeout(self):
-        pass
-
     @discord.ui.button(label="NO", style=discord.ButtonStyle.primary)
     async def no_mentions(self, interaction: discord.Interaction, _button: discord.ui.Button):
-        """Post results without mentions."""
         message = format_standings(self.standings, self.fixture_data)
 
         try:
             await interaction.response.edit_message(
-                content="Results posted without mentions!", view=None
+                content="Results posted without mentions!",
+                view=None,
             )
             await self.channel.send(message)
-        except Exception as e:
-            logger.error(f"Failed to post results: {e}")
+        except Exception as exc:
+            logger.error(f"Failed to post results: {exc}")
             if not interaction.response.is_done():
                 await interaction.response.edit_message(
-                    content=f"Failed to post results: {e}", view=None
+                    content=f"Failed to post results: {exc}",
+                    view=None,
                 )
             else:
-                await interaction.followup.send(f"Failed to post results: {e}")
+                await interaction.followup.send(f"Failed to post results: {exc}")
 
     @discord.ui.button(label="YES", style=discord.ButtonStyle.green)
     async def with_mentions(self, interaction: discord.Interaction, _button: discord.ui.Button):
-        """Post results with user mentions."""
         message = format_standings(self.standings, self.fixture_data)
-
-        # Add mentions section
-        mentions = []
-        for score in self.fixture_data["scores"]:
-            mentions.append(f"<@{score['user_id']}>")
-
+        mentions = [f"<@{score['user_id']}>" for score in self.fixture_data["scores"]]
         message += f"\n\n**Participants:**\n{' '.join(mentions)}"
 
         try:
             await interaction.response.edit_message(
-                content="Results posted with mentions!", view=None
+                content="Results posted with mentions!",
+                view=None,
             )
             await self.channel.send(message)
-        except Exception as e:
-            logger.error(f"Failed to post results: {e}")
+        except Exception as exc:
+            logger.error(f"Failed to post results: {exc}")
             if not interaction.response.is_done():
                 await interaction.response.edit_message(
-                    content=f"Failed to post results: {e}", view=None
+                    content=f"Failed to post results: {exc}",
+                    view=None,
                 )
             else:
-                await interaction.followup.send(f"Failed to post results: {e}")
+                await interaction.followup.send(f"Failed to post results: {exc}")
 
 
 async def setup(bot: commands.Bot):

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -564,11 +564,12 @@ class UserCommands(commands.Cog):
 
 **Input formats:** Use `2:0`, `2-0`, or `2 : 0`
 
-**To change a prediction:** Just post again (it replaces your old one)."""
+**To change a prediction:** Use `/predict` or DM the bot again. Thread posts do not edit existing picks."""
 
         admin_help = """\n\n## 🔧 Admin Commands
 
 **For Admins:**
+• `/admin panel` - Open the admin hub for fixture deletion, overrides, waivers, and result correction
 **Fixture Management:**
 • `/admin fixture create` - Create new fixture (DM workflow, auto-creates thread)
 • `/admin fixture delete [week]` - Delete an open fixture
@@ -605,6 +606,13 @@ class UserCommands(commands.Cog):
 4. **Re-post Results:**
    - `/admin results post`
    - Choose whether to mention users
+
+5. **Corrections / Exceptions:**
+   - `/admin panel`
+   - View fixture predictions
+   - Replace a stored prediction without changing original submit time
+   - Toggle a late-penalty waiver for an approved late pick
+   - Correct stored results and auto-recalculate scored fixtures
 
 **Custom Deadline Format:**
 • `2024-02-15 18:00`
@@ -691,7 +699,11 @@ class UserCommands(commands.Cog):
             ):
                 lines.append(f"{i}. {game} **{pred}**")
 
-            late_status = "⚠️ **LATE**" if prediction["is_late"] else "✅ On time"
+            late_status = "✅ On time"
+            if prediction["is_late"]:
+                late_status = "⚠️ **LATE**"
+                if prediction["late_penalty_waived"]:
+                    late_status += " (waiver active)"
             submitted = format_for_discord(prediction["submitted_at"], "f")
             deadline_str = format_for_discord(fixture["deadline"], "F")
             relative_str = format_for_discord(fixture["deadline"], "R")
@@ -730,7 +742,11 @@ class UserCommands(commands.Cog):
             ):
                 lines.append(f"{i}. {game} **{pred}**")
 
-            late_status = "⚠️ **LATE**" if prediction["is_late"] else "✅ On time"
+            late_status = "✅ On time"
+            if prediction["is_late"]:
+                late_status = "⚠️ **LATE**"
+                if prediction["late_penalty_waived"]:
+                    late_status += " (waiver active)"
             submitted = format_for_discord(prediction["submitted_at"], "f")
             lines.append(f"Status: {late_status}")
             lines.append(f"Submitted: {submitted}")

--- a/typer_bot/database/database.py
+++ b/typer_bot/database/database.py
@@ -3,10 +3,11 @@
 import logging
 import time
 from datetime import datetime
+from pathlib import Path
 
 import aiosqlite
 
-from typer_bot.utils import parse_iso
+from typer_bot.utils import calculate_points, parse_iso
 from typer_bot.utils.config import DB_PATH
 
 logger = logging.getLogger(__name__)
@@ -18,11 +19,87 @@ class Database:
     def __init__(self, db_path: str | None = None):
         self.db_path = db_path or DB_PATH
 
-        from pathlib import Path
-
         db_dir = Path(self.db_path).parent
         if db_dir and not db_dir.exists():
             db_dir.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    async def _table_columns(db: aiosqlite.Connection, table_name: str) -> set[str]:
+        async with db.execute(f"PRAGMA table_info({table_name})") as cursor:
+            columns = await cursor.fetchall()
+        return {col[1] for col in columns}
+
+    async def _migrate_results_table(self, db: aiosqlite.Connection) -> None:
+        columns = await self._table_columns(db, "results")
+        if not columns:
+            return
+
+        async with db.execute(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_results_fixture_id_unique'"
+        ) as cursor:
+            row = await cursor.fetchone()
+            unique_index_exists = bool(row and row[0] > 0)
+
+        if unique_index_exists and "updated_at" in columns:
+            return
+
+        logger.info("Migrating results table for deterministic result updates")
+        await db.execute("BEGIN IMMEDIATE")
+        try:
+            await db.execute("DROP TABLE IF EXISTS results_migrated")
+            await db.execute(
+                """
+                CREATE TABLE results_migrated (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    fixture_id INTEGER NOT NULL,
+                    results TEXT NOT NULL,
+                    calculated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (fixture_id) REFERENCES fixtures(id)
+                )
+                """
+            )
+            await db.execute(
+                """
+                INSERT INTO results_migrated (fixture_id, results, calculated_at, updated_at)
+                SELECT fixture_id,
+                       results,
+                       COALESCE(calculated_at, CURRENT_TIMESTAMP),
+                       COALESCE(calculated_at, CURRENT_TIMESTAMP)
+                FROM results old
+                WHERE old.id IN (
+                    SELECT MAX(id)
+                    FROM results
+                    GROUP BY fixture_id
+                )
+                """
+            )
+            await db.execute("DROP TABLE results")
+            await db.execute("ALTER TABLE results_migrated RENAME TO results")
+            await db.execute(
+                "CREATE UNIQUE INDEX idx_results_fixture_id_unique ON results(fixture_id)"
+            )
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+
+    async def _migrate_prediction_columns(self, db: aiosqlite.Connection) -> None:
+        columns = await self._table_columns(db, "predictions")
+
+        if "late_penalty_waived" not in columns:
+            logger.info("Adding late_penalty_waived column to predictions table")
+            await db.execute(
+                "ALTER TABLE predictions ADD COLUMN late_penalty_waived BOOLEAN DEFAULT FALSE"
+            )
+
+        if "admin_edited_at" not in columns:
+            logger.info("Adding admin_edited_at column to predictions table")
+            await db.execute("ALTER TABLE predictions ADD COLUMN admin_edited_at DATETIME")
+
+        if "admin_edited_by" not in columns:
+            logger.info("Adding admin_edited_by column to predictions table")
+            await db.execute("ALTER TABLE predictions ADD COLUMN admin_edited_by TEXT")
 
     async def initialize(self):
         """Create tables if they don't exist."""
@@ -48,6 +125,9 @@ class Database:
                     predictions TEXT NOT NULL,
                     submitted_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                     is_late BOOLEAN DEFAULT FALSE,
+                    late_penalty_waived BOOLEAN DEFAULT FALSE,
+                    admin_edited_at DATETIME,
+                    admin_edited_by TEXT,
                     FOREIGN KEY (fixture_id) REFERENCES fixtures(id),
                     UNIQUE(fixture_id, user_id)
                 )
@@ -59,6 +139,7 @@ class Database:
                     fixture_id INTEGER NOT NULL,
                     results TEXT NOT NULL,
                     calculated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                     FOREIGN KEY (fixture_id) REFERENCES fixtures(id)
                 )
             """)
@@ -77,14 +158,14 @@ class Database:
                 )
             """)
 
-            # Migration: Add missing columns to fixtures table
-            async with db.execute("PRAGMA table_info(fixtures)") as cursor:
-                columns = await cursor.fetchall()
-                column_names = {col[1] for col in columns}
+            column_names = await self._table_columns(db, "fixtures")
 
             if "message_id" not in column_names:
                 logger.info("Adding message_id column to fixtures table")
                 await db.execute("ALTER TABLE fixtures ADD COLUMN message_id TEXT")
+
+            await self._migrate_prediction_columns(db)
+            await self._migrate_results_table(db)
 
             await db.commit()
 
@@ -221,6 +302,28 @@ class Database:
                 row = await cursor.fetchone()
                 return self._row_to_fixture(row) if row else None
 
+    async def get_fixture_by_week(self, week_number: int) -> dict | None:
+        """Get the most recent fixture for a week, regardless of status."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM fixtures WHERE week_number = ? ORDER BY id DESC LIMIT 1",
+                (week_number,),
+            ) as cursor:
+                row = await cursor.fetchone()
+                return self._row_to_fixture(row) if row else None
+
+    async def get_recent_fixtures(self, limit: int = 25) -> list[dict]:
+        """Get recent fixtures ordered by newest first."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM fixtures ORDER BY id DESC LIMIT ?",
+                (limit,),
+            ) as cursor:
+                rows = await cursor.fetchall()
+                return [self._row_to_fixture(row) for row in rows]
+
     async def get_fixture_by_message_id(self, message_id: str) -> dict | None:
         """Get a fixture by its Discord message ID.
 
@@ -265,9 +368,12 @@ class Database:
                 """INSERT INTO predictions (fixture_id, user_id, user_name, predictions, is_late)
                    VALUES (?, ?, ?, ?, ?)
                    ON CONFLICT(fixture_id, user_id)
-                   DO UPDATE SET predictions = excluded.predictions,
-                                 is_late = excluded.is_late,
-                                 submitted_at = CURRENT_TIMESTAMP""",
+                    DO UPDATE SET predictions = excluded.predictions,
+                                  is_late = excluded.is_late,
+                                  late_penalty_waived = FALSE,
+                                  admin_edited_at = NULL,
+                                  admin_edited_by = NULL,
+                                  submitted_at = CURRENT_TIMESTAMP""",
                 (fixture_id, user_id, user_name, "\n".join(predictions), is_late),
             )
             await db.commit()
@@ -301,8 +407,130 @@ class Database:
                         "predictions": row["predictions"].split("\n"),
                         "submitted_at": parse_iso(row["submitted_at"]),
                         "is_late": row["is_late"],
+                        "late_penalty_waived": row["late_penalty_waived"],
+                        "admin_edited_at": parse_iso(row["admin_edited_at"])
+                        if row["admin_edited_at"]
+                        else None,
+                        "admin_edited_by": row["admin_edited_by"],
                     }
                 return None
+
+    async def admin_update_prediction(
+        self,
+        fixture_id: int,
+        user_id: str,
+        predictions: list[str],
+        admin_user_id: str,
+    ) -> bool:
+        """Replace a stored prediction without changing original submission timing."""
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                """
+                UPDATE predictions
+                SET predictions = ?,
+                    admin_edited_at = CURRENT_TIMESTAMP,
+                    admin_edited_by = ?
+                WHERE fixture_id = ? AND user_id = ?
+                """,
+                ("\n".join(predictions), admin_user_id, fixture_id, user_id),
+            )
+            await db.commit()
+            return cursor.rowcount > 0
+
+    async def admin_update_prediction_with_recalc(
+        self,
+        fixture_id: int,
+        user_id: str,
+        predictions: list[str],
+        admin_user_id: str,
+    ) -> bool:
+        """Replace a stored prediction and refresh scores atomically when needed."""
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = await db.execute(
+                    """
+                    UPDATE predictions
+                    SET predictions = ?,
+                        admin_edited_at = CURRENT_TIMESTAMP,
+                        admin_edited_by = ?
+                    WHERE fixture_id = ? AND user_id = ?
+                    """,
+                    ("\n".join(predictions), admin_user_id, fixture_id, user_id),
+                )
+                if cursor.rowcount <= 0:
+                    await db.rollback()
+                    return False
+
+                if await self._fixture_has_scores_in_connection(db, fixture_id):
+                    await self._recalculate_scores_in_connection(db, fixture_id)
+
+                await db.commit()
+                return True
+            except Exception:
+                await db.rollback()
+                raise
+
+    async def set_late_penalty_waiver(
+        self,
+        fixture_id: int,
+        user_id: str,
+        waived: bool,
+    ) -> bool:
+        """Set late-penalty waiver for an existing prediction."""
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                """
+                UPDATE predictions
+                SET late_penalty_waived = ?
+                WHERE fixture_id = ? AND user_id = ?
+                """,
+                (waived, fixture_id, user_id),
+            )
+            await db.commit()
+            return cursor.rowcount > 0
+
+    async def toggle_late_penalty_waiver_with_recalc(
+        self,
+        fixture_id: int,
+        user_id: str,
+    ) -> bool | None:
+        """Toggle late waiver and refresh scores atomically when needed."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                async with db.execute(
+                    "SELECT late_penalty_waived FROM predictions WHERE fixture_id = ? AND user_id = ?",
+                    (fixture_id, user_id),
+                ) as cursor:
+                    row = await cursor.fetchone()
+
+                if row is None:
+                    await db.rollback()
+                    return None
+
+                waived = not bool(row["late_penalty_waived"])
+                cursor = await db.execute(
+                    """
+                    UPDATE predictions
+                    SET late_penalty_waived = ?
+                    WHERE fixture_id = ? AND user_id = ?
+                    """,
+                    (waived, fixture_id, user_id),
+                )
+                if cursor.rowcount <= 0:
+                    await db.rollback()
+                    return None
+
+                if await self._fixture_has_scores_in_connection(db, fixture_id):
+                    await self._recalculate_scores_in_connection(db, fixture_id)
+
+                await db.commit()
+                return waived
+            except Exception:
+                await db.rollback()
+                raise
 
     async def delete_prediction(self, fixture_id: int, user_id: str) -> bool:
         """Delete a user's prediction for a fixture. Returns True if deleted."""
@@ -329,6 +557,11 @@ class Database:
                         "predictions": row["predictions"].split("\n"),
                         "submitted_at": parse_iso(row["submitted_at"]),
                         "is_late": row["is_late"],
+                        "late_penalty_waived": row["late_penalty_waived"],
+                        "admin_edited_at": parse_iso(row["admin_edited_at"])
+                        if row["admin_edited_at"]
+                        else None,
+                        "admin_edited_by": row["admin_edited_by"],
                     }
                     for row in rows
                 ]
@@ -338,7 +571,13 @@ class Database:
         start_time = time.perf_counter()
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
-                "INSERT OR REPLACE INTO results (fixture_id, results) VALUES (?, ?)",
+                """
+                INSERT INTO results (fixture_id, results)
+                VALUES (?, ?)
+                ON CONFLICT(fixture_id)
+                DO UPDATE SET results = excluded.results,
+                              updated_at = CURRENT_TIMESTAMP
+                """,
                 (fixture_id, "\n".join(results)),
             )
             await db.commit()
@@ -354,16 +593,166 @@ class Database:
                 },
             )
 
+    async def save_results_with_recalc(self, fixture_id: int, results: list[str]) -> bool:
+        """Save results and refresh scores atomically when needed."""
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                await db.execute(
+                    """
+                    INSERT INTO results (fixture_id, results)
+                    VALUES (?, ?)
+                    ON CONFLICT(fixture_id)
+                    DO UPDATE SET results = excluded.results,
+                                  updated_at = CURRENT_TIMESTAMP
+                    """,
+                    (fixture_id, "\n".join(results)),
+                )
+
+                recalculated = False
+                if await self._fixture_has_scores_in_connection(db, fixture_id):
+                    await self._recalculate_scores_in_connection(db, fixture_id)
+                    recalculated = True
+
+                await db.commit()
+                return recalculated
+            except Exception:
+                await db.rollback()
+                raise
+
     async def get_results(self, fixture_id: int) -> list[str] | None:
         """Get results for a fixture."""
         async with (
             aiosqlite.connect(self.db_path) as db,
-            db.execute("SELECT results FROM results WHERE fixture_id = ?", (fixture_id,)) as cursor,
+            db.execute(
+                "SELECT results FROM results WHERE fixture_id = ? ORDER BY id DESC LIMIT 1",
+                (fixture_id,),
+            ) as cursor,
         ):
             row = await cursor.fetchone()
             if row:
                 return row[0].split("\n")
             return None
+
+    async def fixture_has_scores(self, fixture_id: int) -> bool:
+        """Return whether a fixture already has stored scores."""
+        async with (
+            aiosqlite.connect(self.db_path) as db,
+            db.execute(
+                "SELECT 1 FROM scores WHERE fixture_id = ? LIMIT 1", (fixture_id,)
+            ) as cursor,
+        ):
+            return await cursor.fetchone() is not None
+
+    @staticmethod
+    async def _fixture_has_scores_in_connection(db: aiosqlite.Connection, fixture_id: int) -> bool:
+        async with db.execute(
+            "SELECT 1 FROM scores WHERE fixture_id = ? LIMIT 1", (fixture_id,)
+        ) as cursor:
+            return await cursor.fetchone() is not None
+
+    async def _recalculate_scores_in_connection(
+        self,
+        db: aiosqlite.Connection,
+        fixture_id: int,
+    ) -> None:
+        db.row_factory = aiosqlite.Row
+
+        async with db.execute("SELECT * FROM fixtures WHERE id = ?", (fixture_id,)) as cursor:
+            fixture_row = await cursor.fetchone()
+        if fixture_row is None:
+            raise ValueError("Fixture not found")
+
+        async with db.execute(
+            "SELECT results FROM results WHERE fixture_id = ? ORDER BY id DESC LIMIT 1",
+            (fixture_id,),
+        ) as cursor:
+            results_row = await cursor.fetchone()
+        if results_row is None:
+            raise ValueError("No results entered for this fixture")
+
+        async with db.execute(
+            "SELECT * FROM predictions WHERE fixture_id = ?", (fixture_id,)
+        ) as cursor:
+            prediction_rows = await cursor.fetchall()
+        if not prediction_rows:
+            raise ValueError("No predictions found for this fixture")
+
+        results = results_row["results"].split("\n")
+        scores = []
+        for prediction_row in prediction_rows:
+            score_data = calculate_points(
+                prediction_row["predictions"].split("\n"),
+                results,
+                bool(prediction_row["is_late"]),
+                bool(prediction_row["late_penalty_waived"]),
+            )
+            scores.append(
+                {
+                    "user_id": prediction_row["user_id"],
+                    "user_name": prediction_row["user_name"],
+                    "points": score_data["points"],
+                    "exact_scores": score_data["exact_scores"],
+                    "correct_results": score_data["correct_results"],
+                }
+            )
+
+        scores.sort(
+            key=lambda score: (
+                -score["points"],
+                -score["exact_scores"],
+                -score["correct_results"],
+                score["user_name"].lower(),
+            )
+        )
+
+        await db.execute("DELETE FROM scores WHERE fixture_id = ?", (fixture_id,))
+        for score in scores:
+            await db.execute(
+                """
+                INSERT INTO scores (fixture_id, user_id, user_name, points, exact_scores, correct_results)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    fixture_id,
+                    score["user_id"],
+                    score["user_name"],
+                    score["points"],
+                    score["exact_scores"],
+                    score["correct_results"],
+                ),
+            )
+        await db.execute("UPDATE fixtures SET status = 'closed' WHERE id = ?", (fixture_id,))
+
+    async def get_scores_for_fixture(self, fixture_id: int) -> list[dict]:
+        """Get saved scores for a single fixture ordered by points."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                """
+                SELECT s.*, f.week_number
+                FROM scores s
+                JOIN fixtures f ON f.id = s.fixture_id
+                WHERE s.fixture_id = ?
+                ORDER BY s.points DESC, s.exact_scores DESC, s.correct_results DESC, s.user_name ASC
+                """,
+                (fixture_id,),
+            ) as cursor:
+                rows = await cursor.fetchall()
+
+        if not rows:
+            return []
+
+        return [
+            {
+                "user_id": row["user_id"],
+                "user_name": row["user_name"],
+                "points": row["points"],
+                "exact_scores": row["exact_scores"],
+                "correct_results": row["correct_results"],
+            }
+            for row in rows
+        ]
 
     async def save_scores(self, fixture_id: int, scores: list[dict]):
         """Save calculated scores for a fixture atomically."""
@@ -455,7 +844,7 @@ class Database:
                           COUNT(DISTINCT s.fixture_id) as weeks_played
                    FROM scores s
                    GROUP BY s.user_id
-                   ORDER BY total_points DESC"""
+                   ORDER BY total_points DESC, total_exact DESC, total_correct DESC, user_name ASC"""
             ) as cursor:
                 rows = await cursor.fetchall()
                 return [
@@ -486,7 +875,11 @@ class Database:
                 if row:
                     fixture_id = row["fixture_id"]
                     async with db.execute(
-                        "SELECT * FROM scores WHERE fixture_id = ? ORDER BY points DESC",
+                        """
+                        SELECT * FROM scores
+                        WHERE fixture_id = ?
+                        ORDER BY points DESC, exact_scores DESC, correct_results DESC, user_name ASC
+                        """,
                         (fixture_id,),
                     ) as cursor2:
                         scores = await cursor2.fetchall()

--- a/typer_bot/handlers/fixture_handler.py
+++ b/typer_bot/handlers/fixture_handler.py
@@ -396,7 +396,7 @@ class FixtureConfirmView(ui.View):
                 await thread.send(
                     "💬 **Post your predictions here!**\n"
                     "Reply with your scores (one per line or comma-separated).\n"
-                    "To change your prediction, just post again."
+                    "Predictions are one-shot here. To change one, use `/predict`."
                 )
             except Exception as e:
                 logger.warning(f"Could not create thread for fixture: {e}")

--- a/typer_bot/services/__init__.py
+++ b/typer_bot/services/__init__.py
@@ -1,0 +1,5 @@
+"""Shared service-layer helpers."""
+
+from .admin_service import AdminService
+
+__all__ = ["AdminService"]

--- a/typer_bot/services/admin_service.py
+++ b/typer_bot/services/admin_service.py
@@ -1,0 +1,208 @@
+"""Shared admin workflows for commands and admin panel views."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from typer_bot.database import Database
+from typer_bot.utils import calculate_points, parse_line_predictions
+
+
+@dataclass(slots=True)
+class FixtureScoreResult:
+    """Calculated scoring payload for a fixture."""
+
+    fixture: dict
+    results: list[str]
+    predictions: list[dict]
+    scores: list[dict]
+    standings: list[dict]
+    last_fixture: dict | None
+
+
+class AdminService:
+    """Admin workflows shared by slash commands and interaction views."""
+
+    def __init__(self, db: Database):
+        self.db = db
+
+    async def get_fixture_by_week(self, week_number: int) -> dict | None:
+        """Resolve a fixture by week, regardless of status."""
+        return await self.db.get_fixture_by_week(week_number)
+
+    async def get_recent_fixtures(self, limit: int = 25) -> list[dict]:
+        """Return recent fixtures for panel selectors."""
+        return await self.db.get_recent_fixtures(limit)
+
+    async def _build_score_result(self, fixture_id: int) -> FixtureScoreResult:
+        fixture = await self.db.get_fixture_by_id(fixture_id)
+        if fixture is None:
+            raise ValueError("Fixture not found")
+
+        results = await self.db.get_results(fixture_id)
+        if not results:
+            raise ValueError("No results entered for this fixture")
+
+        predictions = await self.db.get_all_predictions(fixture_id)
+        if not predictions:
+            raise ValueError("No predictions found for this fixture")
+
+        scores = await self.db.get_scores_for_fixture(fixture_id)
+        standings = await self.db.get_standings()
+        last_fixture = await self.db.get_last_fixture_scores()
+        return FixtureScoreResult(
+            fixture=fixture,
+            results=results,
+            predictions=predictions,
+            scores=scores,
+            standings=standings,
+            last_fixture=last_fixture,
+        )
+
+    async def calculate_fixture_scores(self, fixture_id: int) -> FixtureScoreResult:
+        """Recalculate one fixture and refresh standings."""
+        fixture = await self.db.get_fixture_by_id(fixture_id)
+        if fixture is None:
+            raise ValueError("Fixture not found")
+
+        results = await self.db.get_results(fixture_id)
+        if not results:
+            raise ValueError("No results entered for this fixture")
+
+        predictions = await self.db.get_all_predictions(fixture_id)
+        if not predictions:
+            raise ValueError("No predictions found for this fixture")
+
+        scores = []
+        for prediction in predictions:
+            score_data = calculate_points(
+                prediction["predictions"],
+                results,
+                prediction["is_late"],
+                prediction["late_penalty_waived"],
+            )
+            scores.append(
+                {
+                    "user_id": prediction["user_id"],
+                    "user_name": prediction["user_name"],
+                    "points": score_data["points"],
+                    "exact_scores": score_data["exact_scores"],
+                    "correct_results": score_data["correct_results"],
+                }
+            )
+
+        scores.sort(
+            key=lambda score: (
+                -score["points"],
+                -score["exact_scores"],
+                -score["correct_results"],
+                score["user_name"].lower(),
+            )
+        )
+        await self.db.save_scores(fixture_id, scores)
+
+        return await self._build_score_result(fixture_id)
+
+    async def maybe_recalculate_fixture(self, fixture_id: int) -> FixtureScoreResult | None:
+        """Recalculate a fixture only when it has already been scored."""
+        if not await self.db.fixture_has_scores(fixture_id):
+            return None
+        return await self.calculate_fixture_scores(fixture_id)
+
+    async def get_fixture_prediction_summary(self, fixture_id: int) -> tuple[dict, list[dict]]:
+        """Return fixture and its predictions for panel display."""
+        fixture = await self.db.get_fixture_by_id(fixture_id)
+        if fixture is None:
+            raise ValueError("Fixture not found")
+
+        predictions = await self.db.get_all_predictions(fixture_id)
+        if not predictions:
+            raise ValueError("No predictions saved for this fixture")
+
+        predictions.sort(key=lambda prediction: prediction["user_name"].lower())
+        return fixture, predictions
+
+    async def replace_prediction(
+        self,
+        fixture_id: int,
+        user_id: str,
+        prediction_lines: str,
+        admin_user_id: str,
+    ) -> tuple[dict, dict, FixtureScoreResult | None]:
+        """Replace a stored prediction through an explicit admin action."""
+        fixture = await self.db.get_fixture_by_id(fixture_id)
+        if fixture is None:
+            raise ValueError("Fixture not found")
+
+        existing_prediction = await self.db.get_prediction(fixture_id, user_id)
+        if existing_prediction is None:
+            raise ValueError("Prediction not found for that user")
+
+        predictions, errors = parse_line_predictions(prediction_lines, fixture["games"])
+        if errors:
+            raise ValueError("\n".join(errors))
+
+        updated = await self.db.admin_update_prediction_with_recalc(
+            fixture_id,
+            user_id,
+            predictions,
+            admin_user_id,
+        )
+        if not updated:
+            raise ValueError("Prediction update failed")
+
+        refreshed_prediction = await self.db.get_prediction(fixture_id, user_id)
+        if refreshed_prediction is None:
+            raise ValueError("Prediction disappeared after update")
+
+        recalculation = None
+        if await self.db.fixture_has_scores(fixture_id):
+            recalculation = await self._build_score_result(fixture_id)
+        return fixture, refreshed_prediction, recalculation
+
+    async def toggle_late_penalty_waiver(
+        self,
+        fixture_id: int,
+        user_id: str,
+    ) -> tuple[dict, dict, FixtureScoreResult | None]:
+        """Toggle the waiver flag for a stored late prediction."""
+        fixture = await self.db.get_fixture_by_id(fixture_id)
+        if fixture is None:
+            raise ValueError("Fixture not found")
+
+        prediction = await self.db.get_prediction(fixture_id, user_id)
+        if prediction is None:
+            raise ValueError("Prediction not found for that user")
+        if not prediction["is_late"]:
+            raise ValueError("That prediction was submitted on time")
+
+        waived = await self.db.toggle_late_penalty_waiver_with_recalc(fixture_id, user_id)
+        if waived is None:
+            raise ValueError("Late waiver update failed")
+
+        refreshed_prediction = await self.db.get_prediction(fixture_id, user_id)
+        if refreshed_prediction is None:
+            raise ValueError("Prediction disappeared after waiver update")
+
+        recalculation = None
+        if await self.db.fixture_has_scores(fixture_id):
+            recalculation = await self._build_score_result(fixture_id)
+        return fixture, refreshed_prediction, recalculation
+
+    async def correct_results(
+        self,
+        fixture_id: int,
+        results_lines: str,
+    ) -> tuple[dict, list[str], FixtureScoreResult | None]:
+        """Replace stored results and recalculate scored fixtures."""
+        fixture = await self.db.get_fixture_by_id(fixture_id)
+        if fixture is None:
+            raise ValueError("Fixture not found")
+
+        results, errors = parse_line_predictions(results_lines, fixture["games"])
+        if errors:
+            raise ValueError("\n".join(errors))
+
+        recalculated = await self.db.save_results_with_recalc(fixture_id, results)
+        recalculation = await self._build_score_result(fixture_id) if recalculated else None
+        return fixture, results, recalculation

--- a/typer_bot/utils/scoring.py
+++ b/typer_bot/utils/scoring.py
@@ -2,7 +2,10 @@
 
 
 def calculate_points(
-    predictions: list[str], actual_results: list[str], is_late: bool = False
+    predictions: list[str],
+    actual_results: list[str],
+    is_late: bool = False,
+    late_penalty_waived: bool = False,
 ) -> dict:
     """Calculate points.
 
@@ -12,7 +15,7 @@ def calculate_points(
 
     Returns: dict with points, exact_scores, correct_results, penalty
     """
-    if is_late:
+    if is_late and not late_penalty_waived:
         return {
             "points": 0,
             "exact_scores": 0,


### PR DESCRIPTION
## Summary
- add `/admin panel` with fixture, prediction, and result management flows for explicit admin intervention
- make prediction overrides and result corrections safe by preserving factual lateness/submission metadata and recalculating scored fixtures atomically
- align docs/help with the one-shot thread prediction model and add regression coverage for migrations, panel permissions, rollback paths, and correction flows

## Testing
- `uv run pytest`
- `uv run ruff check .`
- `uv run ty check typer_bot`

closes #95
closes #96
closes #98
