### PR TITLE
feat: inline admin panel selection state

### DIFF
--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -25,6 +25,10 @@ def _get_button(view: discord.ui.View, label: str) -> discord.ui.Button:
     return next(child for child in view.children if getattr(child, "label", None) == label)
 
 
+def _has_button(view: discord.ui.View, label: str) -> bool:
+    return any(getattr(child, "label", None) == label for child in view.children)
+
+
 class TestAdminPanelCommand:
     """The slash entrypoint should open the panel."""
 
@@ -126,22 +130,200 @@ class TestPredictionPanelFlows:
         )
         await view.load_fixture_options()
 
-        assert _get_button(view, "View Predictions").disabled is True
+        assert _has_button(view, "View Predictions") is False
         assert _get_button(view, "Replace Prediction").disabled is True
         assert _get_button(view, "Toggle Late Waiver").disabled is True
 
         view.fixture_select._values = [str(fixture_id)]
         await view.fixture_select.callback(mock_interaction_admin)
 
-        assert _get_button(view, "View Predictions").disabled is False
+        assert "Fixture: Week 1 [OPEN]" in mock_interaction_admin.response_sent[-1]["content"]
+        assert (
+            "Pick a user to inspect or override a stored prediction."
+            in mock_interaction_admin.response_sent[-1]["content"]
+        )
         assert _get_button(view, "Replace Prediction").disabled is True
         assert _get_button(view, "Toggle Late Waiver").disabled is True
 
         view.user_select._values = ["user-1"]
         await view.user_select.callback(mock_interaction_admin)
 
