### PR TITLE
fix: initialize empty admin prediction selector

### DIFF
--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -68,6 +68,26 @@ class TestPredictionPanelFlows:
         assert "no longer have permission" in mock_interaction_admin.response_sent[0]["content"]
 
     @pytest.mark.asyncio
+    async def test_prediction_panel_initializes_empty_user_select(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        await admin_cog.db.create_fixture(1, sample_games, datetime.now(UTC) + timedelta(days=1))
+
+        home_view = AdminPanelHomeView(admin_cog, str(mock_interaction_admin.user.id))
+        predictions_button = next(
+            child for child in home_view.children if getattr(child, "label", None) == "Predictions"
+        )
+        await predictions_button.callback(mock_interaction_admin)
+
+        edited_view = mock_interaction_admin.response_sent[-1]["view"]
+        assert edited_view.user_select.disabled is True
+        assert len(edited_view.user_select.options) == 1
+        assert edited_view.user_select.options[0].label == "No predictions available"
+
+    @pytest.mark.asyncio
     async def test_prediction_panel_replace_opens_modal(
         self,
         admin_cog,

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -471,6 +471,7 @@ class PredictionsPanelView(OwnerRestrictedView):
         self.selection = PanelSelectionState()
         self.fixture_select = FixtureSelect(self)
         self.user_select = PredictionUserSelect(self)
+        self.user_select.update_options([])
         self._refresh_items()
 
     def _refresh_items(self) -> None:


### PR DESCRIPTION
## Summary
- initialize the admin Predictions panel user selector with a valid empty-state option before the first view edit
- add regression coverage for opening the Predictions panel when fixtures exist but no predictions have been submitted yet

## Testing
- `uv run pytest tests/test_admin_panel.py -q`
- `uv run pytest tests/test_admin_panel.py tests/test_admin_commands.py -q`
- `uv run ruff check typer_bot/commands/admin_commands.py tests/test_admin_panel.py`
