### PR TITLE
docs: add manual Discord test seeding workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 DISCORD_TOKEN=your_bot_token_here
 
 # Environment (optional)
-# Set to "production" for production deployments on Railway, Coolify, etc.
+# Set to "production" to connect to Discord.
 # If not set or set to "development", the bot runs in smoke test mode
 # (validates config but exits without connecting to Discord).
 # This prevents race conditions when multiple deployments share the same token.

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ venv.bak/
 # Environment
 .env
 .env.local
+.local/
 
 # IDE
 .vscode/

--- a/README.md
+++ b/README.md
@@ -136,7 +136,10 @@ The seed command resets that local test database and creates one mixed scenario:
 
 Outside `./.local/manual-discord-test`, add `--force-reset`.
 
-The seed command works the same way in a PR deployment shell. Seed the DB, then use the bot as-is.
+`--force-reset` deletes the target DB, its `-wal` and `-shm` files, and the configured backup directory before reseeding.
+
+In a PR deployment shell, use the same command against that deployment's `DB_PATH` and `BACKUP_DIR`.
+Those paths usually are not `./.local/manual-discord-test`, so add `--force-reset`.
 
 Create a real fixture when you need to test announcement posting, thread creation, reactions, or DMs. The seed data is only there to save setup time.
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,29 @@ $env:ENVIRONMENT="production"
 uv run python -m typer_bot
 ```
 
+## Manual Discord Testing
+
+Use a separate bot token in a private test guild. Point it at an isolated data directory, not your normal local or Railway database.
+
+```powershell
+$env:DISCORD_TOKEN="your_test_bot_token"
+$env:ENVIRONMENT="production"
+$env:DATA_DIR="./.local/manual-discord-test"
+uv run python -m typer_bot.dev.seed_test_data --tester-user-id "your_discord_user_id"
+uv run python -m typer_bot
+```
+
+The seed command resets that local test database and creates one mixed scenario:
+- one scored past fixture for standings/history
+- one open fixture with saved predictions
+- one late open fixture with a late prediction
+
+Outside `./.local/manual-discord-test`, add `--force-reset`.
+
+The seed command works the same way in a PR deployment shell. Seed the DB, then use the bot as-is.
+
+Create a real fixture when you need to test announcement posting, thread creation, reactions, or DMs. The seed data is only there to save setup time.
+
 ## Development
 
 ```bash

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -406,8 +406,9 @@ class TestMainFunction:
             main()
         assert exc_info.value.code == 0
         mock_logger.info.assert_any_call(
-            "⚠️  ENVIRONMENT is not 'production' - running in smoke test mode"
+            "ENVIRONMENT is not 'production'; running config smoke test only"
         )
+        mock_logger.info.assert_any_call("Smoke test passed; stopping before Discord connect")
 
 
 class TestOnMessage:

