### PR TITLE
fix: pre-fill CorrectResultsModal with stored results

### DIFF
--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -368,6 +368,9 @@ class TestResultsPanelFlows:
         await correct_button.callback(mock_interaction_admin)
 
         assert mock_interaction_admin.modal_sent["modal"].title == "Correct Week 3 Results"
+        assert mock_interaction_admin.modal_sent["modal"].results_input.default == (
+            "1. Team A - Team B 1-0\n2. Team C - Team D 1-1\n3. Team E - Team F 0-0"
+        )
 
     @pytest.mark.asyncio
     async def test_results_panel_requires_existing_results(
@@ -460,7 +463,7 @@ class TestAdminPanelModals:
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
         assert fixture is not None
 
-        modal = CorrectResultsModal(view, fixture)
+        modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
         modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
         member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
         member.roles = []
@@ -486,10 +489,33 @@ class TestAdminPanelModals:
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
         assert fixture is not None
 
-        modal = CorrectResultsModal(view, fixture)
+        modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
         modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
         await admin_cog.db.delete_fixture(fixture_id)
 
         await modal.on_submit(mock_interaction_admin)
 
         assert "Fixture not found" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_correct_results_modal_prefills_stored_results(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            7, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+        view = ResultsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
+
+        assert modal.results_input.default == (
+            "1. Team A - Team B 1-0\n2. Team C - Team D 1-1\n3. Team E - Team F 0-0"
+        )

--- a/typer_bot/commands/admin_panel/modals.py
+++ b/typer_bot/commands/admin_panel/modals.py
@@ -75,7 +75,7 @@ class ReplacePredictionModal(discord.ui.Modal):
 class CorrectResultsModal(discord.ui.Modal):
     """Collect corrected results input for a fixture from the admin panel."""
 
-    def __init__(self, parent_view: ResultsPanelView, fixture: dict):
+    def __init__(self, parent_view: ResultsPanelView, fixture: dict, results: list[str] | None):
         super().__init__(title=f"Correct Week {fixture['week_number']} Results")
         self.parent_view = parent_view
         self.fixture = fixture
@@ -83,6 +83,17 @@ class CorrectResultsModal(discord.ui.Modal):
             label="Results",
             style=discord.TextStyle.paragraph,
             placeholder="One line per match, e.g. Team A - Team B 2:1",
+            default=(
+                "\n".join(
+                    _format_prediction_line(index, game, result)
+                    for index, (game, result) in enumerate(
+                        zip(fixture["games"], results, strict=False),
+                        1,
+                    )
+                )
+                if results
+                else None
+            ),
             required=True,
             max_length=4000,
         )

--- a/typer_bot/commands/admin_panel/results.py
+++ b/typer_bot/commands/admin_panel/results.py
@@ -88,12 +88,13 @@ class CorrectResultsButton(discord.ui.Button):
         if fixture is None:
             await interaction.response.send_message("Fixture not found.", ephemeral=True)
             return
-        if not await self.parent_view.db.get_results(fixture_id):
+        results = await self.parent_view.db.get_results(fixture_id)
+        if not results:
             await interaction.response.send_message(
                 "No results are stored for that fixture yet. Use `/admin results enter` first.",
                 ephemeral=True,
             )
             return
 
-        modal = CorrectResultsModal(self.parent_view, fixture)
+        modal = CorrectResultsModal(self.parent_view, fixture, results)
         await interaction.response.send_modal(modal)


### PR DESCRIPTION
## Summary
- pre-fill the results correction modal with the fixture's stored results
- keep the existing guard when a fixture has no saved results yet
- cover both the button flow and direct modal prefill in admin panel tests

Closes #152

## Testing
- `uv run pytest tests/test_admin_panel.py --tb=short`
- `uv run ruff check typer_bot/commands/admin_panel tests/test_admin_panel.py`
- `uv run ty check typer_bot`
