### PR TITLE
feat: move fixture creation into a modal

### DIFF
--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
+import discord
 import pytest
 
 from typer_bot.commands.admin_commands import (
@@ -10,7 +11,7 @@ from typer_bot.commands.admin_commands import (
     AdminCommands,
     PostResultsConfirmView,
 )
-from typer_bot.commands.admin_panel import EnterResultsModal, OpenFixtureWarningView
+from typer_bot.commands.admin_panel import CreateFixtureModal, EnterResultsModal
 from typer_bot.services.admin_service import FixtureScoreResult
 from typer_bot.utils import now
 from typer_bot.utils.permissions import is_admin
@@ -58,52 +59,52 @@ class TestFixtureCreateLogic:
         return AdminCommands(mock_bot)
 
     @pytest.mark.asyncio
-    async def test_fixture_create_starts_session(self, admin_cog, mock_interaction_admin):
-        """DM session prevents spamming public channels during fixture creation."""
-        user_id = str(mock_interaction_admin.user.id)
-        admin_cog.fixture_handler.start_session(user_id, 123456, 111111)
-        assert admin_cog.fixture_handler.has_session(user_id)
+    async def test_fixture_create_opens_modal(self, admin_cog, mock_interaction_admin):
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.id = mock_interaction_admin.channel.id
+        mock_interaction_admin.channel = channel
+
+        await admin_cog.fixture_create.callback(admin_cog, mock_interaction_admin)
+
+        assert isinstance(mock_interaction_admin.modal_sent["modal"], CreateFixtureModal)
 
     @pytest.mark.asyncio
-    async def test_fixture_create_session_has_correct_data(self, admin_cog, mock_interaction_admin):
-        """Session metadata includes guild and channel context for permissions and announcements."""
-        user_id = str(mock_interaction_admin.user.id)
-        admin_cog.fixture_handler.start_session(user_id, 123456, 111111)
+    async def test_fixture_create_from_thread_uses_parent_channel(
+        self, admin_cog, mock_interaction_admin
+    ):
+        parent_channel = MagicMock(spec=discord.TextChannel)
+        parent_channel.id = 123456
+        thread = MagicMock(spec=discord.Thread)
+        thread.parent = parent_channel
+        mock_interaction_admin.channel = thread
 
-        session = admin_cog.fixture_handler.get_session(user_id)
-        assert session.channel_id == 123456
-        assert session.guild_id == 111111
-        assert session.step == "games"
+        await admin_cog.fixture_create.callback(admin_cog, mock_interaction_admin)
+
+        assert mock_interaction_admin.modal_sent["modal"].channel is parent_channel
 
     @pytest.mark.asyncio
-    async def test_fixture_create_shows_warning_when_open_fixture_exists(
+    async def test_fixture_create_still_opens_modal_when_open_fixture_exists(
         self, admin_cog, mock_interaction_admin, sample_games
     ):
-        """Accidental duplicate fixtures are blocked by a confirmation step."""
-        mock_interaction_admin.channel_id = int(mock_interaction_admin.channel.id)
-        mock_interaction_admin.guild_id = mock_interaction_admin.guild.id
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.id = mock_interaction_admin.channel.id
+        mock_interaction_admin.channel = channel
         await admin_cog.db.create_fixture(5, sample_games, datetime.now(UTC) + timedelta(days=1))
 
         await admin_cog.fixture_create.callback(admin_cog, mock_interaction_admin)
 
-        response = mock_interaction_admin.response_sent[-1]
-        assert "already open" in response["content"]
-        assert isinstance(response["view"], OpenFixtureWarningView)
+        assert isinstance(mock_interaction_admin.modal_sent["modal"], CreateFixtureModal)
 
     @pytest.mark.asyncio
-    async def test_fixture_create_proceeds_directly_when_no_open_fixtures(
+    async def test_fixture_create_opens_modal_when_no_open_fixtures(
         self, admin_cog, mock_interaction_admin
     ):
-        """When no fixtures are open the DM session starts without any confirmation gate."""
-        mock_interaction_admin.channel_id = int(mock_interaction_admin.channel.id)
-        mock_interaction_admin.guild_id = mock_interaction_admin.guild.id
-        mock_interaction_admin.user.send = AsyncMock()
-
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.id = mock_interaction_admin.channel.id
+        mock_interaction_admin.channel = channel
         await admin_cog.fixture_create.callback(admin_cog, mock_interaction_admin)
 
-        response = mock_interaction_admin.response_sent[-1]
-        assert "Check your DMs" in response["content"]
-        assert admin_cog.fixture_handler.has_session(str(mock_interaction_admin.user.id))
+        assert isinstance(mock_interaction_admin.modal_sent["modal"], CreateFixtureModal)
 
 
 class TestFixtureDeleteLogic:
@@ -552,7 +553,7 @@ class TestCooldownLogic:
 
 
 class TestAdminSessionExclusivity:
-    """Fixture creation DM state still blocks overlapping DM-style admin workflows."""
+    """Mixed admin workflows respect the remaining DM-session exclusivity rules."""
 
     @pytest.fixture
     def admin_cog(self, mock_bot, database):
@@ -563,39 +564,16 @@ class TestAdminSessionExclusivity:
     async def test_fixture_create_command_blocked_when_results_session_active(
         self, admin_cog, mock_interaction_admin
     ):
-        """fixture_create gives a single clear error — not 'Check your DMs' + error."""
+        """fixture_create now opens a modal even if results DM state exists."""
         user_id = str(mock_interaction_admin.user.id)
-        mock_interaction_admin.channel_id = int(mock_interaction_admin.channel.id)
-        mock_interaction_admin.guild_id = mock_interaction_admin.guild.id
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.id = mock_interaction_admin.channel.id
+        mock_interaction_admin.channel = channel
         admin_cog.results_handler.start_session(user_id, 1, 111111, week_number=1)
 
         await admin_cog.fixture_create.callback(admin_cog, mock_interaction_admin)
 
-        assert len(mock_interaction_admin.response_sent) == 1
-        response = mock_interaction_admin.response_sent[0]["content"]
-        assert "results entry" in response.lower()
-        assert "Check your DMs" not in response
-        assert not admin_cog.fixture_handler.has_session(user_id)
-
-    @pytest.mark.asyncio
-    async def test_start_fixture_dm_blocked_when_results_session_active(
-        self, admin_cog, mock_interaction_admin
-    ):
-        """_start_fixture_dm fallback guard covers the view-triggered path."""
-        user_id = str(mock_interaction_admin.user.id)
-        admin_cog.results_handler.start_session(user_id, 1, 111111, week_number=1)
-
-        result = await admin_cog._start_fixture_dm(
-            mock_interaction_admin.user,
-            user_id,
-            channel_id=123456,
-            guild_id=111111,
-        )
-
-        assert result is False
-        assert not admin_cog.fixture_handler.has_session(user_id)
-        assert len(mock_interaction_admin.user.dm_sent) == 1
-        assert "results entry" in mock_interaction_admin.user.dm_sent[0].lower()
+        assert isinstance(mock_interaction_admin.modal_sent["modal"], CreateFixtureModal)
 
     @pytest.mark.asyncio
     async def test_results_enter_blocked_when_fixture_session_active(
@@ -617,18 +595,14 @@ class TestAdminSessionExclusivity:
     async def test_fixture_create_allowed_when_no_conflicting_session(
         self, admin_cog, mock_interaction_admin
     ):
-        """Fixture creation proceeds normally when no admin session is active."""
-        user_id = str(mock_interaction_admin.user.id)
+        """Fixture creation opens the modal when no admin session is active."""
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.id = mock_interaction_admin.channel.id
+        mock_interaction_admin.channel = channel
 
-        result = await admin_cog._start_fixture_dm(
-            mock_interaction_admin.user,
-            user_id,
-            channel_id=123456,
-            guild_id=111111,
-        )
+        await admin_cog.fixture_create.callback(admin_cog, mock_interaction_admin)
 
-        assert result is True
-        assert admin_cog.fixture_handler.has_session(user_id)
+        assert isinstance(mock_interaction_admin.modal_sent["modal"], CreateFixtureModal)
 
     @pytest.mark.asyncio
     async def test_results_enter_allowed_when_no_conflicting_session(

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -11,6 +11,7 @@ from typer_bot.commands.admin_commands import AdminCommands
 from typer_bot.commands.admin_panel import (
     AdminPanelHomeView,
     CorrectResultsModal,
+    CreateFixtureModal,
     DeleteConfirmView,
     EnterResultsModal,
     FixturesPanelView,
@@ -37,6 +38,270 @@ class TestAdminPanelCommand:
     def admin_cog(self, mock_bot, database):
         mock_bot.db = database
         return AdminCommands(mock_bot)
+
+    @pytest.mark.asyncio
+    async def test_create_fixture_modal_shows_preview_with_default_deadline(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        modal = CreateFixtureModal(
+            admin_cog.db, mock_interaction_admin.channel, str(mock_interaction_admin.user.id)
+        )
+        modal.games_input._value = "\n".join(sample_games)
+        modal.deadline_input._value = ""
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "Week 1 Fixture Preview" in mock_interaction_admin.response_sent[-1]["content"]
+        assert "Deadline:" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_create_fixture_modal_warns_when_other_fixtures_are_open(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        await admin_cog.db.create_fixture(5, sample_games, datetime.now(UTC) + timedelta(days=1))
+        modal = CreateFixtureModal(
+            admin_cog.db, mock_interaction_admin.channel, str(mock_interaction_admin.user.id)
+        )
+        modal.games_input._value = "\n".join(sample_games)
+        modal.deadline_input._value = ""
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "already open" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_create_fixture_modal_rejects_invalid_deadline(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        modal = CreateFixtureModal(
+            admin_cog.db, mock_interaction_admin.channel, str(mock_interaction_admin.user.id)
+        )
+        modal.games_input._value = "\n".join(sample_games)
+        modal.deadline_input._value = "tomorrow 6pm"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "Invalid date format" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_create_fixture_modal_rechecks_admin_permission(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        modal = CreateFixtureModal(
+            admin_cog.db, mock_interaction_admin.channel, str(mock_interaction_admin.user.id)
+        )
+        modal.games_input._value = "\n".join(sample_games)
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.roles = []
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "no longer have permission" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_create_fixture_confirm_creates_fixture_and_announcement(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        announcement = MagicMock()
+        announcement.id = 999999
+        thread = AsyncMock()
+        announcement.create_thread = AsyncMock(return_value=thread)
+        mock_interaction_admin.channel.send = AsyncMock(return_value=announcement)
+
+        modal = CreateFixtureModal(
+            admin_cog.db, mock_interaction_admin.channel, str(mock_interaction_admin.user.id)
+        )
+        modal.games_input._value = "\n".join(sample_games)
+        modal.deadline_input._value = "2026-04-20 18:00"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        confirm_button = next(
+            child
+            for child in confirm_view.children
+            if getattr(child, "label", None) == "Create Fixture"
+        )
+        await confirm_button.callback(mock_interaction_admin)
+
+        fixture = await admin_cog.db.get_fixture_by_id(1)
+        assert fixture is not None
+        assert fixture["message_id"] == "999999"
+        assert fixture["channel_id"] == str(mock_interaction_admin.channel.id)
+        assert "Fixture Created" in mock_interaction_admin.response_sent[-1]["content"]
+        mock_interaction_admin.channel.send.assert_awaited_once()
+        announcement.create_thread.assert_awaited_once()
+        thread.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_create_fixture_confirm_warns_when_thread_creation_fails(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        announcement = MagicMock()
+        announcement.id = 999999
+        announcement.create_thread = AsyncMock(side_effect=Exception("thread failed"))
+        mock_interaction_admin.channel.send = AsyncMock(return_value=announcement)
+
+        modal = CreateFixtureModal(
+            admin_cog.db, mock_interaction_admin.channel, str(mock_interaction_admin.user.id)
+        )
+        modal.games_input._value = "\n".join(sample_games)
+        modal.deadline_input._value = "2026-04-20 18:00"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        confirm_button = next(
+            child
+            for child in confirm_view.children
+            if getattr(child, "label", None) == "Create Fixture"
+        )
+        await confirm_button.callback(mock_interaction_admin)
+
+        fixture = await admin_cog.db.get_fixture_by_id(1)
+        assert fixture is not None
+        assert fixture["message_id"] == "999999"
+        assert fixture["channel_id"] == str(mock_interaction_admin.channel.id)
+        assert (
+            "couldn't create a prediction thread"
+            in mock_interaction_admin.followup_sent[-1]["content"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_fixture_confirm_warns_when_announcement_fails(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        mock_interaction_admin.channel.send = AsyncMock(side_effect=Exception("send failed"))
+
+        modal = CreateFixtureModal(
+            admin_cog.db, mock_interaction_admin.channel, str(mock_interaction_admin.user.id)
+        )
+        modal.games_input._value = "\n".join(sample_games)
+        modal.deadline_input._value = "2026-04-20 18:00"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        confirm_button = next(
+            child
+            for child in confirm_view.children
+            if getattr(child, "label", None) == "Create Fixture"
+        )
+        await confirm_button.callback(mock_interaction_admin)
+
+        assert await admin_cog.db.get_fixture_by_id(1) is not None
+        assert (
+            "couldn't announce it in the channel"
+            in mock_interaction_admin.followup_sent[-1]["content"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_fixture_confirm_warns_when_week_changes_between_preview_and_confirm(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        announcement = MagicMock()
+        announcement.id = 999999
+        thread = AsyncMock()
+        announcement.create_thread = AsyncMock(return_value=thread)
+        mock_interaction_admin.channel.send = AsyncMock(return_value=announcement)
+
+        modal = CreateFixtureModal(
+            admin_cog.db, mock_interaction_admin.channel, str(mock_interaction_admin.user.id)
+        )
+        modal.games_input._value = "\n".join(sample_games)
+        modal.deadline_input._value = "2026-04-20 18:00"
+
+        await modal.on_submit(mock_interaction_admin)
+        await admin_cog.db.create_fixture(1, sample_games, datetime.now(UTC) + timedelta(days=1))
+
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        confirm_button = next(
+            child
+            for child in confirm_view.children
+            if getattr(child, "label", None) == "Create Fixture"
+        )
+        await confirm_button.callback(mock_interaction_admin)
+
+        fixture = await admin_cog.db.get_fixture_by_id(2)
+        assert fixture is not None
+        assert "Week number changed" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_create_fixture_confirm_cancel_leaves_database_unchanged(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        modal = CreateFixtureModal(
+            admin_cog.db, mock_interaction_admin.channel, str(mock_interaction_admin.user.id)
+        )
+        modal.games_input._value = "\n".join(sample_games)
+        modal.deadline_input._value = "2026-04-20 18:00"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        cancel_button = next(
+            child for child in confirm_view.children if getattr(child, "label", None) == "Cancel"
+        )
+        await cancel_button.callback(mock_interaction_admin)
+
+        assert "Fixture creation cancelled" in mock_interaction_admin.response_sent[-1]["content"]
+        assert await admin_cog.db.get_current_fixture() is None
+
+    @pytest.mark.asyncio
+    async def test_create_fixture_confirm_rechecks_admin_permission(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        modal = CreateFixtureModal(
+            admin_cog.db, mock_interaction_admin.channel, str(mock_interaction_admin.user.id)
+        )
+        modal.games_input._value = "\n".join(sample_games)
+        modal.deadline_input._value = "2026-04-20 18:00"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        confirm_button = next(
+            child
+            for child in confirm_view.children
+            if getattr(child, "label", None) == "Create Fixture"
+        )
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.roles = []
+
+        await confirm_button.callback(mock_interaction_admin)
+
+        assert "no longer have permission" in mock_interaction_admin.response_sent[-1]["content"]
+        assert await admin_cog.db.get_current_fixture() is None
 
     @pytest.mark.asyncio
     async def test_panel_command_returns_view(self, admin_cog, mock_interaction_admin):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -83,7 +83,7 @@ class TestSetupHook:
 
     @pytest.mark.asyncio
     async def test_setup_hook_loads_admin_commands(self, bot_instance):
-        """Admin commands cog provides league management commands."""
+        """Admin commands cog provides league management and modal workflows."""
         await bot_instance.setup_hook()
         bot_instance.load_extension.assert_any_call("typer_bot.commands.admin_commands")
 

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import logging
 
 import discord
@@ -11,9 +10,9 @@ from discord.ext import commands
 
 from typer_bot.commands.admin_panel import (
     AdminPanelHomeView,
+    CreateFixtureModal,
     DeleteConfirmView,
     EnterResultsModal,
-    OpenFixtureWarningView,
     _build_delete_confirmation_content,
 )
 from typer_bot.database import Database
@@ -118,45 +117,6 @@ class AdminCommands(commands.Cog):
         except Exception as exc:
             logger.warning(f"Backup failed but calculation succeeded: {exc}")
 
-    async def _start_fixture_dm(
-        self,
-        user: discord.User | discord.Member,
-        user_id: str,
-        channel_id: int,
-        guild_id: int,
-    ) -> bool:
-        """Returns True if the DM was sent successfully."""
-        if self.workflow_state.has_results_session(user_id):
-            with contextlib.suppress(Exception):
-                await user.send(
-                    "❌ You have an active results entry session. "
-                    "Finish or cancel it before starting a new fixture."
-                )
-            return False
-
-        self.fixture_handler.start_session(user_id, channel_id, guild_id)
-        max_week = await self.db.get_max_week_number()
-        predicted_week = max_week + 1
-        try:
-            await user.send(
-                f"**Create New Fixture — Week {predicted_week}**\n\n"
-                f"Based on current data, this will be **Week {predicted_week}** "
-                f"(may change if fixtures are created or deleted before you confirm).\n\n"
-                "Step 1/2: Send me the list of games in this format:\n"
-                "```\n"
-                "Team A - Team B\n"
-                "Team C - Team D\n"
-                "Team E - Team F\n"
-                "...\n"
-                "```\n"
-                "One game per line."
-            )
-        except Exception as exc:
-            reason = "dm_forbidden" if isinstance(exc, discord.Forbidden) else "dm_error"
-            self.fixture_handler.cancel_session(user_id, reason=reason)
-            return False
-        return True
-
     async def _post_calculation_to_channel(
         self,
         interaction: discord.Interaction,
@@ -206,51 +166,34 @@ class AdminCommands(commands.Cog):
             ephemeral=True,
         )
 
-    @fixture.command(name="create", description="Create a new fixture (DM workflow)")
+    @fixture.command(name="create", description="Create a new fixture via modal")
     @admin_only()
     async def fixture_create(self, interaction: discord.Interaction):
-        user_id = str(interaction.user.id)
-        if interaction.channel_id is None or interaction.guild_id is None:
+        if interaction.channel is None or interaction.guild is None:
             await interaction.response.send_message(
                 "Error: Invalid interaction context.", ephemeral=True
             )
             return
 
-        if self.workflow_state.has_results_session(user_id):
+        channel = interaction.channel
+        if isinstance(channel, discord.Thread):
+            parent = channel.parent
+            if not isinstance(parent, discord.TextChannel):
+                await interaction.response.send_message(
+                    "Fixture creation must be started from a server text channel.",
+                    ephemeral=True,
+                )
+                return
+            channel = parent
+        elif not isinstance(channel, discord.TextChannel):
             await interaction.response.send_message(
-                "❌ You have an active results entry session. "
-                "Finish or cancel it before starting a new fixture.",
+                "Fixture creation must be started from a server text channel.",
                 ephemeral=True,
             )
             return
 
-        open_fixtures = await self.db.get_open_fixtures()
-        if open_fixtures:
-            open_weeks = self._format_open_weeks(open_fixtures)
-            view = OpenFixtureWarningView(
-                self._start_fixture_dm, user_id, interaction.channel_id, interaction.guild_id
-            )
-            await interaction.response.send_message(
-                f"Week(s) **{open_weeks}** are already open. Create another fixture anyway?",
-                view=view,
-                ephemeral=True,
-            )
-            return
-
-        await interaction.response.send_message(
-            "Check your DMs! I've sent you instructions for creating the fixture.",
-            ephemeral=True,
-        )
-        if not await self._start_fixture_dm(
-            interaction.user,
-            user_id,
-            interaction.channel_id,
-            interaction.guild_id,
-        ):
-            await interaction.followup.send(
-                "I can't send you DMs. Please enable DMs from server members and try again.",
-                ephemeral=True,
-            )
+        modal = CreateFixtureModal(self.db, channel, str(interaction.user.id))
+        await interaction.response.send_modal(modal)
 
     @fixture.command(name="delete", description="Delete an open fixture")
     @admin_only()

--- a/typer_bot/commands/admin_panel/__init__.py
+++ b/typer_bot/commands/admin_panel/__init__.py
@@ -7,13 +7,19 @@ from .fixtures import (
     OpenFixtureWarningView,
     _build_delete_confirmation_content,
 )
-from .modals import CorrectResultsModal, EnterResultsModal, ReplacePredictionModal
+from .modals import (
+    CorrectResultsModal,
+    CreateFixtureModal,
+    EnterResultsModal,
+    ReplacePredictionModal,
+)
 from .predictions import PredictionsPanelView
 from .results import ResultsPanelView
 
 __all__ = [
     "AdminPanelHomeView",
     "CorrectResultsModal",
+    "CreateFixtureModal",
     "DeleteConfirmView",
     "EnterResultsModal",
     "FixturesPanelView",

--- a/typer_bot/commands/admin_panel/modals.py
+++ b/typer_bot/commands/admin_panel/modals.py
@@ -2,18 +2,234 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 import discord
 
 from typer_bot.database import Database
-from typer_bot.utils import is_admin, parse_line_predictions
+from typer_bot.handlers.fixture_handler import MAX_GAMES, FixtureCreationHandler
+from typer_bot.utils import APP_TZ, is_admin, now, parse_line_predictions
 
 from .base import _build_detail_lines, _format_prediction_line, _prediction_status_text
 
 if TYPE_CHECKING:
     from .predictions import PredictionsPanelView
     from .results import ResultsPanelView
+
+
+def _default_fixture_deadline(current_time: datetime) -> datetime:
+    days_until_friday = (4 - current_time.weekday()) % 7
+    if days_until_friday == 0 and current_time.hour >= 18:
+        days_until_friday = 7
+    deadline = current_time + timedelta(days=days_until_friday)
+    return deadline.replace(hour=18, minute=0, second=0, microsecond=0)
+
+
+def _parse_fixture_games(games_text: str) -> list[str]:
+    games = [line.strip() for line in games_text.strip().split("\n") if line.strip()]
+    if len(games) > MAX_GAMES:
+        raise ValueError(f"Too many games! (max {MAX_GAMES})")
+    if not games:
+        raise ValueError("No games provided! Please enter at least one fixture.")
+    return games
+
+
+def _parse_fixture_deadline(deadline_text: str, current_time: datetime) -> datetime:
+    if not deadline_text.strip():
+        return _default_fixture_deadline(current_time)
+
+    for fmt in ("%Y-%m-%d %H:%M", "%d.%m.%Y %H:%M", "%d/%m/%Y %H:%M"):
+        try:
+            return datetime.strptime(deadline_text.strip(), fmt).replace(tzinfo=APP_TZ)
+        except ValueError:
+            continue
+
+    raise ValueError(
+        "Invalid date format. Use one of these formats:\n"
+        "2024-02-15 18:00\n"
+        "15.02.2024 18:00\n"
+        "15/02/2024 18:00"
+    )
+
+
+class CreateFixtureConfirmView(discord.ui.View):
+    """Confirm or cancel modal-based fixture creation.
+
+    Confirm persists the fixture, posts the announcement, and attempts to create
+    the predictions thread. The fixture may still be created even if the later
+    Discord-side steps fail.
+    """
+
+    def __init__(
+        self,
+        db: Database,
+        channel,
+        owner_user_id: str,
+        preview_week_number: int,
+        games: list[str],
+        deadline: datetime,
+    ):
+        super().__init__(timeout=120)
+        self.db = db
+        self.channel = channel
+        self.owner_user_id = owner_user_id
+        self.preview_week_number = preview_week_number
+        self.games = games
+        self.deadline = deadline
+
+    @discord.ui.button(label="Create Fixture", style=discord.ButtonStyle.green)
+    async def confirm(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        if str(interaction.user.id) != self.owner_user_id:
+            await interaction.response.send_message(
+                "You don't have permission to do this!", ephemeral=True
+            )
+            return
+        if not is_admin(interaction):
+            await interaction.response.send_message(
+                "You no longer have permission to use admin commands.", ephemeral=True
+            )
+            return
+
+        fixture_id, allocated_week = await self.db.create_next_fixture(self.games, self.deadline)
+        final_preview = FixtureCreationHandler._build_fixture_preview_text(
+            allocated_week,
+            self.games,
+            self.deadline,
+        )
+
+        created_text = f"**Week {allocated_week} Fixture Created!**\n\n{final_preview}"
+        if allocated_week != self.preview_week_number:
+            created_text += (
+                f"\n\n⚠️ **Week number changed:** preview showed Week {self.preview_week_number} but "
+                f"this was created as **Week {allocated_week}** because the fixture set "
+                f"changed between steps."
+            )
+
+        await interaction.response.edit_message(content=created_text, view=None)
+
+        try:
+            announcement = await self.channel.send(
+                f"**Week {allocated_week} Fixture is now open!**\n\n"
+                f"{final_preview}\n\n"
+                f"💬 **How to predict:**\n"
+                f"• Reply in this thread with your scores (one per line)\n"
+                f"• Or use `/predict` for DM mode"
+            )
+
+            await self.db.update_fixture_announcement(
+                fixture_id,
+                message_id=str(announcement.id),
+                channel_id=str(self.channel.id),
+            )
+
+            try:
+                thread = await announcement.create_thread(
+                    name=f"Week {allocated_week} Predictions",
+                    auto_archive_duration=1440,
+                )
+                await thread.send(
+                    "💬 **Post your predictions here!**\n"
+                    "Reply with your scores (one per line or comma-separated).\n"
+                    "Predictions are one-shot here. To change one, use `/predict`."
+                )
+            except Exception:
+                await interaction.followup.send(
+                    "⚠️ Fixture created but I couldn't create a prediction thread. Users can still use `/predict`.",
+                    ephemeral=True,
+                )
+        except Exception:
+            await interaction.followup.send(
+                "⚠️ Fixture created but I couldn't announce it in the channel. Please announce it manually.",
+                ephemeral=True,
+            )
+
+    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.red)
+    async def cancel(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        if str(interaction.user.id) != self.owner_user_id:
+            await interaction.response.send_message(
+                "You don't have permission to do this!", ephemeral=True
+            )
+            return
+
+        await interaction.response.edit_message(
+            content="Fixture creation cancelled.",
+            view=None,
+        )
+
+
+class CreateFixtureModal(discord.ui.Modal):
+    """Collect fixture games and an optional deadline in one interaction.
+
+    Blank deadline falls back to Friday 18:00 in the app timezone. Manual
+    deadlines accept `YYYY-MM-DD HH:MM`, `DD.MM.YYYY HH:MM`, or
+    `DD/MM/YYYY HH:MM`. Open fixtures show a warning in the preview, but do not
+    block creation. Nothing is persisted until the confirm view succeeds.
+    """
+
+    def __init__(self, db: Database, channel, owner_user_id: str):
+        super().__init__(title="Create Fixture")
+        self.db = db
+        self.channel = channel
+        self.owner_user_id = owner_user_id
+        self.games_input = discord.ui.TextInput(
+            label="Games",
+            style=discord.TextStyle.paragraph,
+            placeholder="Team A - Team B\nTeam C - Team D",
+            required=True,
+            max_length=4000,
+        )
+        self.deadline_input = discord.ui.TextInput(
+            label="Deadline",
+            style=discord.TextStyle.short,
+            placeholder="YYYY-MM-DD HH:MM or blank for Friday 18:00",
+            required=False,
+            max_length=32,
+        )
+        self.add_item(self.games_input)
+        self.add_item(self.deadline_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        if not is_admin(interaction):
+            await interaction.response.send_message(
+                "You no longer have permission to use admin commands.", ephemeral=True
+            )
+            return
+
+        try:
+            games = _parse_fixture_games(self.games_input.value)
+            deadline = _parse_fixture_deadline(self.deadline_input.value, now())
+        except ValueError as exc:
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
+
+        preview_week_number = await self.db.get_max_week_number() + 1
+        preview = FixtureCreationHandler._build_fixture_preview_text(
+            preview_week_number,
+            games,
+            deadline,
+        )
+        open_fixtures = await self.db.get_open_fixtures()
+        if open_fixtures:
+            open_weeks = ", ".join(str(fixture["week_number"]) for fixture in open_fixtures)
+            preview += (
+                f"\n\n⚠️ **Warning:** Week(s) {open_weeks} are already open. "
+                "Creating another fixture may overlap prediction windows."
+            )
+
+        view = CreateFixtureConfirmView(
+            self.db,
+            self.channel,
+            self.owner_user_id,
+            preview_week_number,
+            games,
+            deadline,
+        )
+        await interaction.response.send_message(
+            f"{preview}\n\nCreate this fixture?",
+            view=view,
+            ephemeral=True,
+        )
 
 
 def _build_results_preview(week_number: int, games: list[str], results: list[str]) -> str:

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -135,7 +135,7 @@ class UserCommands(commands.Cog):
 **For Admins:**
 • `/admin panel` - Open the admin hub for fixture deletion, overrides, waivers, and result correction
 **Fixture Management:**
-• `/admin fixture create` - Create new fixture (DM workflow, auto-creates thread)
+• `/admin fixture create` - Create new fixture (modal + confirm, auto-creates thread)
 • `/admin fixture delete [week]` - Delete an open fixture
 
 **Results Management:**
@@ -146,10 +146,9 @@ class UserCommands(commands.Cog):
 **Admin Workflow:**
 1. **Create Fixture:**
    - `/admin fixture create`
-   - Bot DMs you
-   - Send game list (one per line)
-   - Choose deadline (default or custom)
-   - Confirm
+   - Modal opens in Discord
+   - Enter game list and optional deadline
+   - Review preview and confirm
    - Bot auto-creates thread for predictions
 
 2. **Enter Results:**


### PR DESCRIPTION
## Summary
- replace `/admin fixture create` DM session startup with a modal and in-message confirm/cancel flow
- preserve the existing fixture announcement and prediction-thread creation behavior, including partial-failure warnings
- update help text and tests to cover preview warnings, thread-parent routing, metadata persistence, and confirm-time race handling

Closes #148

## Testing
- `uv run pytest tests/test_admin_commands.py tests/test_admin_panel.py tests/test_bot.py --tb=short`
- `uv run ruff check typer_bot/commands/admin_commands.py typer_bot/commands/admin_panel typer_bot/commands/user_commands.py tests/test_admin_commands.py tests/test_admin_panel.py tests/test_bot.py`
- `uv run ty check typer_bot`
