### PR TITLE
feat: move admin results entry into a modal

### DIFF
--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -10,7 +10,7 @@ from typer_bot.commands.admin_commands import (
     AdminCommands,
     PostResultsConfirmView,
 )
-from typer_bot.commands.admin_panel import OpenFixtureWarningView
+from typer_bot.commands.admin_panel import EnterResultsModal, OpenFixtureWarningView
 from typer_bot.services.admin_service import FixtureScoreResult
 from typer_bot.utils import now
 from typer_bot.utils.permissions import is_admin
@@ -144,21 +144,14 @@ class TestResultsEnterLogic:
         return AdminCommands(mock_bot)
 
     @pytest.mark.asyncio
-    async def test_results_enter_starts_session(self, admin_cog, mock_interaction_admin):
-        """DM session keeps results private before public announcement."""
-        user_id = str(mock_interaction_admin.user.id)
-        admin_cog.results_handler.start_session(user_id, 1, 111111, week_number=1)
-        assert admin_cog.results_handler.has_session(user_id)
+    async def test_results_enter_opens_modal(self, admin_cog, mock_interaction_admin, sample_games):
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        await admin_cog.db.create_fixture(1, sample_games, deadline)
 
-    @pytest.mark.asyncio
-    async def test_results_enter_session_has_correct_data(self, admin_cog, mock_interaction_admin):
-        """Session tracks fixture ID for result-to-match mapping."""
-        user_id = str(mock_interaction_admin.user.id)
-        admin_cog.results_handler.start_session(user_id, 42, 111111, week_number=5)
+        await admin_cog.results_enter.callback(admin_cog, mock_interaction_admin, 1)
 
