### PR TITLE
refactor: remove smoke test startup mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,16 +2,15 @@
 DISCORD_TOKEN=your_bot_token_here
 
 # Environment (optional)
-# Set to "production" to connect to Discord.
-# If not set or set to "development", the bot runs in smoke test mode
-# (validates config but exits without connecting to Discord).
-# This prevents race conditions when multiple deployments share the same token.
-# ENVIRONMENT=production
+# Labels the runtime environment. The bot connects to Discord regardless.
+# Use "production" for the live deploy. Local/manual testing can stay on
+# "development" or any other non-production value.
+# ENVIRONMENT=development
 
 # Data directory (optional)
 # Railway: /app/data (must use persistent volume)
 # Local default: ./data
-DATA_DIR=/app/data
+# DATA_DIR=./data
 
 # Database path (optional)
 # Defaults to DATA_DIR/typer.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,8 +163,9 @@ prek run ruff            # Run specific hook
 
 ## 8. Deployment Environment
 - **Configuration:** The `ENVIRONMENT` variable controls bot behavior:
-  - `production`: Bot connects to Discord and runs normally
-  - Not set/`development`: Bot runs in "smoke test" mode - validates config then exits
-- **Purpose:** Prevents race conditions when multiple deployments (e.g., PR previews) share the same Discord token
+  - `production`: Production deployment label
+  - Not set/`development`: Non-production environment label
+- **Runtime:** The bot still connects to Discord in non-production environments; use a separate token for manual testing and previews
+- **Token Safety:** Any deployment with a valid token will connect; never run multiple environments against the same live token
 - **Railway:** Set `ENVIRONMENT=production` in Railway variables for production deployments
 - **Portability:** Works on any platform (Railway, Coolify, local, etc.) - just set the variable accordingly

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Admins need a Discord role named `Admin` or `typer-admin`.
 - `Create Public Threads`
 - `Use Slash Commands`
 
+## Privileged Intents
+- Enable `Message Content Intent` in the Discord Developer Portal
+- Enable `Server Members Intent` in the Discord Developer Portal
+
 ## Prediction flow
 - Reply in the fixture thread with one line per match.
 - Run `/predict` or DM the bot and submit the same scores privately.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Team E - Team F 3:2
 - `DISCORD_TOKEN` - Discord bot token
 
 ### Optional
-- `ENVIRONMENT` - `production` to run the bot; default is `development`, which only smoke-tests config and exits
+- `ENVIRONMENT` - environment label; use `production` for production deploys, default is `development`
 - `DATA_DIR` - base data directory; default `./data` locally, set `/app/data` on Railway
 - `DB_PATH` - database path; default `{DATA_DIR}/typer.db`
 - `BACKUP_DIR` - backup directory; default `{DATA_DIR}/backups`
@@ -88,9 +88,11 @@ Team E - Team F 3:2
    - `DATA_DIR=/app/data`
    - optional: `TZ=Europe/Warsaw`
 
+`ENVIRONMENT` is labeling only. Any deployment with a valid `DISCORD_TOKEN` will connect to Discord and process events. Use a separate token for previews and manual testing. If `DISCORD_TOKEN` is unset, startup fails instead of connecting. Do not run multiple deployments against the same live token.
+
 ## Running locally
 
-By default the bot runs in smoke-test mode. It validates config and exits without connecting to Discord. Local runs also default to `DATA_DIR=./data` and `TZ=UTC`.
+Local runs default to `ENVIRONMENT=development`, `DATA_DIR=./data`, and `TZ=UTC`.
 
 ```bash
 git clone https://github.com/adrunkhuman/TyperBot
@@ -98,14 +100,7 @@ cd TyperBot
 uv sync --group dev
 
 export DISCORD_TOKEN="your_token"
-uv run python -m typer_bot
-```
-
-Live run:
-
-```bash
-export DISCORD_TOKEN="your_token"
-export ENVIRONMENT=production
+export ENVIRONMENT=development
 uv run python -m typer_bot
 ```
 
