### PR TITLE
fix: disable admin panel buttons until selections exist

### DIFF
--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -12,12 +12,17 @@ from typer_bot.commands.admin_panel import (
     AdminPanelHomeView,
     CorrectResultsModal,
     DeleteConfirmView,
+    FixturesPanelView,
     PredictionsPanelView,
     ReplacePredictionModal,
     ResultsPanelView,
 )
 from typer_bot.commands.admin_panel.fixtures import _cleanup_discord_announcement
 from typer_bot.database import Database
+
+
+def _get_button(view: discord.ui.View, label: str) -> discord.ui.Button:
+    return next(child for child in view.children if getattr(child, "label", None) == label)
 
 
 class TestAdminPanelCommand:
@@ -97,6 +102,46 @@ class TestPredictionPanelFlows:
         assert edited_view.user_select.disabled is True
         assert len(edited_view.user_select.options) == 1
         assert edited_view.user_select.options[0].label == "No predictions available"
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_buttons_enable_as_selections_are_made(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-2"],
+            False,
+        )
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+
+        assert _get_button(view, "View Predictions").disabled is True
+        assert _get_button(view, "Replace Prediction").disabled is True
+        assert _get_button(view, "Toggle Late Waiver").disabled is True
+
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        assert _get_button(view, "View Predictions").disabled is False
+        assert _get_button(view, "Replace Prediction").disabled is True
+        assert _get_button(view, "Toggle Late Waiver").disabled is True
+
+        view.user_select._values = ["user-1"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        assert _get_button(view, "Replace Prediction").disabled is False
+        assert _get_button(view, "Toggle Late Waiver").disabled is False
 
     @pytest.mark.asyncio
     async def test_prediction_panel_replace_opens_modal(
@@ -203,6 +248,29 @@ class TestFixturePanelFlows:
         edited_view = mock_interaction_admin.response_sent[-1]["view"]
         assert edited_view.fixture_select.disabled is False
         assert edited_view.fixture_select.options[0].label == "Week 4 [OPEN]"
+
+    @pytest.mark.asyncio
+    async def test_fixture_panel_delete_button_enables_after_fixture_selection(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            5, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+
+        view = FixturesPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), bot=admin_cog.bot
+        )
+        await view.load_fixture_options()
+
+        assert _get_button(view, "Delete Fixture").disabled is True
+
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        assert _get_button(view, "Delete Fixture").disabled is False
 
     @pytest.mark.asyncio
     async def test_fixture_panel_delete_confirmation_shows_games(
@@ -370,6 +438,32 @@ class TestResultsPanelFlows:
         assert mock_interaction_admin.modal_sent["modal"].title == "Correct Week 3 Results"
 
     @pytest.mark.asyncio
+    async def test_results_panel_buttons_enable_after_fixture_selection(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            4, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+
+        view = ResultsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+
+        assert _get_button(view, "View Results").disabled is True
+        assert _get_button(view, "Correct Results").disabled is True
+
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        assert _get_button(view, "View Results").disabled is False
+        assert _get_button(view, "Correct Results").disabled is False
+
+    @pytest.mark.asyncio
     async def test_results_panel_requires_existing_results(
         self,
         admin_cog,
@@ -442,6 +536,39 @@ class TestAdminPanelModals:
         await modal.on_submit(mock_interaction_admin)
 
         assert "no longer have permission" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_clears_actions_for_deleted_prediction(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            9, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-0"],
+            False,
+        )
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        await admin_cog.db.delete_prediction(fixture_id, "user-1")
+
+        view.user_select._values = ["user-1"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        assert view.selection.user_id is None
+        assert "Prediction no longer exists" in mock_interaction_admin.response_sent[-1]["content"]
+        assert _get_button(view, "Replace Prediction").disabled is True
+        assert _get_button(view, "Toggle Late Waiver").disabled is True
 
     @pytest.mark.asyncio
     async def test_correct_results_modal_rechecks_admin_permission(

--- a/typer_bot/commands/admin_panel/base.py
+++ b/typer_bot/commands/admin_panel/base.py
@@ -170,13 +170,14 @@ class FixtureSelect(discord.ui.Select):
             return
 
         fixture_id = int(self.values[0])
-        self.parent_view.selection.fixture_id = fixture_id
         self.parent_view.selection.user_id = None
 
         fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
         if fixture is None:
+            self.parent_view.selection.fixture_id = None
             self.parent_view.selection.status_message = "Fixture no longer exists."
         else:
+            self.parent_view.selection.fixture_id = fixture_id
             self.parent_view.selection.status_message = (
                 f"Selected week {fixture['week_number']} ({fixture['status']})."
             )
@@ -184,6 +185,10 @@ class FixtureSelect(discord.ui.Select):
         load_user_options = getattr(self.parent_view, "load_user_options", None)
         if callable(load_user_options):
             await load_user_options()
+
+        refresh_items = getattr(self.parent_view, "_refresh_items", None)
+        if callable(refresh_items):
+            refresh_items()
 
         await interaction.response.edit_message(
             content=self.parent_view.render_content(),

--- a/typer_bot/commands/admin_panel/fixtures.py
+++ b/typer_bot/commands/admin_panel/fixtures.py
@@ -69,7 +69,7 @@ class FixturesPanelView(OwnerRestrictedView):
     def _refresh_items(self) -> None:
         self.clear_items()
         self.add_item(self.fixture_select)
-        self.add_item(FixturesDeleteButton(self))
+        self.add_item(FixturesDeleteButton(self, disabled=self.selection.fixture_id is None))
         self.add_item(BackButton(self))
 
     async def load_fixture_options(self) -> None:
@@ -85,9 +85,13 @@ class FixturesPanelView(OwnerRestrictedView):
 
 
 class FixturesDeleteButton(discord.ui.Button):
-    def __init__(self, parent_view: FixturesPanelView):
+    def __init__(self, parent_view: FixturesPanelView, disabled: bool = False):
         self.parent_view = parent_view
-        super().__init__(label="Delete Fixture", style=discord.ButtonStyle.danger)
+        super().__init__(
+            label="Delete Fixture",
+            style=discord.ButtonStyle.danger,
+            disabled=disabled,
+        )
 
     async def callback(self, interaction: discord.Interaction):
         fixture_id = self.parent_view.selection.fixture_id

--- a/typer_bot/commands/admin_panel/predictions.py
+++ b/typer_bot/commands/admin_panel/predictions.py
@@ -33,9 +33,19 @@ class PredictionsPanelView(OwnerRestrictedView):
         self.clear_items()
         self.add_item(self.fixture_select)
         self.add_item(self.user_select)
-        self.add_item(ViewPredictionsButton(self))
-        self.add_item(ReplacePredictionButton(self))
-        self.add_item(ToggleWaiverButton(self))
+        self.add_item(ViewPredictionsButton(self, disabled=self.selection.fixture_id is None))
+        self.add_item(
+            ReplacePredictionButton(
+                self,
+                disabled=self.selection.fixture_id is None or self.selection.user_id is None,
+            )
+        )
+        self.add_item(
+            ToggleWaiverButton(
+                self,
+                disabled=self.selection.fixture_id is None or self.selection.user_id is None,
+            )
+        )
         self.add_item(BackButton(self))
 
     async def load_fixture_options(self) -> None:
@@ -91,19 +101,23 @@ class PredictionUserSelect(discord.ui.Select):
             await interaction.response.send_message("No predictions available.", ephemeral=True)
             return
 
-        self.parent_view.selection.user_id = self.values[0]
+        selected_user_id = self.values[0]
         fixture_id = self.parent_view.selection.fixture_id
         if fixture_id is None:
             await interaction.response.send_message("Select a fixture first.", ephemeral=True)
             return
 
-        prediction = await self.parent_view.db.get_prediction(fixture_id, self.values[0])
+        prediction = await self.parent_view.db.get_prediction(fixture_id, selected_user_id)
         if prediction is None:
+            self.parent_view.selection.user_id = None
             self.parent_view.selection.status_message = "Prediction no longer exists."
         else:
+            self.parent_view.selection.user_id = selected_user_id
             self.parent_view.selection.status_message = (
                 f"Selected {prediction['user_name']} ({_prediction_status_text(prediction)})."
             )
+
+        self.parent_view._refresh_items()
 
         await interaction.response.edit_message(
             content=self.parent_view.render_content(),
@@ -112,9 +126,13 @@ class PredictionUserSelect(discord.ui.Select):
 
 
 class ViewPredictionsButton(discord.ui.Button):
-    def __init__(self, parent_view: PredictionsPanelView):
+    def __init__(self, parent_view: PredictionsPanelView, disabled: bool = False):
         self.parent_view = parent_view
-        super().__init__(label="View Predictions", style=discord.ButtonStyle.secondary)
+        super().__init__(
+            label="View Predictions",
+            style=discord.ButtonStyle.secondary,
+            disabled=disabled,
+        )
 
     async def callback(self, interaction: discord.Interaction):
         fixture_id = self.parent_view.selection.fixture_id
@@ -141,9 +159,13 @@ class ViewPredictionsButton(discord.ui.Button):
 
 
 class ReplacePredictionButton(discord.ui.Button):
-    def __init__(self, parent_view: PredictionsPanelView):
+    def __init__(self, parent_view: PredictionsPanelView, disabled: bool = False):
         self.parent_view = parent_view
-        super().__init__(label="Replace Prediction", style=discord.ButtonStyle.primary)
+        super().__init__(
+            label="Replace Prediction",
+            style=discord.ButtonStyle.primary,
+            disabled=disabled,
+        )
 
     async def callback(self, interaction: discord.Interaction):
         fixture_id = self.parent_view.selection.fixture_id
@@ -167,9 +189,13 @@ class ReplacePredictionButton(discord.ui.Button):
 
 
 class ToggleWaiverButton(discord.ui.Button):
-    def __init__(self, parent_view: PredictionsPanelView):
+    def __init__(self, parent_view: PredictionsPanelView, disabled: bool = False):
         self.parent_view = parent_view
-        super().__init__(label="Toggle Late Waiver", style=discord.ButtonStyle.success)
+        super().__init__(
+            label="Toggle Late Waiver",
+            style=discord.ButtonStyle.success,
+            disabled=disabled,
+        )
 
     async def callback(self, interaction: discord.Interaction):
         fixture_id = self.parent_view.selection.fixture_id

--- a/typer_bot/commands/admin_panel/results.py
+++ b/typer_bot/commands/admin_panel/results.py
@@ -30,8 +30,8 @@ class ResultsPanelView(OwnerRestrictedView):
     def _refresh_items(self) -> None:
         self.clear_items()
         self.add_item(self.fixture_select)
-        self.add_item(ViewResultsButton(self))
-        self.add_item(CorrectResultsButton(self))
+        self.add_item(ViewResultsButton(self, disabled=self.selection.fixture_id is None))
+        self.add_item(CorrectResultsButton(self, disabled=self.selection.fixture_id is None))
         self.add_item(BackButton(self))
 
     async def load_fixture_options(self) -> None:
@@ -46,9 +46,13 @@ class ResultsPanelView(OwnerRestrictedView):
 
 
 class ViewResultsButton(discord.ui.Button):
-    def __init__(self, parent_view: ResultsPanelView):
+    def __init__(self, parent_view: ResultsPanelView, disabled: bool = False):
         self.parent_view = parent_view
-        super().__init__(label="View Results", style=discord.ButtonStyle.secondary)
+        super().__init__(
+            label="View Results",
+            style=discord.ButtonStyle.secondary,
+            disabled=disabled,
+        )
 
     async def callback(self, interaction: discord.Interaction):
         fixture_id = self.parent_view.selection.fixture_id
@@ -74,9 +78,13 @@ class ViewResultsButton(discord.ui.Button):
 
 
 class CorrectResultsButton(discord.ui.Button):
-    def __init__(self, parent_view: ResultsPanelView):
+    def __init__(self, parent_view: ResultsPanelView, disabled: bool = False):
         self.parent_view = parent_view
-        super().__init__(label="Correct Results", style=discord.ButtonStyle.primary)
+        super().__init__(
+            label="Correct Results",
+            style=discord.ButtonStyle.primary,
+            disabled=disabled,
+        )
 
     async def callback(self, interaction: discord.Interaction):
         fixture_id = self.parent_view.selection.fixture_id


### PR DESCRIPTION
## Summary
- disable admin panel action buttons until the required fixture or user selection exists
- refresh button state as fixture and user selections change, including stale selection cases
- cover prediction, fixture, and results panel enablement with focused admin panel tests

Closes #151

## Testing
- `uv run pytest tests/test_admin_panel.py --tb=short`
- `uv run ruff check typer_bot/commands/admin_panel tests/test_admin_panel.py`
- `uv run ty check typer_bot`
