### PR TITLE
docs: refresh references and comments after refactors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,11 +64,14 @@ scores (
 
 ## 4. Codebase Map
 - `typer_bot/bot.py`: Entry point and setup hook.
-- `typer_bot/commands/user_commands.py`: `/predict`, `/standings` (Public).
-- `typer_bot/commands/admin_commands.py`: `/admin` hub (Protected).
+- `typer_bot/commands/user_commands.py`: Public slash commands plus the DM message listener that delegates user prediction DMs.
+- `typer_bot/commands/admin_commands.py`: `/admin` command surface and orchestration for admin workflows.
+- `typer_bot/commands/admin_panel/`: Admin panel UI views, selects, and modals split out of `admin_commands.py`.
+- `typer_bot/handlers/dm_prediction_handler.py`: DM workflow for user predictions across one or more open fixtures.
 - `typer_bot/handlers/thread_prediction_handler.py`: Thread-based prediction processing (on_message).
 - `typer_bot/handlers/fixture_handler.py`: DM workflow for fixture creation.
 - `typer_bot/handlers/results_handler.py`: DM workflow for results entry.
+- `typer_bot/services/workflow_state.py`: Central owner for in-memory DM sessions and short-lived cooldowns.
 - `typer_bot/utils/config.py`: Centralized configuration (data paths via env vars).
 - `typer_bot/utils/prediction_parser.py`: Central logic for parsing "2-1" or "2:1" strings.
 - `typer_bot/utils/scoring.py`: Point calculation rules.
@@ -78,6 +81,9 @@ scores (
 
 ## 5. Common Tasks
 - **Fixing Parsing:** Edit `prediction_parser.py`.
+- **Prediction DM Flow:** Edit `handlers/dm_prediction_handler.py`.
+- **Admin Panel UI:** Edit `commands/admin_panel/`.
+- **Workflow/Cooldown State:** Edit `services/workflow_state.py`. Keep process-local sessions and cooldowns there instead of introducing new module-level dicts.
 - **New Commands:** Add Cog to `commands/` folder, load in `bot.py`.
 - **Database Changes:** Edit `database.py` `initialize()` (Handle migrations manually if needed).
 - **Debugging:** Check `utils/logger.py` for config. Set `LOG_LEVEL=DEBUG` in env.
@@ -113,11 +119,12 @@ uv run pytest --tb=short         # Shorter traceback output
 ```
 
 ## 6. Known Quirks
-- **Handler Coordination:** The prediction handler (`user_commands.py`) checks `results_handler.has_results_session()` before processing DMs. This prevents admin's own predictions from being overwritten when they're entering results. Always check for conflicting sessions before processing DMs.
+- **Handler Coordination:** `handlers/dm_prediction_handler.py` checks `WorkflowStateStore.has_results_session()` before processing DMs. This prevents an admin's result-entry messages from being mistaken for prediction updates. Always check for conflicting sessions through `WorkflowStateStore`.
 - **Double Digits:** Scores like `10-0` are allowed.
 - **Format:** Users provide flexible separators (`-`, `:`, `–`).
 - **Rate Limiting:** Thread predictions limited to 1/second per user. DM predictions have no rate limit.
-- **Session Timeouts:** Fixture creation and results entry DM flows auto-expire after 1 hour of inactivity.
+- **Session Timeouts:** Fixture creation, results entry, and DM prediction flows auto-expire after 1 hour of inactivity.
+- **Workflow State Ownership:** Process-local sessions plus thread/admin calculate cooldowns live in `services/workflow_state.py`; they are not persisted and reset on process restart.
 - **Token Safety:** Bot validates DISCORD_TOKEN at startup (rejects placeholders like "your_bot_token_here"). Token values are never logged.
 
 ## 7. Code Quality & Pre-commit Hooks

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Bot requires:
 ## Workflow State
 - Match data, predictions, results, and scores are persisted in SQLite.
 - Active DM workflows and short-lived cooldowns are intentionally kept in memory.
+- This includes the thread-post rate limiter and the `/admin results calculate` cooldown, so both reset if the bot process restarts.
 - This bot assumes a single-process deployment. If the process restarts, any in-progress fixture/results/prediction DM flow is lost and users need to start again.
 - That tradeoff is deliberate for a small personal bot: simpler code, fewer moving parts, and no extra operational state to migrate or debug.
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -62,7 +62,7 @@ class TestFullWorkflow:
         await database.save_prediction(fixture_id, "user1", "User1", ["2-1", "1-1", "0-2"], True)
 
         predictions = await database.get_all_predictions(fixture_id)
-        assert predictions[0]["is_late"] == 1  # SQLite BOOLEAN returns int, not bool
+        assert predictions[0]["is_late"] == 1  # SQLite returns BOOLEAN columns as ints.
 
         await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
 
@@ -236,7 +236,6 @@ class TestUsernameChangeHandling:
         games = ["Team A - Team B"]
         deadline = datetime.now(UTC) - timedelta(days=2)
 
-        # Week 1: User is "st4chu"
         fixture1_id = await database.create_fixture(1, games, deadline)
         await database.save_prediction(fixture1_id, "user1", "st4chu", ["2-1"], False)
         await database.save_results(fixture1_id, ["2-1"])
@@ -253,7 +252,6 @@ class TestUsernameChangeHandling:
             ],
         )
 
-        # Week 2: Same user is now "Stachu"
         deadline = datetime.now(UTC) - timedelta(days=1)
         fixture2_id = await database.create_fixture(2, games, deadline)
         await database.save_prediction(fixture2_id, "user1", "Stachu", ["1-0"], False)
@@ -272,10 +270,9 @@ class TestUsernameChangeHandling:
         )
 
         standings = await database.get_standings()
-        assert len(standings) == 1  # Should NOT be 2 separate entries
+        assert len(standings) == 1
         assert standings[0]["total_points"] == 6
         assert standings[0]["weeks_played"] == 2
-        # Should show most recent name (from fixture 2)
         assert standings[0]["user_name"] == "Stachu"
 
     @pytest.mark.asyncio
@@ -283,7 +280,6 @@ class TestUsernameChangeHandling:
         """Should show the most recent username from latest fixture."""
         games = ["Team A - Team B"]
 
-        # Week 1: "OldName"
         fixture1_id = await database.create_fixture(1, games, datetime.now(UTC) - timedelta(days=3))
         await database.save_results(fixture1_id, ["2-1"])
         await database.save_scores(
@@ -299,7 +295,6 @@ class TestUsernameChangeHandling:
             ],
         )
 
-        # Week 2: "MiddleName"
         fixture2_id = await database.create_fixture(2, games, datetime.now(UTC) - timedelta(days=2))
         await database.save_results(fixture2_id, ["2-1"])
         await database.save_scores(
@@ -315,7 +310,6 @@ class TestUsernameChangeHandling:
             ],
         )
 
-        # Week 3: "NewName" (latest)
         fixture3_id = await database.create_fixture(3, games, datetime.now(UTC) - timedelta(days=1))
         await database.save_results(fixture3_id, ["2-1"])
         await database.save_scores(
@@ -333,6 +327,5 @@ class TestUsernameChangeHandling:
 
         standings = await database.get_standings()
         assert len(standings) == 1
-        # Should show name from most recent fixture (fixture 3)
         assert standings[0]["user_name"] == "NewName"
         assert standings[0]["total_points"] == 3

--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -30,7 +30,7 @@ class TestOnMessage:
     @pytest.mark.asyncio
     async def test_ignores_non_thread_channels(self, handler, mock_message):
         """Should ignore messages not in threads."""
-        mock_message.channel = object()  # Not a thread
+        mock_message.channel = object()
 
         result = await handler.on_message(mock_message)
 
@@ -40,7 +40,7 @@ class TestOnMessage:
     @pytest.mark.usefixtures("database")
     async def test_ignores_unknown_threads(self, handler, mock_message):
         """Should ignore threads not associated with fixtures."""
-        mock_message.channel.id = 999999  # Unknown thread ID
+        mock_message.channel.id = 999999
 
         result = await handler.on_message(mock_message)
 
@@ -77,7 +77,6 @@ class TestOnMessage:
     @pytest.mark.usefixtures("fixture_with_thread")
     async def test_handles_invalid_prediction_format(self, handler, mock_message):
         """Should DM user when predictions have format errors."""
-        # Must provide exactly 3 lines for 3 games
         mock_message.content = "Team A - Team B invalid\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
         mock_message.channel.id = 789012
 
@@ -99,7 +98,6 @@ class TestOnMessage:
         assert result is True
         assert "✅" in mock_message.reactions_added
 
-        # Verify prediction was saved
         predictions = await handler.db.get_all_predictions(fixture_with_thread["id"])
         assert len(predictions) == 1
         assert predictions[0]["user_id"] == "123456"
@@ -108,7 +106,6 @@ class TestOnMessage:
     @pytest.mark.asyncio
     async def test_marks_late_predictions(self, handler, database, mock_message, sample_games):
         """Should mark predictions as late when past deadline."""
-        # Create fixture with past deadline
         deadline = datetime.now(UTC) - timedelta(hours=1)
         fixture_id = await database.create_fixture(1, sample_games, deadline)
         await database.update_fixture_announcement(fixture_id, message_id="789012")
@@ -121,7 +118,6 @@ class TestOnMessage:
         assert result is True
         assert "✅" in mock_message.reactions_added
 
-        # Verify prediction was saved as late
         predictions = await handler.db.get_all_predictions(fixture_id)
         assert len(predictions) == 1
         assert predictions[0]["is_late"]
@@ -173,7 +169,6 @@ class TestEdgeCases:
         mock_message.content = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
         monkeypatch.setattr(mock_message, "add_reaction", raise_forbidden)
 
-        # Should not crash
         result = await handler.on_message(mock_message)
         assert result is True
 
@@ -187,11 +182,9 @@ class TestEdgeCases:
             raise discord.Forbidden(MagicMock(), "Cannot send DMs")
 
         mock_message.channel.id = 789012
-        # Must provide exactly 3 lines for 3 games, with invalid format to trigger DM
         mock_message.content = "Team A - Team B invalid\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
         monkeypatch.setattr(mock_message.author, "send", raise_forbidden)
 
-        # Should not crash and should add error reaction
         result = await handler.on_message(mock_message)
         assert result is True
 
@@ -207,7 +200,6 @@ class TestEdgeCases:
         mock_message.content = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
         monkeypatch.setattr(handler.db, "save_prediction", raise_error)
 
-        # Should not crash and should notify user
         result = await handler.on_message(mock_message)
         assert result is True
         assert len(mock_message.author.dm_sent) == 1
@@ -216,7 +208,7 @@ class TestEdgeCases:
     @pytest.mark.asyncio
     async def test_thread_exists_but_not_in_database(self, handler, mock_message):
         """Should handle threads created manually (not through bot)."""
-        mock_message.channel.id = 999999  # Thread not in database
+        mock_message.channel.id = 999999
 
         result = await handler.on_message(mock_message)
 
@@ -227,7 +219,6 @@ class TestEdgeCases:
     async def test_mixed_valid_and_chat_content(self, handler, mock_message):
         """Should error when some lines have chat text instead of scores."""
         mock_message.channel.id = 789012
-        # 3 lines but only 1 has a valid score - will error on lines 1 and 3
         mock_message.content = "Let's go Team A!\nTeam A - Team B 2-1\nGood luck everyone!"
 
         result = await handler.on_message(mock_message)
@@ -306,12 +297,10 @@ class TestIntegration:
         """Test multiple users predicting in the same thread."""
         from tests.conftest import MockMessage, MockUser
 
-        # Create fixture
         deadline = datetime.now(UTC) + timedelta(days=1)
         fixture_id = await database.create_fixture(1, sample_games, deadline)
         await database.update_fixture_announcement(fixture_id, message_id="789012")
 
-        # User 1 predicts
         user1 = MockUser(user_id="111", name="User1")
         message1 = MockMessage(
             content="Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2",
@@ -324,7 +313,6 @@ class TestIntegration:
         result = await handler.on_message(message1)
         assert result is True
 
-        # User 2 predicts
         user2 = MockUser(user_id="222", name="User2")
         message2 = MockMessage(
             content="Team A - Team B 1-0\nTeam C - Team D 2-2\nTeam E - Team F 1-1",
@@ -336,7 +324,6 @@ class TestIntegration:
         result = await handler.on_message(message2)
         assert result is True
 
-        # Verify both predictions exist
         predictions = await database.get_all_predictions(fixture_id)
         assert len(predictions) == 2
         user_ids = {p["user_id"] for p in predictions}

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -49,7 +49,7 @@ class TyperBot(commands.Bot):
         guild_id = str(interaction.guild_id) if interaction.guild_id else None
         set_log_context(user_id=user_id, guild_id=guild_id, source="command")
 
-        # ContextVars are task-local, so each interaction gets isolated context.
+        # ContextVars are task-local, so this handler does not need explicit cleanup.
 
     async def on_message(self, message: discord.Message):
         """Set trace ID and context for every message before processing."""
@@ -81,8 +81,7 @@ class TyperBot(commands.Bot):
             return
 
         set_trace_id(f"del-{message.id}")
-        # ContextVars are task-local; cleanup automatic when task completes.
-        # No log_context set, so no cleanup needed.
+        # No cleanup needed: this handler only sets a trace ID, and ContextVars are task-local.
 
     async def setup_hook(self):
         """Initialize database and load cogs."""
@@ -132,10 +131,8 @@ class TyperBot(commands.Bot):
         for guild in self.guilds:
             logger.info(f"  - {guild.name} (ID: {guild.id})")
 
-        # Check bot permissions on all guilds
         await self._check_permissions()
 
-        # Sync any manually-created threads
         await self._sync_fixture_thread()
 
     async def on_error(self, event_method, *_args, **_kwargs):
@@ -238,7 +235,6 @@ class TyperBot(commands.Bot):
                     continue
 
                 found = False
-                # Search channels for the announcement message
                 for guild in self.guilds:
                     for channel in guild.text_channels:
                         try:
@@ -273,10 +269,7 @@ class TyperBot(commands.Bot):
             logger.exception(f"Error during fixture verification: {e}")
 
     async def _check_permissions(self):
-        """Check bot permissions on all guilds.
-
-        Logs warnings if the bot is missing critical permissions.
-        """
+        """Warn when a guild is missing permissions required for prediction workflows."""
         required_permissions = [
             ("send_messages", "Send Messages"),
             ("read_message_history", "Read Message History"),
@@ -319,7 +312,7 @@ def main():
         logger.error("Please update it with your actual bot token")
         sys.exit(1)
 
-    # Token is validated above; this satisfies type checker
+    # The guard above exits on missing/placeholder tokens; this keeps the type checker honest.
     if token is None:
         raise RuntimeError("Token validation failed unexpectedly")
     logger.info("✅ Token configured")

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -19,7 +19,7 @@ class UserCommands(commands.Cog):
 
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        # TyperBot sets db attr dynamically; discord.py typing doesn't track custom attrs
+        # TyperBot injects these attrs; discord.py typing cannot see them.
         self.db: Database = bot.db  # type: ignore
         self.workflow_state: WorkflowStateStore = bot.workflow_state  # type: ignore[attr-defined]
         self.prediction_handler = DMPredictionHandler(self.db, self.workflow_state)

--- a/typer_bot/handlers/dm_prediction_handler.py
+++ b/typer_bot/handlers/dm_prediction_handler.py
@@ -154,7 +154,7 @@ class DMPredictionHandler:
 
         user_id = str(message.author.id)
 
-        # Prevent admin's existing predictions being marked late during results entry
+        # Ignore admin result-entry DMs so they do not overwrite stored predictions as late.
         if self.workflow_state.has_results_session(user_id):
             return False
 

--- a/typer_bot/handlers/fixture_handler.py
+++ b/typer_bot/handlers/fixture_handler.py
@@ -70,7 +70,6 @@ class FixtureCreationHandler:
             await message.author.send(f"Message too long! (max {MAX_MESSAGE_LENGTH} characters)")
             return True
 
-        # Verify admin status
         state = self.get_session(user_id)
         if state is None:
             return False
@@ -147,7 +146,6 @@ class FixtureCreationHandler:
         state.games = games
         state.step = "deadline"
 
-        # Calculate default deadline (Friday 18:00)
         current_time = now()
         days_until_friday = (4 - current_time.weekday()) % 7
         if days_until_friday == 0 and current_time.hour >= 18:
@@ -378,7 +376,6 @@ class FixtureConfirmView(ui.View):
         )
 
         try:
-            # Send announcement message
             announcement = await self.channel.send(
                 f"**Week {allocated_week} Fixture is now open!**\n\n"
                 f"{final_preview}\n\n"
@@ -392,7 +389,6 @@ class FixtureConfirmView(ui.View):
                 message_id=str(announcement.id),
             )
 
-            # Create a thread for predictions
             try:
                 thread = await announcement.create_thread(
                     name=f"Week {allocated_week} Predictions",

--- a/typer_bot/handlers/results_handler.py
+++ b/typer_bot/handlers/results_handler.py
@@ -71,7 +71,6 @@ class ResultsEntryHandler:
 
         logger.info(f"Processing results DM from user {user_id}")
 
-        # Verify admin status
         guild_id = session.guild_id
 
         if not await self._verify_admin(message, user_id, guild_id, is_admin_fn):

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -43,7 +43,7 @@ class ThreadPredictionHandler:
 
         user_id = str(message.author.id)
         with LogContextManager(user_id=user_id, fixture_id=fixture["id"], source="thread"):
-            # Rate limiting check - atomic update to prevent race conditions
+            # Update and check the cooldown in one step so rapid reposts cannot race each other.
             current_time = now()
             last_time = self.workflow_state.record_thread_prediction_attempt(user_id, current_time)
             if (
@@ -51,9 +51,8 @@ class ThreadPredictionHandler:
                 and (current_time - last_time).total_seconds() < PREDICTION_RATE_LIMIT_SECONDS
             ):
                 logger.debug(f"Rate limiting prediction from {user_id}")
-                return True  # Silently ignore rate-limited messages
+                return True
 
-            # Check message length
             if len(message.content) > MAX_MESSAGE_LENGTH:
                 await self._handle_error(
                     message,
@@ -61,15 +60,13 @@ class ThreadPredictionHandler:
                 )
                 return True
 
-            # Parse predictions
             predictions, errors = parse_line_predictions(message.content, fixture["games"])
 
-            # Chatty Thread fix: If no valid scores found, ignore silently
+            # Threads also contain chatter; only treat messages with score lines as submissions.
             if len(predictions) == 0:
                 logger.debug(f"Ignoring message with no valid scores from {message.author.id}")
                 return False
 
-            # If there are parsing errors, DM the user
             if errors:
                 error_msg = "\n".join(errors)
                 log_event(
@@ -90,11 +87,10 @@ class ThreadPredictionHandler:
                 )
                 return True
 
-            # Check deadline
             current_time = now()
             is_late = current_time > fixture["deadline"]
 
-            # Check if already submitted via DM (race condition prevention)
+            # DM and thread submissions can land at the same time; keep the first stored pick.
             existing = await self.db.get_prediction(fixture["id"], user_id)
             if existing:
                 log_event(
@@ -112,7 +108,6 @@ class ThreadPredictionHandler:
                 return True
 
         try:
-            # Save prediction
             await self.db.save_prediction(
                 fixture["id"],
                 user_id,
@@ -121,7 +116,6 @@ class ThreadPredictionHandler:
                 is_late,
             )
 
-            # Add success reaction
             try:
                 await message.add_reaction("✅")
             except discord.Forbidden:
@@ -129,7 +123,7 @@ class ThreadPredictionHandler:
                     f"Could not add reaction to thread prediction from {message.author.id}. "
                     "Missing 'Add Reactions' permission."
                 )
-                # Fallback: DM the user so they know it worked
+                # Fall back to DM so the user still gets confirmation.
                 with suppress(discord.Forbidden):
                     await message.author.send(
                         "✅ **Prediction saved!**\n"
@@ -179,7 +173,7 @@ class ThreadPredictionHandler:
         """Handle errors by DMing the user and optionally reacting to the message."""
         with suppress(discord.Forbidden):
             await message.author.send(error_text)
-        # If DM failed (DMs disabled), add reaction to indicate error
+        # Fall back to a reaction when DMs are closed.
         with suppress(discord.Forbidden):
             await message.add_reaction("❌")
 

--- a/typer_bot/services/workflow_state.py
+++ b/typer_bot/services/workflow_state.py
@@ -1,4 +1,4 @@
-"""Centralized in-memory workflow and cooldown state."""
+"""Process-local DM workflow and cooldown state."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ PredictionStep = Literal["select", "predict", "continue"]
 
 @dataclass(slots=True)
 class FixtureSession:
-    """Mutable state for the fixture creation DM workflow."""
+    """In-memory state for fixture creation DMs."""
 
     channel_id: int
     guild_id: int
@@ -30,7 +30,7 @@ class FixtureSession:
 
 @dataclass(slots=True)
 class ResultsSession:
-    """Mutable state for the results entry DM workflow."""
+    """In-memory state for result-entry DMs."""
 
     fixture_id: int
     guild_id: int
@@ -39,7 +39,7 @@ class ResultsSession:
 
 @dataclass(slots=True)
 class PredictionSession:
-    """Mutable state for one user's DM prediction flow."""
+    """In-memory state for one user's DM prediction flow."""
 
     step: PredictionStep
     fixture_ids: list[int] = field(default_factory=list)
@@ -49,7 +49,7 @@ class PredictionSession:
 
 
 class WorkflowStateStore:
-    """Owns all process-local workflow state for the bot."""
+    """Owns process-local DM sessions and cooldowns."""
 
     def __init__(self):
         self._fixture_sessions: dict[str, FixtureSession] = {}


### PR DESCRIPTION
## Summary
- refresh `AGENTS.md` so the codebase map and common task guidance match the new DM handler, admin panel, and workflow state ownership
- clarify `README.md` restart behavior for in-memory cooldowns introduced by the workflow state refactor
- trim or rewrite stale narration comments/docstrings in the touched handlers, bot wiring, workflow state store, and related tests

## Testing
- pre-commit hooks passed during `git commit`