@@ -113,7 +108,7 @@ Windows PowerShell:
 
 ```powershell
 $env:DISCORD_TOKEN="your_token"
-$env:ENVIRONMENT="production"
+$env:ENVIRONMENT="development"
 uv run python -m typer_bot
 ```
 
@@ -123,7 +118,7 @@ Use a separate bot token in a private test guild. Point it at an isolated data d
 
 ```powershell
 $env:DISCORD_TOKEN="your_test_bot_token"
-$env:ENVIRONMENT="production"
+$env:ENVIRONMENT="development"
 $env:DATA_DIR="./.local/manual-discord-test"
 uv run python -m typer_bot.dev.seed_test_data --tester-user-id "your_discord_user_id"
 uv run python -m typer_bot

--- a/railway.toml
+++ b/railway.toml
@@ -7,7 +7,8 @@ restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 10
 
 # Environment Configuration:
-# Set ENVIRONMENT=production in Railway variables for production deployments.
-# PR deployments without ENVIRONMENT=production will run in smoke test mode
-# (bot starts, validates config, then exits successfully without connecting to Discord).
-# This prevents race conditions when multiple deployments share the same token.
+# Set ENVIRONMENT=production in Railway variables for the live deploy.
+# Non-production values still run the bot; they only change environment labeling.
+# Any deployment with a valid DISCORD_TOKEN will connect to Discord.
+# Use a separate token for previews/manual testing. If DISCORD_TOKEN is unset,
+# the process exits at startup instead of connecting.

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -5,6 +5,7 @@ from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import discord
 import pytest
 
 from typer_bot.bot import TyperBot, main
@@ -433,6 +434,23 @@ class TestMainFunction:
 
         mock_logger.info.assert_any_call("Running in production environment")
         mock_bot.run.assert_called_once_with("valid_token", log_handler=None)
+
+    @patch.dict(os.environ, {"DISCORD_TOKEN": "valid_token", "ENVIRONMENT": "production"})
+    @patch("typer_bot.bot.TyperBot")
+    @patch("typer_bot.bot.logger")
+    def test_main_logs_clear_error_for_missing_privileged_intents(self, mock_logger, mock_bot_cls):
+        """Privileged intent failures should point to the developer portal setting."""
+        mock_bot = mock_bot_cls.return_value
+        mock_bot.run.side_effect = discord.PrivilegedIntentsRequired(shard_id=None)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1
+        mock_logger.exception.assert_called_once_with(
+            "❌ Privileged intents are not enabled in the Discord developer portal. "
+            "Enable Message Content Intent and Server Members Intent for this bot application."
+        )
 
 
 class TestOnMessage:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -399,16 +399,40 @@ class TestMainFunction:
         assert exc_info.value.code == 1
 
     @patch.dict(os.environ, {"DISCORD_TOKEN": "valid_token", "ENVIRONMENT": "development"})
+    @patch("typer_bot.bot.TyperBot")
     @patch("typer_bot.bot.logger")
-    def test_main_smoke_test_mode(self, mock_logger):
-        """Smoke test mode validates configuration without connecting."""
-        with pytest.raises(SystemExit) as exc_info:
-            main()
-        assert exc_info.value.code == 0
-        mock_logger.info.assert_any_call(
-            "ENVIRONMENT is not 'production'; running config smoke test only"
-        )
-        mock_logger.info.assert_any_call("Smoke test passed; stopping before Discord connect")
+    def test_main_runs_bot_in_non_production_environment(self, mock_logger, mock_bot_cls):
+        """Non-production environments still connect to Discord."""
+        mock_bot = mock_bot_cls.return_value
+
+        main()
+
+        mock_logger.info.assert_any_call("Running in non-production environment: %s", "development")
+        mock_bot.run.assert_called_once_with("valid_token", log_handler=None)
+
+    @patch.dict(os.environ, {"DISCORD_TOKEN": "valid_token"}, clear=True)
+    @patch("typer_bot.bot.TyperBot")
+    @patch("typer_bot.bot.logger")
+    def test_main_runs_bot_when_environment_is_unset(self, mock_logger, mock_bot_cls):
+        """Missing ENVIRONMENT still boots with the default non-production label."""
+        mock_bot = mock_bot_cls.return_value
+
+        main()
+
+        mock_logger.info.assert_any_call("Running in non-production environment: %s", "development")
+        mock_bot.run.assert_called_once_with("valid_token", log_handler=None)
+
+    @patch.dict(os.environ, {"DISCORD_TOKEN": "valid_token", "ENVIRONMENT": "production"})
+    @patch("typer_bot.bot.TyperBot")
+    @patch("typer_bot.bot.logger")
+    def test_main_runs_bot_in_production_environment(self, mock_logger, mock_bot_cls):
+        """Production environment uses the production label and still boots normally."""
+        mock_bot = mock_bot_cls.return_value
+
+        main()
+
+        mock_logger.info.assert_any_call("Running in production environment")
+        mock_bot.run.assert_called_once_with("valid_token", log_handler=None)
 
 
 class TestOnMessage:

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -380,6 +380,12 @@ def main():
         bot = TyperBot()
         logger.info("Starting bot.run()...")
         bot.run(token, log_handler=None)
+    except discord.PrivilegedIntentsRequired:
+        logger.exception(
+            "❌ Privileged intents are not enabled in the Discord developer portal. "
+            "Enable Message Content Intent and Server Members Intent for this bot application."
+        )
+        sys.exit(1)
     except discord.LoginFailure:
         logger.exception("❌ Discord login failed - check if DISCORD_TOKEN is valid")
         sys.exit(1)

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -15,7 +15,6 @@ from typer_bot.handlers.thread_prediction_handler import ThreadPredictionHandler
 from typer_bot.services import WorkflowStateStore
 from typer_bot.services.dm_router import DMRouter
 from typer_bot.utils import format_for_discord, now
-from typer_bot.utils.config import IS_PRODUCTION
 from typer_bot.utils.logger import set_log_context, set_trace_id
 
 logger = logging.getLogger(__name__)
@@ -367,10 +366,13 @@ def main():
         raise RuntimeError("Token validation failed unexpectedly")
     logger.info("✅ Token configured")
 
-    if not IS_PRODUCTION:
-        logger.info("ENVIRONMENT is not 'production'; running config smoke test only")
-        logger.info("Smoke test passed; stopping before Discord connect")
-        sys.exit(0)
+    environment = os.getenv("ENVIRONMENT", "development")
+    is_production = environment.lower() in ("production", "prod")
+
+    if is_production:
+        logger.info("Running in production environment")
+    else:
+        logger.info("Running in non-production environment: %s", environment)
 
     logger.info("Creating TyperBot instance...")
 

--- a/typer_bot/utils/config.py
+++ b/typer_bot/utils/config.py
@@ -1,7 +1,7 @@
 """Deployment-sensitive configuration defaults.
 
-The bot boots in smoke-test mode unless ``ENVIRONMENT`` is set to a production
-value.
+``ENVIRONMENT`` describes whether the bot is running in production or in some
+other environment. It does not control whether the bot connects to Discord.
 
 ``DATA_DIR`` intentionally defaults to ``./data`` so local development writes
 into a repo-adjacent folder without depending on Railway's volume mount.


### PR DESCRIPTION
## Summary
- remove the startup smoke-test mode so non-production environments still run the bot normally
- make `ENVIRONMENT` a label instead of a connect/disconnect switch and log production vs non-production explicitly
- update docs and tests so preview/local deployments are warned to use separate tokens

## Testing
- `uv run pytest tests/test_bot.py tests/test_config.py --tb=short`
- `uv run ruff check typer_bot/bot.py typer_bot/utils/config.py tests/test_bot.py`
- `uv run ty check typer_bot`