-        session = admin_cog.results_handler.get_session(user_id)
-        assert session.fixture_id == 42
-        assert session.guild_id == 111111
+        assert isinstance(mock_interaction_admin.modal_sent["modal"], EnterResultsModal)
+        assert mock_interaction_admin.modal_sent["modal"].title == "Enter Week 1 Results"
 
     @pytest.mark.asyncio
     async def test_results_enter_rejects_fixture_that_already_has_results(
@@ -172,8 +165,6 @@ class TestResultsEnterLogic:
 
         await admin_cog.results_enter.callback(admin_cog, mock_interaction_admin, 1)
 
-        user_id = str(mock_interaction_admin.user.id)
-        assert not admin_cog.results_handler.has_session(user_id)
         assert "Results already entered" in mock_interaction_admin.response_sent[0]["content"]
         assert mock_interaction_admin.user.dm_sent == []
 
@@ -561,7 +552,7 @@ class TestCooldownLogic:
 
 
 class TestAdminSessionExclusivity:
-    """Admin DM workflows are mutually exclusive — only one active session per user."""
+    """Fixture creation DM state still blocks overlapping DM-style admin workflows."""
 
     @pytest.fixture
     def admin_cog(self, mock_bot, database):
@@ -610,9 +601,7 @@ class TestAdminSessionExclusivity:
     async def test_results_enter_blocked_when_fixture_session_active(
         self, admin_cog, mock_interaction_admin, sample_games
     ):
-        """Starting results entry while fixture creation is in progress is rejected."""
-        from datetime import UTC, datetime, timedelta
-
+        """Results modal can open even while fixture creation DM state exists."""
         deadline = datetime.now(UTC) + timedelta(days=1)
         await admin_cog.db.create_fixture(1, sample_games, deadline)
 
@@ -622,9 +611,7 @@ class TestAdminSessionExclusivity:
 
         await admin_cog.results_enter.callback(admin_cog, mock_interaction_admin, 1)
 
-        assert not admin_cog.results_handler.has_session(user_id)
-        response = mock_interaction_admin.response_sent[-1]
-        assert "fixture creation" in response["content"].lower()
+        assert isinstance(mock_interaction_admin.modal_sent["modal"], EnterResultsModal)
 
     @pytest.mark.asyncio
     async def test_fixture_create_allowed_when_no_conflicting_session(
@@ -647,18 +634,13 @@ class TestAdminSessionExclusivity:
     async def test_results_enter_allowed_when_no_conflicting_session(
         self, admin_cog, mock_interaction_admin, sample_games
     ):
-        """Results entry proceeds normally when no admin session is active."""
-        from datetime import UTC, datetime, timedelta
-
+        """Results entry opens the modal when no conflicting session exists."""
         deadline = datetime.now(UTC) + timedelta(days=1)
         await admin_cog.db.create_fixture(1, sample_games, deadline)
 
-        mock_interaction_admin.guild_id = mock_interaction_admin.guild.id
-
         await admin_cog.results_enter.callback(admin_cog, mock_interaction_admin, 1)
 
-        user_id = str(mock_interaction_admin.user.id)
-        assert admin_cog.results_handler.has_session(user_id)
+        assert isinstance(mock_interaction_admin.modal_sent["modal"], EnterResultsModal)
 
 
 class TestMultiOpenFixtureTargeting:
@@ -695,18 +677,14 @@ class TestMultiOpenFixtureTargeting:
         mock_interaction_admin,
         sample_games,
     ):
-        """Results entry session starts for the requested open fixture week."""
+        """Results modal targets the requested open fixture week."""
         deadline = datetime.now(UTC) + timedelta(days=1)
-        fixture_week_1 = await admin_cog.db.create_fixture(1, sample_games, deadline)
+        await admin_cog.db.create_fixture(1, sample_games, deadline)
         await admin_cog.db.create_fixture(2, sample_games, deadline)
-
-        mock_interaction_admin.guild_id = mock_interaction_admin.guild.id
 
         await admin_cog.results_enter.callback(admin_cog, mock_interaction_admin, 1)
 
-        user_id = str(mock_interaction_admin.user.id)
-        assert admin_cog.results_handler.get_session(user_id).fixture_id == fixture_week_1
-        assert "Check your DMs" in mock_interaction_admin.response_sent[0]["content"]
+        assert mock_interaction_admin.modal_sent["modal"].title == "Enter Week 1 Results"
 
     @pytest.mark.asyncio
     async def test_results_calculate_requires_week_when_multiple_open(

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -12,6 +12,7 @@ from typer_bot.commands.admin_panel import (
     AdminPanelHomeView,
     CorrectResultsModal,
     DeleteConfirmView,
+    EnterResultsModal,
     FixturesPanelView,
     PredictionsPanelView,
     ReplacePredictionModal,
@@ -872,6 +873,222 @@ class TestAdminPanelModals:
     def admin_cog(self, mock_bot, database):
         mock_bot.db = database
         return AdminCommands(mock_bot)
+
+    @pytest.mark.asyncio
+    async def test_enter_results_modal_prefills_fixture_template(
+        self,
+        admin_cog,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            24, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = EnterResultsModal(fixture, admin_cog.db)
+
+        assert modal.results_input.default == (
+            "Team A - Team B 2:0\nTeam C - Team D 2:0\nTeam E - Team F 2:0"
+        )
+
+    @pytest.mark.asyncio
+    async def test_enter_results_modal_shows_parse_errors(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            25, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = EnterResultsModal(fixture, admin_cog.db)
+        modal.results_input._value = "Team A - Team B\nTeam C - Team D\nTeam E - Team F"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "Could not find score" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_enter_results_modal_rechecks_admin_permission(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            28, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = EnterResultsModal(fixture, admin_cog.db)
+        modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.roles = []
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "no longer have permission" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_enter_results_modal_save_results_persists_fixture_results(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            26, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = EnterResultsModal(fixture, admin_cog.db)
+        modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        confirm_button = next(
+            child
+            for child in confirm_view.children
+            if getattr(child, "label", None) == "Save Results"
+        )
+        await confirm_button.callback(mock_interaction_admin)
+
+        assert "Results Saved!" in mock_interaction_admin.response_sent[-1]["content"]
+        assert await admin_cog.db.get_results(fixture_id) == ["2-1", "1-1", "0-2"]
+
+    @pytest.mark.asyncio
+    async def test_enter_results_modal_save_results_supports_cancelled_games(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            30, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = EnterResultsModal(fixture, admin_cog.db)
+        modal.results_input._value = "Team A - Team B x\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        confirm_button = next(
+            child
+            for child in confirm_view.children
+            if getattr(child, "label", None) == "Save Results"
+        )
+        await confirm_button.callback(mock_interaction_admin)
+
+        assert await admin_cog.db.get_results(fixture_id) == ["x", "1-1", "0-2"]
+
+    @pytest.mark.asyncio
+    async def test_enter_results_confirm_shows_save_error_when_fixture_becomes_unavailable(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            31, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = EnterResultsModal(fixture, admin_cog.db)
+        modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        await modal.on_submit(mock_interaction_admin)
+        await admin_cog.db.save_scores(
+            fixture_id,
+            [
+                {
+                    "user_id": "user-1",
+                    "user_name": "User One",
+                    "points": 3,
+                    "exact_scores": 1,
+                    "correct_results": 1,
+                }
+            ],
+        )
+
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        confirm_button = next(
+            child
+            for child in confirm_view.children
+            if getattr(child, "label", None) == "Save Results"
+        )
+        await confirm_button.callback(mock_interaction_admin)
+
+        assert "Cannot save results" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_enter_results_modal_cancel_leaves_results_unsaved(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            27, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = EnterResultsModal(fixture, admin_cog.db)
+        modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        cancel_button = next(
+            child for child in confirm_view.children if getattr(child, "label", None) == "Cancel"
+        )
+        await cancel_button.callback(mock_interaction_admin)
+
+        assert "Results entry cancelled" in mock_interaction_admin.response_sent[-1]["content"]
+        assert await admin_cog.db.get_results(fixture_id) is None
+
+    @pytest.mark.asyncio
+    async def test_enter_results_confirm_rechecks_admin_permission(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            29, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = EnterResultsModal(fixture, admin_cog.db)
+        modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        confirm_button = next(
+            child
+            for child in confirm_view.children
+            if getattr(child, "label", None) == "Save Results"
+        )
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.roles = []
+
+        await confirm_button.callback(mock_interaction_admin)
+
+        assert "no longer have permission" in mock_interaction_admin.response_sent[-1]["content"]
+        assert await admin_cog.db.get_results(fixture_id) is None
 
     @pytest.mark.asyncio
     async def test_replace_prediction_modal_rechecks_admin_permission(

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -83,7 +83,7 @@ class TestSetupHook:
 
     @pytest.mark.asyncio
     async def test_setup_hook_loads_admin_commands(self, bot_instance):
-        """Admin commands cog provides league management via DM workflows."""
+        """Admin commands cog provides league management commands."""
         await bot_instance.setup_hook()
         bot_instance.load_extension.assert_any_call("typer_bot.commands.admin_commands")
 

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -12,6 +12,7 @@ from discord.ext import commands
 from typer_bot.commands.admin_panel import (
     AdminPanelHomeView,
     DeleteConfirmView,
+    EnterResultsModal,
     OpenFixtureWarningView,
     _build_delete_confirmation_content,
 )
@@ -278,7 +279,7 @@ class AdminCommands(commands.Cog):
             ephemeral=True,
         )
 
-    @results.command(name="enter", description="Enter results for an open fixture (DM workflow)")
+    @results.command(name="enter", description="Enter results for an open fixture")
     @admin_only()
     async def results_enter(self, interaction: discord.Interaction, week: int | None = None):
         fixture = await self._resolve_open_fixture(
@@ -298,55 +299,8 @@ class AdminCommands(commands.Cog):
             )
             return
 
-        user_id = str(interaction.user.id)
-        if interaction.guild_id is None:
-            await interaction.response.send_message(
-                "Error: Invalid interaction context.", ephemeral=True
-            )
-            return
-
-        if self.workflow_state.has_fixture_session(user_id):
-            await interaction.response.send_message(
-                "❌ You have an active fixture creation session. "
-                "Finish or cancel it before entering results.",
-                ephemeral=True,
-            )
-            return
-
-        self.results_handler.start_session(
-            user_id, fixture["id"], interaction.guild_id, fixture["week_number"]
-        )
-
-        await interaction.response.send_message(
-            "Check your DMs! I've sent you instructions for entering results.",
-            ephemeral=True,
-        )
-
-        try:
-            lines = [
-                f"**Week {fixture['week_number']} - Enter Results**",
-                "",
-                "Reply with the actual results in this format:",
-                "```",
-            ]
-            for game in fixture["games"]:
-                lines.append(f"{game} 2:0")
-            lines.extend(
-                [
-                    "```",
-                    "",
-                    "Add the actual score (e.g., 2:0 or 2-1) at the end of each line.",
-                    "Type 'x' for cancelled or postponed games.",
-                ]
-            )
-            await interaction.user.send("\n".join(lines))
-        except Exception as exc:
-            reason = "dm_forbidden" if isinstance(exc, discord.Forbidden) else "dm_error"
-            self.results_handler.cancel_session(user_id, reason=reason)
-            await interaction.followup.send(
-                "I can't send you DMs. Please enable DMs from server members and try again.",
-                ephemeral=True,
-            )
+        modal = EnterResultsModal(fixture, self.db)
+        await interaction.response.send_modal(modal)
 
     @results.command(name="calculate", description="Calculate scores and post results")
     @admin_only()

--- a/typer_bot/commands/admin_panel/__init__.py
+++ b/typer_bot/commands/admin_panel/__init__.py
@@ -7,7 +7,7 @@ from .fixtures import (
     OpenFixtureWarningView,
     _build_delete_confirmation_content,
 )
-from .modals import CorrectResultsModal, ReplacePredictionModal
+from .modals import CorrectResultsModal, EnterResultsModal, ReplacePredictionModal
 from .predictions import PredictionsPanelView
 from .results import ResultsPanelView
 
@@ -15,6 +15,7 @@ __all__ = [
     "AdminPanelHomeView",
     "CorrectResultsModal",
     "DeleteConfirmView",
+    "EnterResultsModal",
     "FixturesPanelView",
     "OpenFixtureWarningView",
     "PredictionsPanelView",

--- a/typer_bot/commands/admin_panel/modals.py
+++ b/typer_bot/commands/admin_panel/modals.py
@@ -6,13 +6,135 @@ from typing import TYPE_CHECKING
 
 import discord
 
-from typer_bot.utils import is_admin
+from typer_bot.database import Database
+from typer_bot.utils import is_admin, parse_line_predictions
 
 from .base import _build_detail_lines, _format_prediction_line, _prediction_status_text
 
 if TYPE_CHECKING:
     from .predictions import PredictionsPanelView
     from .results import ResultsPanelView
+
+
+def _build_results_preview(week_number: int, games: list[str], results: list[str]) -> str:
+    lines = [f"**Week {week_number} Results Preview**", ""]
+    lines.extend(
+        _format_prediction_line(index, game, result)
+        for index, (game, result) in enumerate(zip(games, results, strict=False), 1)
+    )
+    return "\n".join(lines)
+
+
+class EnterResultsConfirmView(discord.ui.View):
+    """Confirm or cancel modal-based results entry.
+
+    Confirm is owner-only, rechecks admin permission, and persists the parsed
+    results only after the preview step succeeds.
+    """
+
+    def __init__(
+        self,
+        db: Database,
+        fixture: dict,
+        results: list[str],
+        preview: str,
+        owner_user_id: str,
+    ):
+        super().__init__(timeout=120)
+        self.db = db
+        self.fixture = fixture
+        self.results = results
+        self.preview = preview
+        self.owner_user_id = owner_user_id
+
+    @discord.ui.button(label="Save Results", style=discord.ButtonStyle.green)
+    async def confirm(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        if str(interaction.user.id) != self.owner_user_id:
+            await interaction.response.send_message(
+                "You don't have permission to do this!", ephemeral=True
+            )
+            return
+        if not is_admin(interaction):
+            await interaction.response.send_message(
+                "You no longer have permission to use admin commands.", ephemeral=True
+            )
+            return
+
+        try:
+            await self.db.save_results(self.fixture["id"], self.results)
+        except ValueError as exc:
+            await interaction.response.edit_message(
+                content=f"**Cannot save results:** {exc}", view=None
+            )
+            return
+
+        await interaction.response.edit_message(
+            content=f"**Results Saved!**\n\n{self.preview}\n\nUse `/admin results calculate` to calculate scores.",
+            view=None,
+        )
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.red)
+    async def cancel(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        if str(interaction.user.id) != self.owner_user_id:
+            await interaction.response.send_message(
+                "You don't have permission to do this!", ephemeral=True
+            )
+            return
+
+        await interaction.response.edit_message(
+            content="Results entry cancelled. Use `/admin results enter` to try again.",
+            view=None,
+        )
+
+
+class EnterResultsModal(discord.ui.Modal):
+    """Collect results for an open fixture without starting a DM session.
+
+    Parse failures are returned ephemerally, and nothing is persisted until the
+    follow-up confirm view succeeds.
+    """
+
+    def __init__(self, fixture: dict, db: Database):
+        super().__init__(title=f"Enter Week {fixture['week_number']} Results")
+        self.fixture = fixture
+        self.db = db
+        self.results_input = discord.ui.TextInput(
+            label="Results",
+            style=discord.TextStyle.paragraph,
+            placeholder="One line per match, e.g. Team A - Team B 2:1",
+            default="\n".join(f"{game} 2:0" for game in fixture["games"]),
+            required=True,
+            max_length=4000,
+        )
+        self.add_item(self.results_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        if not is_admin(interaction):
+            await interaction.response.send_message(
+                "You no longer have permission to use admin commands.", ephemeral=True
+            )
+            return
+
+        results, errors = parse_line_predictions(self.results_input.value, self.fixture["games"])
+        if errors:
+            await interaction.response.send_message("\n".join(errors), ephemeral=True)
+            return
+
+        preview = _build_results_preview(
+            self.fixture["week_number"], self.fixture["games"], results
+        )
+        view = EnterResultsConfirmView(
+            self.db,
+            self.fixture,
+            results,
+            preview,
+            str(interaction.user.id),
+        )
+        await interaction.response.send_message(
+            f"{preview}\n\nSave these results?",
+            view=view,
+            ephemeral=True,
+        )
 
 
 class ReplacePredictionModal(discord.ui.Modal):

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -139,7 +139,7 @@ class UserCommands(commands.Cog):
 • `/admin fixture delete [week]` - Delete an open fixture
 
 **Results Management:**
-• `/admin results enter [week]` - Enter actual scores (DM workflow)
+• `/admin results enter [week]` - Enter actual scores (modal + confirm)
 • `/admin results calculate [week]` - Calculate and post scores
 • `/admin results post` - Re-post results with optional mentions
 
@@ -154,14 +154,14 @@ class UserCommands(commands.Cog):
 
 2. **Enter Results:**
    - `/admin results enter` (add `week:` if multiple fixtures are open)
-   - Bot DMs you
-   - Send actual scores:
-     ```
-     Team A - Team B 1:0
-     Team C - Team D 2:2
-     ...
-     ```
-   - Confirm
+   - Modal opens in Discord
+   - Enter actual scores:
+      ```
+      Team A - Team B 1:0
+      Team C - Team D 2:2
+      ...
+      ```
+   - Review preview and confirm
 
 3. **Calculate Scores:**
    - `/admin results calculate` (add `week:` if multiple fixtures are open)
@@ -183,7 +183,7 @@ class UserCommands(commands.Cog):
 • `15.02.2024 18:00`
 • `15/02/2024 18:00`
 
-⚠️ Make sure your Discord allows DMs from server members!"""
+⚠️ DMs are still required for `/admin fixture create`."""
 
         await interaction.response.send_message(user_help, ephemeral=True)
 


### PR DESCRIPTION
## Summary
- replace `/admin results enter` DM session startup with a modal and in-message confirm/cancel flow
- reuse the shared parser for modal validation and preserve scored-fixture save guards at confirm time
- update help text and tests to reflect the modal workflow, permission rechecks, and preview/save edge cases

Closes #149

## Testing
- `uv run pytest tests/test_admin_commands.py tests/test_admin_panel.py tests/test_bot.py --tb=short`
- `uv run ruff check typer_bot/commands/admin_commands.py typer_bot/commands/admin_panel typer_bot/commands/user_commands.py tests/test_admin_commands.py tests/test_admin_panel.py tests/test_bot.py`
- `uv run ty check typer_bot`