--- a/tests/test_seed_test_data.py
+++ b/tests/test_seed_test_data.py
@@ -1,0 +1,130 @@
+"""Tests for the manual Discord test data seeder."""
+
+from pathlib import Path
+
+import pytest
+
+from typer_bot.dev.seed_test_data import seed_mixed_test_data
+
+
+def _write_cleanup_artifacts(temp_db_path: str, backup_dir: Path) -> None:
+    Path(f"{temp_db_path}-wal").write_text("wal", encoding="utf-8")
+    Path(f"{temp_db_path}-shm").write_text("shm", encoding="utf-8")
+    (backup_dir / "backup.sql").write_text("old", encoding="utf-8")
+
+
+def _cleanup_artifacts_removed(temp_db_path: str, backup_dir: Path) -> bool:
+    return not any(
+        [
+            Path(f"{temp_db_path}-wal").exists(),
+            Path(f"{temp_db_path}-shm").exists(),
+            (backup_dir / "backup.sql").exists(),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_seed_mixed_data_creates_expected_fixture_states(temp_db_path, tmp_path):
+    backup_dir = tmp_path / "backups"
+
+    await seed_mixed_test_data(temp_db_path, str(backup_dir), None, force_reset=True)
+
+    from typer_bot.database import Database
+
+    db = Database(temp_db_path)
+    open_fixtures = await db.get_open_fixtures()
+    standings = await db.get_standings()
+    week_one = await db.get_fixture_by_week(1)
+    week_two = await db.get_fixture_by_week(2)
+    week_three = await db.get_fixture_by_week(3)
+
+    assert [fixture["week_number"] for fixture in open_fixtures] == [2, 3]
+    assert week_one is not None
+    assert week_one["status"] == "closed"
+    assert week_two is not None
+    assert week_two["status"] == "open"
+    assert week_three is not None
+    assert week_three["status"] == "open"
+    assert len(standings) == 2
+    assert standings[0]["user_name"] == "Seed Alpha"
+    assert standings[0]["total_points"] == 9
+    assert standings[1]["user_name"] == "Seed Beta"
+    assert standings[1]["total_points"] == 5
+
+    week_one_results = await db.get_results(week_one["id"])
+    week_one_scores = await db.get_scores_for_fixture(week_one["id"])
+
+    open_predictions = await db.get_all_predictions(week_two["id"])
+    late_predictions = await db.get_all_predictions(week_three["id"])
+
+    assert week_one_results == ["2-1", "1-1", "0-2"]
+    assert [score["user_name"] for score in week_one_scores] == ["Seed Alpha", "Seed Beta"]
+    assert [score["points"] for score in week_one_scores] == [9, 5]
+    assert len(open_predictions) == 2
+    assert len(late_predictions) == 1
+    assert late_predictions[0]["is_late"] == 1
+
+
+@pytest.mark.asyncio
+async def test_seed_mixed_data_includes_real_tester_when_user_id_provided(temp_db_path, tmp_path):
+    backup_dir = tmp_path / "backups"
+    tester_user_id = "123456789012345678"
+
+    await seed_mixed_test_data(temp_db_path, str(backup_dir), tester_user_id, force_reset=True)
+
+    from typer_bot.database import Database
+
+    db = Database(temp_db_path)
+    week_one = await db.get_fixture_by_week(1)
+    week_two = await db.get_fixture_by_week(2)
+    assert week_one is not None
+    assert week_two is not None
+
+    tester_scored_prediction = await db.get_prediction(week_one["id"], tester_user_id)
+    tester_prediction = await db.get_prediction(week_two["id"], tester_user_id)
+    synthetic_prediction = await db.get_prediction(week_two["id"], "seed-user-1")
+
+    assert tester_scored_prediction is None
+    assert tester_prediction is not None
+    assert tester_prediction["user_name"] == "Manual Tester"
+    assert synthetic_prediction is not None
+
+
+@pytest.mark.asyncio
+async def test_seed_mixed_data_resets_existing_database(temp_db_path, tmp_path):
+    backup_dir = tmp_path / "backups"
+
+    await seed_mixed_test_data(temp_db_path, str(backup_dir), None, force_reset=True)
+
+    from typer_bot.database import Database
+
+    db = Database(temp_db_path)
+    week_two = await db.get_fixture_by_week(2)
+    assert week_two is not None
+    await db.delete_fixture(week_two["id"])
+
+    await seed_mixed_test_data(temp_db_path, str(backup_dir), None, force_reset=True)
+
+    refreshed_db = Database(temp_db_path)
+    open_fixtures = await refreshed_db.get_open_fixtures()
+    assert [fixture["week_number"] for fixture in open_fixtures] == [2, 3]
+
+
+@pytest.mark.asyncio
+async def test_seed_mixed_data_cleans_wal_shm_and_backups(temp_db_path, tmp_path):
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+    _write_cleanup_artifacts(temp_db_path, backup_dir)
+
+    await seed_mixed_test_data(temp_db_path, str(backup_dir), None, force_reset=True)
+
+    assert _cleanup_artifacts_removed(temp_db_path, backup_dir)
+
+
+@pytest.mark.asyncio
+async def test_seed_mixed_data_refuses_non_default_reset_without_force(tmp_path):
+    db_path = tmp_path / "manual.db"
+    backup_dir = tmp_path / "backups"
+
+    with pytest.raises(ValueError, match="--force-reset"):
+        await seed_mixed_test_data(str(db_path), str(backup_dir), None)

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -368,8 +368,8 @@ def main():
     logger.info("✅ Token configured")
 
     if not IS_PRODUCTION:
-        logger.info("⚠️  ENVIRONMENT is not 'production' - running in smoke test mode")
-        logger.info("✅ Smoke test successful - deployment validated, exiting")
+        logger.info("ENVIRONMENT is not 'production'; running config smoke test only")
+        logger.info("Smoke test passed; stopping before Discord connect")
         sys.exit(0)
 
     logger.info("Creating TyperBot instance...")

--- a/typer_bot/dev/__init__.py
+++ b/typer_bot/dev/__init__.py
@@ -1,0 +1,1 @@
+"""Development-only utilities."""

--- a/typer_bot/dev/seed_test_data.py
+++ b/typer_bot/dev/seed_test_data.py
@@ -1,0 +1,188 @@
+"""Reset and seed a local database for manual Discord testing."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import shutil
+from datetime import timedelta
+from pathlib import Path
+
+from typer_bot.database import Database
+from typer_bot.utils import calculate_points, now
+from typer_bot.utils.config import BACKUP_DIR, DB_PATH
+from typer_bot.utils.logger import setup_logging
+
+SAMPLE_GAMES = [
+    "Team A - Team B",
+    "Team C - Team D",
+    "Team E - Team F",
+]
+
+SYNTHETIC_USERS = [
+    {"user_id": "seed-user-1", "user_name": "Seed Alpha"},
+    {"user_id": "seed-user-2", "user_name": "Seed Beta"},
+]
+
+logger = logging.getLogger(__name__)
+DEFAULT_MANUAL_TEST_DIR = Path(".local/manual-discord-test").resolve()
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Reset the configured database and seed mixed manual test data."
+    )
+    parser.add_argument(
+        "--tester-user-id",
+        help="Real Discord user ID to include in seeded open-fixture predictions.",
+    )
+    parser.add_argument(
+        "--force-reset",
+        action="store_true",
+        help="Allow resetting a database outside ./.local/manual-discord-test.",
+    )
+    return parser
+
+
+def _ensure_safe_reset_target(db_path: str, backup_dir: str, force_reset: bool) -> None:
+    db_parent = Path(db_path).resolve().parent
+    backup_path = Path(backup_dir).resolve()
+    if force_reset:
+        return
+
+    if db_parent == DEFAULT_MANUAL_TEST_DIR and backup_path == DEFAULT_MANUAL_TEST_DIR / "backups":
+        return
+
+    message = (
+        "Refusing to reset a non-default database without --force-reset. "
+        f"DB_PATH={Path(db_path).resolve()} BACKUP_DIR={backup_path}"
+    )
+    raise ValueError(message)
+
+
+def _reset_database_files(db_path: str, backup_dir: str, force_reset: bool) -> None:
+    _ensure_safe_reset_target(db_path, backup_dir, force_reset)
+
+    db_file = Path(db_path)
+    for suffix in ("", "-wal", "-shm"):
+        db_file.with_name(f"{db_file.name}{suffix}").unlink(missing_ok=True)
+
+    backup_path = Path(backup_dir)
+    if backup_path.exists():
+        shutil.rmtree(backup_path)
+
+
+def _build_seed_users() -> list[dict[str, str]]:
+    return [user.copy() for user in SYNTHETIC_USERS]
+
+
+async def seed_mixed_test_data(
+    db_path: str,
+    backup_dir: str,
+    tester_user_id: str | None,
+    *,
+    force_reset: bool = False,
+) -> None:
+    _reset_database_files(db_path, backup_dir, force_reset)
+
+    db = Database(db_path)
+    await db.initialize()
+
+    current_time = now()
+    users = _build_seed_users()
+
+    scored_fixture_id = await db.create_fixture(
+        1,
+        SAMPLE_GAMES,
+        current_time - timedelta(days=7),
+    )
+    scored_results = ["2-1", "1-1", "0-2"]
+    scored_predictions = {
+        users[0]["user_id"]: ["2-1", "1-1", "0-2"],
+        users[1]["user_id"]: ["1-0", "1-1", "1-2"],
+    }
+    scored_scores: list[dict[str, int | str]] = []
+    for user in users:
+        predictions = scored_predictions[user["user_id"]]
+        await db.save_prediction(
+            scored_fixture_id,
+            user["user_id"],
+            user["user_name"],
+            predictions,
+            False,
+        )
+        score_data = calculate_points(predictions, scored_results, False)
+        scored_scores.append(
+            {
+                "user_id": user["user_id"],
+                "user_name": user["user_name"],
+                "points": score_data["points"],
+                "exact_scores": score_data["exact_scores"],
+                "correct_results": score_data["correct_results"],
+            }
+        )
+
+    scored_scores.sort(
+        key=lambda score: (
+            -int(score["points"]),
+            -int(score["exact_scores"]),
+            -int(score["correct_results"]),
+            str(score["user_name"]).lower(),
+        )
+    )
+    await db.save_results(scored_fixture_id, scored_results)
+    await db.save_scores(scored_fixture_id, scored_scores)
+
+    open_fixture_id = await db.create_fixture(
+        2,
+        SAMPLE_GAMES,
+        current_time + timedelta(days=2),
+    )
+    open_fixture_users = list(users)
+    if tester_user_id:
+        open_fixture_users.insert(0, {"user_id": tester_user_id, "user_name": "Manual Tester"})
+
+    open_predictions = [
+        (open_fixture_users[0], ["1-0", "2-1", "0-0"], False),
+        (open_fixture_users[1], ["2-0", "2-2", "1-1"], False),
+    ]
+    if len(open_fixture_users) > 2:
+        open_predictions.append((open_fixture_users[2], ["0-1", "1-1", "0-2"], False))
+
+    for user, predictions, is_late in open_predictions:
+        await db.save_prediction(
+            open_fixture_id,
+            user["user_id"],
+            user["user_name"],
+            predictions,
+            is_late,
+        )
+
+    late_fixture_id = await db.create_fixture(
+        3,
+        SAMPLE_GAMES,
+        current_time - timedelta(hours=3),
+    )
+    await db.save_prediction(
+        late_fixture_id,
+        users[1]["user_id"],
+        users[1]["user_name"],
+        ["3-1", "0-0", "1-2"],
+        True,
+    )
+
+
+async def _async_main(tester_user_id: str | None, force_reset: bool) -> None:
+    await seed_mixed_test_data(DB_PATH, BACKUP_DIR, tester_user_id, force_reset=force_reset)
+    logger.info("Seeded mixed manual test data into %s", DB_PATH)
+
+
+def main() -> None:
+    setup_logging()
+    args = _build_argument_parser().parse_args()
+    asyncio.run(_async_main(args.tester_user_id, args.force_reset))
+
+
+if __name__ == "__main__":
+    main()

--- a/typer_bot/dev/seed_test_data.py
+++ b/typer_bot/dev/seed_test_data.py
@@ -84,6 +84,25 @@ async def seed_mixed_test_data(
     *,
     force_reset: bool = False,
 ) -> None:
+    """Reset the target SQLite files and seed one mixed manual-testing scenario.
+
+    Args:
+        db_path: SQLite database file to recreate and seed.
+        backup_dir: Backup directory removed before reseeding.
+        tester_user_id: Real Discord user ID added only to the open-fixture seed data.
+        force_reset: Allows resetting paths outside ``./.local/manual-discord-test``.
+
+    Raises:
+        ValueError: Target paths are outside the default manual-test directory and
+            ``force_reset`` is not enabled.
+
+    Notes:
+        The reset removes the database file, its WAL/SHM sidecars, and the backup
+        directory. The seed creates three fixtures: one scored past fixture, one
+        open fixture with saved predictions, and one overdue fixture with a late
+        prediction. This touches SQLite only. It does not post announcements,
+        create threads, or run any Discord workflows.
+    """
     _reset_database_files(db_path, backup_dir, force_reset)
 
     db = Database(db_path)


### PR DESCRIPTION
## Summary
- add an explicit dev-only seed command for manual Discord testing with one reusable mixed scenario
- document the minimal local and PR-preview testing flow without wiring seeding into bot startup
- guard destructive resets outside `./.local/manual-discord-test` unless `--force-reset` is passed

Closes #161 

## Testing
- `uv run pytest tests/test_seed_test_data.py tests/test_config.py --tb=short`
- `uv run ruff check typer_bot/dev tests/test_seed_test_data.py`
- `uv run ty check typer_bot`