+        assert "User: User One (on time)" in mock_interaction_admin.response_sent[-1]["content"]
+        assert "1. Team A - Team B 1-0" in mock_interaction_admin.response_sent[-1]["content"]
+        assert "3. Team E - Team F 0-2" in mock_interaction_admin.response_sent[-1]["content"]
         assert _get_button(view, "Replace Prediction").disabled is False
         assert _get_button(view, "Toggle Late Waiver").disabled is False
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_shows_no_predictions_inline_after_fixture_selection(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            10, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        assert "Fixture: Week 10 [OPEN]" in mock_interaction_admin.response_sent[-1]["content"]
+        assert (
+            "No predictions saved for this fixture yet."
+            in mock_interaction_admin.response_sent[-1]["content"]
+        )
+        assert _get_button(view, "Replace Prediction").disabled is True
+        assert _get_button(view, "Toggle Late Waiver").disabled is True
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_keeps_view_button_for_overflowing_user_lists(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            17, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        for index in range(30):
+            await admin_cog.db.save_prediction(
+                fixture_id,
+                f"user-{index}",
+                f"User {index:02d}",
+                ["1-0", "1-1", "0-2"],
+                False,
+            )
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        assert _has_button(view, "View Predictions") is True
+        assert (
+            "More than 25 users predicted this fixture."
+            in mock_interaction_admin.response_sent[-1]["content"]
+        )
+
+        view_button = _get_button(view, "View Predictions")
+        await view_button.callback(mock_interaction_admin)
+
+        assert "**Week 17 Predictions**" in mock_interaction_admin.response_sent[-1]["content"]
+        assert "User 29" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_view_predictions_recovers_when_fixture_is_deleted(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            19, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        for index in range(26):
+            await admin_cog.db.save_prediction(
+                fixture_id,
+                f"user-{index}",
+                f"User {index:02d}",
+                ["1-0", "1-1", "0-2"],
+                False,
+            )
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        await admin_cog.db.delete_fixture(fixture_id)
+
+        view_button = _get_button(view, "View Predictions")
+        await view_button.callback(mock_interaction_admin)
+
+        assert view.selection.fixture_id is None
+        assert "Fixture not found" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_view_predictions_recovers_when_predictions_disappear(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            22, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        for index in range(26):
+            await admin_cog.db.save_prediction(
+                fixture_id,
+                f"user-{index}",
+                f"User {index:02d}",
+                ["1-0", "1-1", "0-2"],
+                False,
+            )
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        for index in range(26):
+            await admin_cog.db.delete_prediction(fixture_id, f"user-{index}")
+
+        view_button = _get_button(view, "View Predictions")
+        await view_button.callback(mock_interaction_admin)
+
+        assert (
+            "No predictions saved for this fixture"
+            in mock_interaction_admin.response_sent[-1]["content"]
+        )
+        assert view.user_select.disabled is True
+        assert _has_button(view, "View Predictions") is False
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_view_predictions_truncates_long_summary(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+    ):
+        games = [
+            f"Very Long Home Team {index:02d} - Very Long Away Team {index:02d}"
+            for index in range(1, 21)
+        ]
+        fixture_id = await admin_cog.db.create_fixture(
+            20, games, datetime.now(UTC) + timedelta(days=1)
+        )
+        for index in range(26):
+            await admin_cog.db.save_prediction(
+                fixture_id,
+                f"user-{index}",
+                f"Very Long User Name {index:02d}",
+                ["1-0"] * len(games),
+                False,
+            )
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        view_button = _get_button(view, "View Predictions")
+        await view_button.callback(mock_interaction_admin)
+
+        content = mock_interaction_admin.response_sent[-1]["content"]
+        assert len(content) <= 1900
+        assert "content truncated" in content
 
     @pytest.mark.asyncio
     async def test_prediction_panel_replace_opens_modal(
@@ -181,6 +363,76 @@ class TestPredictionPanelFlows:
         assert mock_interaction_admin.modal_sent["modal"].title == "Replace Week 1 Prediction"
 
     @pytest.mark.asyncio
+    async def test_prediction_panel_replace_recovers_when_prediction_is_deleted(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            13, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-2"],
+            False,
+        )
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["user-1"]
+        await view.user_select.callback(mock_interaction_admin)
+        await admin_cog.db.delete_prediction(fixture_id, "user-1")
+
+        replace_button = _get_button(view, "Replace Prediction")
+        await replace_button.callback(mock_interaction_admin)
+
+        assert view.selection.user_id is None
+        assert "no longer available" in mock_interaction_admin.response_sent[-1]["content"].lower()
+        assert _get_button(view, "Replace Prediction").disabled is True
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_recovers_when_fixture_disappears_before_user_selection(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            11, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-2"],
+            False,
+        )
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        await admin_cog.db.delete_fixture(fixture_id)
+
+        view.user_select._values = ["user-1"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        assert view.selection.fixture_id is None
+        assert view.selection.user_id is None
+        assert "Fixture no longer exists" in mock_interaction_admin.response_sent[-1]["content"]
+        assert _get_button(view, "Replace Prediction").disabled is True
+        assert _get_button(view, "Toggle Late Waiver").disabled is True
+
+    @pytest.mark.asyncio
     async def test_prediction_panel_toggle_waiver_updates_status(
         self,
         admin_cog,
@@ -218,6 +470,46 @@ class TestPredictionPanelFlows:
         assert prediction is not None
         assert prediction["late_penalty_waived"] == 1
         assert "waiver enabled" in mock_interaction_admin.response_sent[-1]["content"].lower()
+        assert (
+            "User: User One (late, waiver active)"
+            in mock_interaction_admin.response_sent[-1]["content"]
+        )
+        assert "1. Team A - Team B 1-0" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_toggle_waiver_recovers_when_prediction_is_deleted(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            18, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-2"],
+            True,
+        )
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["user-1"]
+        await view.user_select.callback(mock_interaction_admin)
+        await admin_cog.db.delete_prediction(fixture_id, "user-1")
+
+        toggle_button = _get_button(view, "Toggle Late Waiver")
+        await toggle_button.callback(mock_interaction_admin)
+
+        assert view.selection.user_id is None
+        assert "no longer available" in mock_interaction_admin.response_sent[-1]["content"].lower()
+        assert _get_button(view, "Toggle Late Waiver").disabled is True
 
 
 class TestFixturePanelFlows:
@@ -270,6 +562,7 @@ class TestFixturePanelFlows:
         view.fixture_select._values = [str(fixture_id)]
         await view.fixture_select.callback(mock_interaction_admin)
 
+        assert "Fixture: Week 5 [OPEN]" in mock_interaction_admin.response_sent[-1]["content"]
         assert _get_button(view, "Delete Fixture").disabled is False
 
     @pytest.mark.asyncio
@@ -457,13 +750,15 @@ class TestResultsPanelFlows:
         )
         await view.load_fixture_options()
 
-        assert _get_button(view, "View Results").disabled is True
+        assert _has_button(view, "View Results") is False
         assert _get_button(view, "Correct Results").disabled is True
 
         view.fixture_select._values = [str(fixture_id)]
         await view.fixture_select.callback(mock_interaction_admin)
 
-        assert _get_button(view, "View Results").disabled is False
+        assert "Fixture: Week 4 [OPEN]" in mock_interaction_admin.response_sent[-1]["content"]
+        assert "1. Team A - Team B 1-0" in mock_interaction_admin.response_sent[-1]["content"]
+        assert "3. Team E - Team F 0-0" in mock_interaction_admin.response_sent[-1]["content"]
         assert _get_button(view, "Correct Results").disabled is False
 
     @pytest.mark.asyncio
@@ -495,6 +790,80 @@ class TestResultsPanelFlows:
             in mock_interaction_admin.response_sent[-1]["content"]
         )
 
+    @pytest.mark.asyncio
+    async def test_results_panel_correct_recovers_when_fixture_is_deleted(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            14, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+
+        view = ResultsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        await admin_cog.db.delete_fixture(fixture_id)
+
+        correct_button = _get_button(view, "Correct Results")
+        await correct_button.callback(mock_interaction_admin)
+
+        assert view.selection.fixture_id is None
+        assert "Fixture no longer exists" in mock_interaction_admin.response_sent[-1]["content"]
+        assert _get_button(view, "Correct Results").disabled is True
+
+    @pytest.mark.asyncio
+    async def test_fixture_select_removes_deleted_fixture_option(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            23, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        view = ResultsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        await admin_cog.db.delete_fixture(fixture_id)
+
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        assert view.fixture_select.options[0].label == "No fixtures available"
+
+    @pytest.mark.asyncio
+    async def test_results_panel_truncates_long_inline_preview(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+    ):
+        games = [
+            f"Very Long Home Team {index:02d} - Very Long Away Team {index:02d}"
+            for index in range(1, 101)
+        ]
+        fixture_id = await admin_cog.db.create_fixture(
+            12, games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0"] * len(games))
+
+        view = ResultsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        content = mock_interaction_admin.response_sent[-1]["content"]
+        assert len(content) <= 1900
+        assert "content truncated" in content
+
 
 class TestAdminPanelModals:
     """Modal submit paths should reject stale permissions."""
@@ -524,6 +893,11 @@ class TestAdminPanelModals:
         view = PredictionsPanelView(
             admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
         )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["user-1"]
+        await view.user_select.callback(mock_interaction_admin)
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
         prediction = await admin_cog.db.get_prediction(fixture_id, "user-1")
         assert fixture is not None
@@ -574,6 +948,94 @@ class TestAdminPanelModals:
         assert _get_button(view, "Toggle Late Waiver").disabled is True
 
     @pytest.mark.asyncio
+    async def test_replace_prediction_modal_updates_inline_panel_content(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            15, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-0"],
+            False,
+        )
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["user-1"]
+        await view.user_select.callback(mock_interaction_admin)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        prediction = await admin_cog.db.get_prediction(fixture_id, "user-1")
+        assert fixture is not None
+        assert prediction is not None
+
+        modal = ReplacePredictionModal(view, fixture, prediction)
+        modal.predictions_input._value = (
+            "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+        )
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert (
+            "Replaced User One's prediction in week 15."
+            in mock_interaction_admin.response_sent[-1]["content"]
+        )
+        assert "1. Team A - Team B 2-1" in mock_interaction_admin.response_sent[-1]["content"]
+        assert "User: User One (on time)" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_replace_prediction_modal_recovers_when_prediction_disappears(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            21, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-0"],
+            False,
+        )
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["user-1"]
+        await view.user_select.callback(mock_interaction_admin)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        prediction = await admin_cog.db.get_prediction(fixture_id, "user-1")
+        assert fixture is not None
+        assert prediction is not None
+        await admin_cog.db.delete_prediction(fixture_id, "user-1")
+
+        modal = ReplacePredictionModal(view, fixture, prediction)
+        modal.predictions_input._value = (
+            "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+        )
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert view.selection.user_id is None
+        assert (
+            "Prediction not found for that user"
+            in mock_interaction_admin.response_sent[-1]["content"]
+        )
+
+    @pytest.mark.asyncio
     async def test_correct_results_modal_rechecks_admin_permission(
         self,
         admin_cog,
@@ -587,6 +1049,9 @@ class TestAdminPanelModals:
         view = ResultsPanelView(
             admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
         )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
         assert fixture is not None
 
@@ -613,6 +1078,9 @@ class TestAdminPanelModals:
         view = ResultsPanelView(
             admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
         )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
         assert fixture is not None
 
@@ -638,6 +1106,9 @@ class TestAdminPanelModals:
         view = ResultsPanelView(
             admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
         )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
         assert fixture is not None
 
@@ -646,3 +1117,35 @@ class TestAdminPanelModals:
         assert modal.results_input.default == (
             "1. Team A - Team B 1-0\n2. Team C - Team D 1-1\n3. Team E - Team F 0-0"
         )
+
+    @pytest.mark.asyncio
+    async def test_correct_results_modal_updates_inline_panel_content(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            16, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+        view = ResultsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
+        modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert (
+            "Saved corrected results for week 16."
+            in mock_interaction_admin.response_sent[-1]["content"]
+        )
+        assert "1. Team A - Team B 2-1" in mock_interaction_admin.response_sent[-1]["content"]
+        assert "Fixture: Week 16 [OPEN]" in mock_interaction_admin.response_sent[-1]["content"]

--- a/typer_bot/commands/admin_panel/base.py
+++ b/typer_bot/commands/admin_panel/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import discord
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from .results import ResultsPanelView
 
 MAX_SELECT_OPTIONS = 25
+MAX_PANEL_CONTENT_LENGTH = 1900
 
 
 def _fixture_select_label(fixture: dict) -> str:
@@ -30,7 +31,50 @@ def _fixture_select_description(fixture: dict) -> str:
 
 
 def _format_prediction_line(index: int, game: str, prediction: str) -> str:
+    """Format a per-match score line for prediction or result displays."""
+
     return f"{index}. {game} {prediction}"
+
+
+def _build_detail_lines(games: list[str], values: list[str]) -> list[str]:
+    """Format per-match detail lines, truncating to the shorter input list.
+
+    This intentionally drops unmatched trailing items if the inputs differ.
+    """
+
+    return [
+        _format_prediction_line(index, game, value)
+        for index, (game, value) in enumerate(zip(games, values, strict=False), 1)
+    ]
+
+
+def _render_panel_content(lines: list[str]) -> str:
+    """Join panel lines under Discord's message limit.
+
+    Uses a 1900-char safety cap so panel edits stay below Discord's 2000-char
+    hard limit after adding a truncation marker when needed.
+    """
+
+    content = ""
+    suffix = "\n\n... content truncated."
+    for line in lines:
+        candidate = f"{content}\n{line}" if content else line
+        if len(candidate) <= MAX_PANEL_CONTENT_LENGTH:
+            content = candidate
+            continue
+
+        if not content:
+            return line[: MAX_PANEL_CONTENT_LENGTH - 3] + "..."
+
+        if len(suffix) >= MAX_PANEL_CONTENT_LENGTH:
+            return content[:MAX_PANEL_CONTENT_LENGTH]
+
+        if len(content) + len(suffix) <= MAX_PANEL_CONTENT_LENGTH:
+            return content + suffix
+
+        return content[: MAX_PANEL_CONTENT_LENGTH - len(suffix)] + suffix
+
+    return content
 
 
 def _prediction_status_text(prediction: dict) -> str:
@@ -43,10 +87,17 @@ def _prediction_status_text(prediction: dict) -> str:
 
 @dataclass(slots=True)
 class PanelSelectionState:
-    """Shared selection state for admin panel flows."""
+    """Shared render state for admin panel subviews.
+
+    `fixture_label`, `user_label`, and `detail_lines` drive the inline panel body.
+    `status_message` carries transient feedback after selections or admin actions.
+    """
 
     fixture_id: int | None = None
     user_id: str | None = None
+    fixture_label: str = ""
+    user_label: str = ""
+    detail_lines: list[str] = field(default_factory=list)
     status_message: str = ""
 
 
@@ -134,7 +185,13 @@ class BackButton(discord.ui.Button):
 
 
 class FixtureSelect(discord.ui.Select):
-    """Shared fixture selector that updates panel selection state in place."""
+    """Shared fixture selector that updates panel selection state in place.
+
+    Before hooks run, the selector clears user/detail state and refreshes the
+    selected fixture label + status. Subviews can optionally react to fixture
+    changes by exposing `populate_fixture_details()` and/or `load_user_options()`.
+    The selector calls those hooks before re-rendering the panel.
+    """
 
     def __init__(
         self,
@@ -171,16 +228,25 @@ class FixtureSelect(discord.ui.Select):
 
         fixture_id = int(self.values[0])
         self.parent_view.selection.user_id = None
+        self.parent_view.selection.user_label = ""
+        self.parent_view.selection.detail_lines = []
 
         fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
         if fixture is None:
             self.parent_view.selection.fixture_id = None
+            self.parent_view.selection.fixture_label = ""
             self.parent_view.selection.status_message = "Fixture no longer exists."
+            load_fixture_options = getattr(self.parent_view, "load_fixture_options", None)
+            if callable(load_fixture_options):
+                await load_fixture_options()
         else:
             self.parent_view.selection.fixture_id = fixture_id
-            self.parent_view.selection.status_message = (
-                f"Selected week {fixture['week_number']} ({fixture['status']})."
-            )
+            self.parent_view.selection.fixture_label = _fixture_select_label(fixture)
+            self.parent_view.selection.status_message = ""
+
+        populate_fixture_details = getattr(self.parent_view, "populate_fixture_details", None)
+        if callable(populate_fixture_details):
+            await populate_fixture_details(fixture)
 
         load_user_options = getattr(self.parent_view, "load_user_options", None)
         if callable(load_user_options):

--- a/typer_bot/commands/admin_panel/fixtures.py
+++ b/typer_bot/commands/admin_panel/fixtures.py
@@ -12,7 +12,13 @@ from typer_bot.database import Database
 from typer_bot.services import AdminService
 from typer_bot.utils import is_admin
 
-from .base import BackButton, FixtureSelect, OwnerRestrictedView, PanelSelectionState
+from .base import (
+    BackButton,
+    FixtureSelect,
+    OwnerRestrictedView,
+    PanelSelectionState,
+    _render_panel_content,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -77,11 +83,23 @@ class FixturesPanelView(OwnerRestrictedView):
         self.fixture_select.update_options(fixtures)
 
     def render_content(self) -> str:
-        status = (
-            self.selection.status_message
-            or "Select an open fixture to delete, or use `/admin fixture create` for new fixtures."
-        )
-        return "**Admin Panel - Fixtures**\n" + status
+        lines = ["**Admin Panel - Fixtures**"]
+        if self.selection.fixture_label:
+            lines.append(f"Fixture: {self.selection.fixture_label}")
+            lines.extend(
+                [
+                    "",
+                    "Delete the selected open fixture, or use `/admin fixture create` for new fixtures.",
+                ]
+            )
+        else:
+            lines.append(
+                "Select an open fixture to delete, or use `/admin fixture create` for new fixtures."
+            )
+
+        if self.selection.status_message:
+            lines.extend(["", self.selection.status_message])
+        return _render_panel_content(lines)
 
 
 class FixturesDeleteButton(discord.ui.Button):

--- a/typer_bot/commands/admin_panel/modals.py
+++ b/typer_bot/commands/admin_panel/modals.py
@@ -8,7 +8,7 @@ import discord
 
 from typer_bot.utils import is_admin
 
-from .base import _format_prediction_line
+from .base import _build_detail_lines, _format_prediction_line, _prediction_status_text
 
 if TYPE_CHECKING:
     from .predictions import PredictionsPanelView
@@ -58,6 +58,27 @@ class ReplacePredictionModal(discord.ui.Modal):
                 str(interaction.user.id),
             )
         except ValueError as exc:
+            if str(exc) in {
+                "Fixture not found",
+                "Prediction not found for that user",
+                "Prediction disappeared after update",
+            }:
+                self.parent_view.selection.user_id = None
+                self.parent_view.selection.user_label = ""
+                self.parent_view.selection.detail_lines = []
+                self.parent_view.selection.status_message = str(exc)
+                if str(exc) == "Fixture not found":
+                    self.parent_view.selection.fixture_id = None
+                    self.parent_view.selection.fixture_label = ""
+                    await self.parent_view.load_fixture_options()
+                await self.parent_view.load_user_options()
+                self.parent_view._refresh_items()
+                await interaction.response.edit_message(
+                    content=self.parent_view.render_content(),
+                    view=self.parent_view,
+                )
+                return
+
             await interaction.response.send_message(str(exc), ephemeral=True)
             return
 
@@ -65,7 +86,15 @@ class ReplacePredictionModal(discord.ui.Modal):
         if recalculation is not None:
             self.parent_view.selection.status_message += " Scores were recalculated."
 
+        self.parent_view.selection.user_label = (
+            f"{updated_prediction['user_name']} ({_prediction_status_text(updated_prediction)})"
+        )
+        self.parent_view.selection.detail_lines = _build_detail_lines(
+            fixture["games"], updated_prediction["predictions"]
+        )
+
         await self.parent_view.load_user_options()
+        self.parent_view._refresh_items()
         await interaction.response.edit_message(
             content=self.parent_view.render_content(),
             view=self.parent_view,
@@ -116,6 +145,19 @@ class CorrectResultsModal(discord.ui.Modal):
                 self.results_input.value,
             )
         except ValueError as exc:
+            if str(exc) == "Fixture not found":
+                self.parent_view.selection.fixture_id = None
+                self.parent_view.selection.fixture_label = ""
+                self.parent_view.selection.detail_lines = []
+                self.parent_view.selection.status_message = str(exc)
+                await self.parent_view.load_fixture_options()
+                self.parent_view._refresh_items()
+                await interaction.response.edit_message(
+                    content=self.parent_view.render_content(),
+                    view=self.parent_view,
+                )
+                return
+
             await interaction.response.send_message(str(exc), ephemeral=True)
             return
 
@@ -124,6 +166,10 @@ class CorrectResultsModal(discord.ui.Modal):
         )
         if recalculation is not None:
             self.parent_view.selection.status_message += " Scores were recalculated."
+
+        self.parent_view.selection.detail_lines = _build_detail_lines(fixture["games"], _results)
+
+        self.parent_view._refresh_items()
 
         await interaction.response.edit_message(
             content=self.parent_view.render_content(),

--- a/typer_bot/commands/admin_panel/predictions.py
+++ b/typer_bot/commands/admin_panel/predictions.py
@@ -13,7 +13,9 @@ from .base import (
     FixtureSelect,
     OwnerRestrictedView,
     PanelSelectionState,
+    _build_detail_lines,
     _prediction_status_text,
+    _render_panel_content,
 )
 from .modals import ReplacePredictionModal
 
@@ -24,6 +26,7 @@ class PredictionsPanelView(OwnerRestrictedView):
     def __init__(self, db: Database, service: AdminService, owner_user_id: str):
         super().__init__(db, service, owner_user_id)
         self.selection = PanelSelectionState()
+        self.has_user_overflow = False
         self.fixture_select = FixtureSelect(self)
         self.user_select = PredictionUserSelect(self)
         self.user_select.update_options([])
@@ -33,7 +36,8 @@ class PredictionsPanelView(OwnerRestrictedView):
         self.clear_items()
         self.add_item(self.fixture_select)
         self.add_item(self.user_select)
-        self.add_item(ViewPredictionsButton(self, disabled=self.selection.fixture_id is None))
+        if self.has_user_overflow:
+            self.add_item(ViewPredictionsButton(self, disabled=self.selection.fixture_id is None))
         self.add_item(
             ReplacePredictionButton(
                 self,
@@ -54,17 +58,44 @@ class PredictionsPanelView(OwnerRestrictedView):
 
     async def load_user_options(self) -> None:
         if self.selection.fixture_id is None:
+            self.has_user_overflow = False
             self.user_select.update_options([])
             return
 
         predictions = await self.db.get_all_predictions(self.selection.fixture_id)
+        self.has_user_overflow = len(predictions) > MAX_SELECT_OPTIONS
         self.user_select.update_options(predictions)
 
     def render_content(self) -> str:
-        status = self.selection.status_message or (
-            "Select a fixture, then pick a user to view or override a stored prediction."
-        )
-        return "**Admin Panel - Predictions**\n" + status
+        lines = ["**Admin Panel - Predictions**"]
+        if self.selection.fixture_label:
+            header = f"Fixture: {self.selection.fixture_label}"
+            if self.selection.user_label:
+                header += f"  •  User: {self.selection.user_label}"
+            lines.append(header)
+            if self.selection.status_message:
+                lines.extend(["", self.selection.status_message])
+            if self.selection.detail_lines:
+                lines.extend(["", *self.selection.detail_lines])
+            elif self.user_select.disabled:
+                lines.extend(["", "No predictions saved for this fixture yet."])
+            elif self.selection.user_id is None:
+                lines.extend(["", "Pick a user to inspect or override a stored prediction."])
+
+            if self.has_user_overflow:
+                lines.extend(
+                    [
+                        "",
+                        "More than 25 users predicted this fixture. Use View Predictions for the full list.",
+                    ]
+                )
+        else:
+            lines.append(
+                "Select a fixture, then pick a user to inspect or override a stored prediction."
+            )
+            if self.selection.status_message:
+                lines.extend(["", self.selection.status_message])
+        return _render_panel_content(lines)
 
 
 class PredictionUserSelect(discord.ui.Select):
@@ -107,15 +138,39 @@ class PredictionUserSelect(discord.ui.Select):
             await interaction.response.send_message("Select a fixture first.", ephemeral=True)
             return
 
+        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
+        if fixture is None:
+            self.parent_view.selection.fixture_id = None
+            self.parent_view.selection.fixture_label = ""
+            self.parent_view.selection.user_id = None
+            self.parent_view.selection.user_label = ""
+            self.parent_view.selection.detail_lines = []
+            self.parent_view.selection.status_message = "Fixture no longer exists."
+            await self.parent_view.load_fixture_options()
+            await self.parent_view.load_user_options()
+            self.parent_view._refresh_items()
+            await interaction.response.edit_message(
+                content=self.parent_view.render_content(),
+                view=self.parent_view,
+            )
+            return
+
         prediction = await self.parent_view.db.get_prediction(fixture_id, selected_user_id)
         if prediction is None:
             self.parent_view.selection.user_id = None
+            self.parent_view.selection.user_label = ""
+            self.parent_view.selection.detail_lines = []
             self.parent_view.selection.status_message = "Prediction no longer exists."
+            await self.parent_view.load_user_options()
         else:
             self.parent_view.selection.user_id = selected_user_id
-            self.parent_view.selection.status_message = (
-                f"Selected {prediction['user_name']} ({_prediction_status_text(prediction)})."
+            self.parent_view.selection.user_label = (
+                f"{prediction['user_name']} ({_prediction_status_text(prediction)})"
             )
+            self.parent_view.selection.detail_lines = _build_detail_lines(
+                fixture["games"], prediction["predictions"]
+            )
+            self.parent_view.selection.status_message = ""
 
         self.parent_view._refresh_items()
 
@@ -123,39 +178,6 @@ class PredictionUserSelect(discord.ui.Select):
             content=self.parent_view.render_content(),
             view=self.parent_view,
         )
-
-
-class ViewPredictionsButton(discord.ui.Button):
-    def __init__(self, parent_view: PredictionsPanelView, disabled: bool = False):
-        self.parent_view = parent_view
-        super().__init__(
-            label="View Predictions",
-            style=discord.ButtonStyle.secondary,
-            disabled=disabled,
-        )
-
-    async def callback(self, interaction: discord.Interaction):
-        fixture_id = self.parent_view.selection.fixture_id
-        if fixture_id is None:
-            await interaction.response.send_message("Select a fixture first.", ephemeral=True)
-            return
-
-        try:
-            (
-                fixture,
-                predictions,
-            ) = await self.parent_view.service.get_fixture_prediction_summary(fixture_id)
-        except ValueError as exc:
-            await interaction.response.send_message(str(exc), ephemeral=True)
-            return
-
-        lines = [f"**Week {fixture['week_number']} Predictions**"]
-        for prediction in predictions:
-            status = _prediction_status_text(prediction)
-            scores = ", ".join(prediction["predictions"])
-            lines.append(f"- {prediction['user_name']}: {scores} ({status})")
-
-        await interaction.response.send_message("\n".join(lines), ephemeral=True)
 
 
 class ReplacePredictionButton(discord.ui.Button):
@@ -178,14 +200,96 @@ class ReplacePredictionButton(discord.ui.Button):
 
         fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
         prediction = await self.parent_view.db.get_prediction(fixture_id, user_id)
-        if fixture is None or prediction is None:
-            await interaction.response.send_message(
-                "That prediction is no longer available.", ephemeral=True
+        if fixture is None:
+            self.parent_view.selection.fixture_id = None
+            self.parent_view.selection.fixture_label = ""
+            self.parent_view.selection.user_id = None
+            self.parent_view.selection.user_label = ""
+            self.parent_view.selection.detail_lines = []
+            self.parent_view.selection.status_message = "Fixture no longer exists."
+            await self.parent_view.load_fixture_options()
+            await self.parent_view.load_user_options()
+            self.parent_view._refresh_items()
+            await interaction.response.edit_message(
+                content=self.parent_view.render_content(),
+                view=self.parent_view,
+            )
+            return
+        if prediction is None:
+            self.parent_view.selection.user_id = None
+            self.parent_view.selection.user_label = ""
+            self.parent_view.selection.detail_lines = []
+            self.parent_view.selection.status_message = "That prediction is no longer available."
+            await self.parent_view.load_user_options()
+            self.parent_view._refresh_items()
+            await interaction.response.edit_message(
+                content=self.parent_view.render_content(),
+                view=self.parent_view,
             )
             return
 
         modal = ReplacePredictionModal(self.parent_view, fixture, prediction)
         await interaction.response.send_modal(modal)
+
+
+class ViewPredictionsButton(discord.ui.Button):
+    def __init__(self, parent_view: PredictionsPanelView, disabled: bool = False):
+        self.parent_view = parent_view
+        super().__init__(
+            label="View Predictions",
+            style=discord.ButtonStyle.secondary,
+            disabled=disabled,
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        fixture_id = self.parent_view.selection.fixture_id
+        if fixture_id is None:
+            await interaction.response.send_message("Select a fixture first.", ephemeral=True)
+            return
+
+        try:
+            fixture, predictions = await self.parent_view.service.get_fixture_prediction_summary(
+                fixture_id
+            )
+        except ValueError as exc:
+            if str(exc) == "Fixture not found":
+                self.parent_view.selection.fixture_id = None
+                self.parent_view.selection.fixture_label = ""
+                self.parent_view.selection.user_id = None
+                self.parent_view.selection.user_label = ""
+                self.parent_view.selection.detail_lines = []
+                self.parent_view.selection.status_message = str(exc)
+                await self.parent_view.load_fixture_options()
+                await self.parent_view.load_user_options()
+                self.parent_view._refresh_items()
+                await interaction.response.edit_message(
+                    content=self.parent_view.render_content(),
+                    view=self.parent_view,
+                )
+                return
+            if str(exc) == "No predictions saved for this fixture":
+                self.parent_view.selection.user_id = None
+                self.parent_view.selection.user_label = ""
+                self.parent_view.selection.detail_lines = []
+                self.parent_view.selection.status_message = str(exc)
+                await self.parent_view.load_user_options()
+                self.parent_view._refresh_items()
+                await interaction.response.edit_message(
+                    content=self.parent_view.render_content(),
+                    view=self.parent_view,
+                )
+                return
+
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
+
+        lines = [f"**Week {fixture['week_number']} Predictions**"]
+        for prediction in predictions:
+            status = _prediction_status_text(prediction)
+            scores = ", ".join(prediction["predictions"])
+            lines.append(f"- {prediction['user_name']}: {scores} ({status})")
+
+        await interaction.response.send_message(_render_panel_content(lines), ephemeral=True)
 
 
 class ToggleWaiverButton(discord.ui.Button):
@@ -206,6 +310,37 @@ class ToggleWaiverButton(discord.ui.Button):
             )
             return
 
+        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
+        if fixture is None:
+            self.parent_view.selection.fixture_id = None
+            self.parent_view.selection.fixture_label = ""
+            self.parent_view.selection.user_id = None
+            self.parent_view.selection.user_label = ""
+            self.parent_view.selection.detail_lines = []
+            self.parent_view.selection.status_message = "Fixture no longer exists."
+            await self.parent_view.load_fixture_options()
+            await self.parent_view.load_user_options()
+            self.parent_view._refresh_items()
+            await interaction.response.edit_message(
+                content=self.parent_view.render_content(),
+                view=self.parent_view,
+            )
+            return
+
+        prediction = await self.parent_view.db.get_prediction(fixture_id, user_id)
+        if prediction is None:
+            self.parent_view.selection.user_id = None
+            self.parent_view.selection.user_label = ""
+            self.parent_view.selection.detail_lines = []
+            self.parent_view.selection.status_message = "That prediction is no longer available."
+            await self.parent_view.load_user_options()
+            self.parent_view._refresh_items()
+            await interaction.response.edit_message(
+                content=self.parent_view.render_content(),
+                view=self.parent_view,
+            )
+            return
+
         try:
             (
                 fixture,
@@ -216,6 +351,37 @@ class ToggleWaiverButton(discord.ui.Button):
                 user_id,
             )
         except ValueError as exc:
+            if str(exc) == "Fixture not found":
+                self.parent_view.selection.fixture_id = None
+                self.parent_view.selection.fixture_label = ""
+                self.parent_view.selection.user_id = None
+                self.parent_view.selection.user_label = ""
+                self.parent_view.selection.detail_lines = []
+                self.parent_view.selection.status_message = str(exc)
+                await self.parent_view.load_fixture_options()
+                await self.parent_view.load_user_options()
+                self.parent_view._refresh_items()
+                await interaction.response.edit_message(
+                    content=self.parent_view.render_content(),
+                    view=self.parent_view,
+                )
+                return
+            if str(exc) in {
+                "Prediction not found for that user",
+                "Prediction disappeared after waiver update",
+            }:
+                self.parent_view.selection.user_id = None
+                self.parent_view.selection.user_label = ""
+                self.parent_view.selection.detail_lines = []
+                self.parent_view.selection.status_message = str(exc)
+                await self.parent_view.load_user_options()
+                self.parent_view._refresh_items()
+                await interaction.response.edit_message(
+                    content=self.parent_view.render_content(),
+                    view=self.parent_view,
+                )
+                return
+
             await interaction.response.send_message(str(exc), ephemeral=True)
             return
 
@@ -226,7 +392,15 @@ class ToggleWaiverButton(discord.ui.Button):
         if recalculation is not None:
             self.parent_view.selection.status_message += " Scores were recalculated."
 
+        self.parent_view.selection.user_label = (
+            f"{prediction['user_name']} ({_prediction_status_text(prediction)})"
+        )
+        self.parent_view.selection.detail_lines = _build_detail_lines(
+            fixture["games"], prediction["predictions"]
+        )
+
         await self.parent_view.load_user_options()
+        self.parent_view._refresh_items()
         await interaction.response.edit_message(
             content=self.parent_view.render_content(),
             view=self.parent_view,

--- a/typer_bot/commands/admin_panel/results.py
+++ b/typer_bot/commands/admin_panel/results.py
@@ -13,7 +13,8 @@ from .base import (
     FixtureSelect,
     OwnerRestrictedView,
     PanelSelectionState,
-    _format_prediction_line,
+    _build_detail_lines,
+    _render_panel_content,
 )
 from .modals import CorrectResultsModal
 
@@ -30,7 +31,6 @@ class ResultsPanelView(OwnerRestrictedView):
     def _refresh_items(self) -> None:
         self.clear_items()
         self.add_item(self.fixture_select)
-        self.add_item(ViewResultsButton(self, disabled=self.selection.fixture_id is None))
         self.add_item(CorrectResultsButton(self, disabled=self.selection.fixture_id is None))
         self.add_item(BackButton(self))
 
@@ -38,43 +38,35 @@ class ResultsPanelView(OwnerRestrictedView):
         fixtures = await self.db.get_recent_fixtures(MAX_SELECT_OPTIONS)
         self.fixture_select.update_options(fixtures)
 
-    def render_content(self) -> str:
-        status = (
-            self.selection.status_message or "Select a fixture to inspect or correct saved results."
-        )
-        return "**Admin Panel - Results**\n" + status
+    async def populate_fixture_details(self, fixture: dict | None) -> None:
+        """Update inline result lines and empty-state message for the selection."""
 
-
-class ViewResultsButton(discord.ui.Button):
-    def __init__(self, parent_view: ResultsPanelView, disabled: bool = False):
-        self.parent_view = parent_view
-        super().__init__(
-            label="View Results",
-            style=discord.ButtonStyle.secondary,
-            disabled=disabled,
-        )
-
-    async def callback(self, interaction: discord.Interaction):
-        fixture_id = self.parent_view.selection.fixture_id
-        if fixture_id is None:
-            await interaction.response.send_message("Select a fixture first.", ephemeral=True)
-            return
-
-        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
+        self.selection.detail_lines = []
         if fixture is None:
-            await interaction.response.send_message("Fixture not found.", ephemeral=True)
-            return
-        results = await self.parent_view.db.get_results(fixture_id)
-        if not results:
-            await interaction.response.send_message(
-                "No results saved for that fixture yet.", ephemeral=True
-            )
             return
 
-        lines = [f"**Week {fixture['week_number']} Results**"]
-        for index, (game, result) in enumerate(zip(fixture["games"], results, strict=False), 1):
-            lines.append(_format_prediction_line(index, game, result))
-        await interaction.response.send_message("\n".join(lines), ephemeral=True)
+        results = await self.db.get_results(fixture["id"])
+        if not results:
+            self.selection.status_message = "No results saved for that fixture yet."
+            return
+
+        self.selection.detail_lines = _build_detail_lines(fixture["games"], results)
+
+    def render_content(self) -> str:
+        lines = ["**Admin Panel - Results**"]
+        if self.selection.fixture_label:
+            lines.append(f"Fixture: {self.selection.fixture_label}")
+            if self.selection.status_message:
+                lines.extend(["", self.selection.status_message])
+            if self.selection.detail_lines:
+                lines.extend(["", *self.selection.detail_lines])
+            elif not self.selection.status_message:
+                lines.extend(["", "No results saved for that fixture yet."])
+        else:
+            lines.append("Select a fixture to inspect or correct saved results.")
+            if self.selection.status_message:
+                lines.extend(["", self.selection.status_message])
+        return _render_panel_content(lines)
 
 
 class CorrectResultsButton(discord.ui.Button):
@@ -94,7 +86,16 @@ class CorrectResultsButton(discord.ui.Button):
 
         fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
         if fixture is None:
-            await interaction.response.send_message("Fixture not found.", ephemeral=True)
+            self.parent_view.selection.fixture_id = None
+            self.parent_view.selection.fixture_label = ""
+            self.parent_view.selection.detail_lines = []
+            self.parent_view.selection.status_message = "Fixture no longer exists."
+            await self.parent_view.load_fixture_options()
+            self.parent_view._refresh_items()
+            await interaction.response.edit_message(
+                content=self.parent_view.render_content(),
+                view=self.parent_view,
+            )
             return
         results = await self.parent_view.db.get_results(fixture_id)
         if not results:


### PR DESCRIPTION
## Summary
- render selected prediction and results data directly in the admin panel instead of requiring separate view clicks
- remove the redundant results view button and keep predictions view only as an overflow fallback for fixtures with more than 25 predictors
- harden panel state recovery for stale fixture/prediction actions and cover the new inline rendering paths with focused tests

Closes #153

## Testing
- `uv run pytest tests/test_admin_panel.py --tb=short`
- `uv run ruff check typer_bot/commands/admin_panel tests/test_admin_panel.py`
- `uv run ty check typer_bot`
