### PR TITLE
refactor: open admin panel in one view

### DIFF
--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -9,7 +9,6 @@ import pytest
 from tests.conftest import MockInteraction, MockUser
 from typer_bot.commands.admin_commands import AdminCommands
 from typer_bot.commands.admin_panel import (
-    AdminPanelHomeView,
     CorrectResultsModal,
     CreateFixtureModal,
     DeleteConfirmView,
@@ -18,6 +17,7 @@ from typer_bot.commands.admin_panel import (
     PredictionsPanelView,
     ReplacePredictionModal,
     ResultsPanelView,
+    UnifiedAdminPanelView,
 )
 from typer_bot.commands.admin_panel.fixtures import _cleanup_discord_announcement
 from typer_bot.database import Database
@@ -452,18 +452,14 @@ class TestPredictionPanelFlows:
     ):
         await admin_cog.db.create_fixture(1, sample_games, datetime.now(UTC) + timedelta(days=1))
 
-        home_view = AdminPanelHomeView(
+        unified_view = UnifiedAdminPanelView(
             admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), bot=admin_cog.bot
         )
-        predictions_button = next(
-            child for child in home_view.children if getattr(child, "label", None) == "Predictions"
-        )
-        await predictions_button.callback(mock_interaction_admin)
+        await unified_view.load_fixture_options()
 
-        edited_view = mock_interaction_admin.response_sent[-1]["view"]
-        assert edited_view.user_select.disabled is True
-        assert len(edited_view.user_select.options) == 1
-        assert edited_view.user_select.options[0].label == "No predictions available"
+        assert unified_view.user_select.disabled is True
+        assert len(unified_view.user_select.options) == 1
+        assert unified_view.user_select.options[0].label == "No predictions available"
 
     @pytest.mark.asyncio
     async def test_prediction_panel_buttons_enable_as_selections_are_made(
@@ -887,17 +883,13 @@ class TestFixturePanelFlows:
     ):
         await admin_cog.db.create_fixture(4, sample_games, datetime.now(UTC) + timedelta(days=1))
 
-        view = AdminPanelHomeView(
+        view = UnifiedAdminPanelView(
             admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), bot=admin_cog.bot
         )
-        fixture_button = next(
-            child for child in view.children if getattr(child, "label", None) == "Fixtures"
-        )
-        await fixture_button.callback(mock_interaction_admin)
+        await view.load_fixture_options()
 
-        edited_view = mock_interaction_admin.response_sent[-1]["view"]
-        assert edited_view.fixture_select.disabled is False
-        assert edited_view.fixture_select.options[0].label == "Week 4 [OPEN]"
+        assert view.fixture_select.disabled is False
+        assert view.fixture_select.options[0].label == "Week 4 [OPEN]"
 
     @pytest.mark.asyncio
     async def test_fixture_panel_delete_button_enables_after_fixture_selection(
@@ -935,22 +927,16 @@ class TestFixturePanelFlows:
             6, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
 
-        view = AdminPanelHomeView(
+        view = UnifiedAdminPanelView(
             admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), bot=admin_cog.bot
         )
-        fixture_button = next(
-            child for child in view.children if getattr(child, "label", None) == "Fixtures"
-        )
-        await fixture_button.callback(mock_interaction_admin)
+        await view.load_fixture_options()
 
-        fixtures_view = mock_interaction_admin.response_sent[-1]["view"]
-        fixtures_view.fixture_select._values = [str(fixture_id)]
-        await fixtures_view.fixture_select.callback(mock_interaction_admin)
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
 
         delete_button = next(
-            child
-            for child in fixtures_view.children
-            if getattr(child, "label", None) == "Delete Fixture"
+            child for child in view.children if getattr(child, "label", None) == "Delete Fixture"
         )
         await delete_button.callback(mock_interaction_admin)
 
@@ -1221,6 +1207,83 @@ class TestResultsPanelFlows:
         content = mock_interaction_admin.response_sent[-1]["content"]
         assert len(content) <= 1900
         assert "content truncated" in content
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_correct_results_clears_stale_user_on_success(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            32, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-2"],
+            False,
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), bot=admin_cog.bot
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["user-1"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+        modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
+        modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert view.selection.user_id is None
+        assert view.selection.user_label == ""
+        assert "User:" not in mock_interaction_admin.response_sent[-1]["content"]
+        assert "1. Team A - Team B 2-1" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_correct_results_clears_stale_user_on_deleted_fixture(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            33, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            ["1-0", "1-1", "0-2"],
+            False,
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), bot=admin_cog.bot
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["user-1"]
+        await view.user_select.callback(mock_interaction_admin)
+        await admin_cog.db.delete_fixture(fixture_id)
+
+        correct_button = _get_button(view, "Correct Results")
+        await correct_button.callback(mock_interaction_admin)
+
+        assert view.selection.fixture_id is None
+        assert view.selection.user_id is None
+        assert view.user_select.disabled is True
+        assert "Fixture no longer exists" in mock_interaction_admin.response_sent[-1]["content"]
 
 
 class TestAdminPanelModals:

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -10,10 +10,10 @@ from discord import app_commands
 from discord.ext import commands
 
 from typer_bot.commands.admin_panel import (
-    AdminPanelHomeView,
     CreateFixtureModal,
     DeleteConfirmView,
     EnterResultsModal,
+    UnifiedAdminPanelView,
     _build_delete_confirmation_content,
 )
 from typer_bot.database import Database
@@ -269,9 +269,10 @@ class AdminCommands(commands.Cog):
     @admin.command(name="panel", description="Open the admin management panel")
     @admin_only()
     async def panel(self, interaction: discord.Interaction):
-        view = AdminPanelHomeView(self.db, self.service, str(interaction.user.id), bot=self.bot)
+        view = UnifiedAdminPanelView(self.db, self.service, str(interaction.user.id), bot=self.bot)
+        await view.load_fixture_options()
         await interaction.response.send_message(
-            "**Admin Panel**\nChoose the workflow you want to manage.",
+            view.render_content(),
             view=view,
             ephemeral=True,
         )

--- a/typer_bot/commands/admin_panel/__init__.py
+++ b/typer_bot/commands/admin_panel/__init__.py
@@ -1,6 +1,5 @@
 """Admin panel views and interaction components."""
 
-from .base import AdminPanelHomeView
 from .fixtures import (
     DeleteConfirmView,
     FixturesPanelView,
@@ -14,9 +13,9 @@ from .modals import (
 )
 from .predictions import PredictionsPanelView
 from .results import ResultsPanelView
+from .unified import UnifiedAdminPanelView
 
 __all__ = [
-    "AdminPanelHomeView",
     "CorrectResultsModal",
     "CreateFixtureModal",
     "DeleteConfirmView",
@@ -25,5 +24,6 @@ __all__ = [
     "PredictionsPanelView",
     "ReplacePredictionModal",
     "ResultsPanelView",
+    "UnifiedAdminPanelView",
     "_build_delete_confirmation_content",
 ]

--- a/typer_bot/commands/admin_panel/base.py
+++ b/typer_bot/commands/admin_panel/base.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from .fixtures import FixturesPanelView
     from .predictions import PredictionsPanelView
     from .results import ResultsPanelView
+    from .unified import UnifiedAdminPanelView
 
 MAX_SELECT_OPTIONS = 25
 MAX_PANEL_CONTENT_LENGTH = 1900
@@ -87,7 +88,7 @@ def _prediction_status_text(prediction: dict) -> str:
 
 @dataclass(slots=True)
 class PanelSelectionState:
-    """Shared render state for admin panel subviews.
+    """Shared render state for admin panel views.
 
     `fixture_label`, `user_label`, and `detail_lines` drive the inline panel body.
     `status_message` carries transient feedback after selections or admin actions.
@@ -104,8 +105,8 @@ class PanelSelectionState:
 class OwnerRestrictedView(discord.ui.View):
     """Base view that only accepts interactions from the opening admin.
 
-    The owner check persists across nested panel navigation so one admin cannot
-    click through another admin's ephemeral management flow.
+    The owner check persists across unified-panel refreshes and modal callbacks
+    so one admin cannot click through another admin's ephemeral management flow.
     """
 
     def __init__(
@@ -136,54 +137,6 @@ class OwnerRestrictedView(discord.ui.View):
         return True
 
 
-class AdminPanelHomeView(OwnerRestrictedView):
-    """Top-level admin panel router for fixture, prediction, and results flows."""
-
-    @discord.ui.button(label="Fixtures", style=discord.ButtonStyle.secondary)
-    async def fixtures(self, interaction: discord.Interaction, _button: discord.ui.Button):
-        from .fixtures import FixturesPanelView
-
-        view = FixturesPanelView(self.db, self.service, self.owner_user_id, bot=self.bot)
-        await view.load_fixture_options()
-        await interaction.response.edit_message(content=view.render_content(), view=view)
-
-    @discord.ui.button(label="Predictions", style=discord.ButtonStyle.primary)
-    async def predictions(self, interaction: discord.Interaction, _button: discord.ui.Button):
-        from .predictions import PredictionsPanelView
-
-        view = PredictionsPanelView(self.db, self.service, self.owner_user_id)
-        await view.load_fixture_options()
-        await interaction.response.edit_message(content=view.render_content(), view=view)
-
-    @discord.ui.button(label="Results", style=discord.ButtonStyle.success)
-    async def results(self, interaction: discord.Interaction, _button: discord.ui.Button):
-        from .results import ResultsPanelView
-
-        view = ResultsPanelView(self.db, self.service, self.owner_user_id)
-        await view.load_fixture_options()
-        await interaction.response.edit_message(content=view.render_content(), view=view)
-
-
-class BackButton(discord.ui.Button):
-    """Return from a subview to the home panel while preserving ownership."""
-
-    def __init__(self, parent_view: OwnerRestrictedView):
-        self.parent_view = parent_view
-        super().__init__(label="Back", style=discord.ButtonStyle.secondary)
-
-    async def callback(self, interaction: discord.Interaction):
-        view = AdminPanelHomeView(
-            self.parent_view.db,
-            self.parent_view.service,
-            self.parent_view.owner_user_id,
-            bot=self.parent_view.bot,
-        )
-        await interaction.response.edit_message(
-            content="**Admin Panel**\nChoose the workflow you want to manage.",
-            view=view,
-        )
-
-
 class FixtureSelect(discord.ui.Select):
     """Shared fixture selector that updates panel selection state in place.
 
@@ -195,7 +148,10 @@ class FixtureSelect(discord.ui.Select):
 
     def __init__(
         self,
-        parent_view: FixturesPanelView | PredictionsPanelView | ResultsPanelView,
+        parent_view: FixturesPanelView
+        | PredictionsPanelView
+        | ResultsPanelView
+        | UnifiedAdminPanelView,
     ):
         self.parent_view = parent_view
         super().__init__(

--- a/typer_bot/commands/admin_panel/fixtures.py
+++ b/typer_bot/commands/admin_panel/fixtures.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Protocol, cast
+from typing import TYPE_CHECKING, Protocol, cast
 
 import discord
 
@@ -12,7 +12,6 @@ from typer_bot.services import AdminService
 from typer_bot.utils import is_admin
 
 from .base import (
-    BackButton,
     FixtureSelect,
     OwnerRestrictedView,
     PanelSelectionState,
@@ -20,6 +19,9 @@ from .base import (
 )
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from .unified import UnifiedAdminPanelView
 
 
 class _MessageLookupChannel(Protocol):
@@ -75,7 +77,6 @@ class FixturesPanelView(OwnerRestrictedView):
         self.clear_items()
         self.add_item(self.fixture_select)
         self.add_item(FixturesDeleteButton(self, disabled=self.selection.fixture_id is None))
-        self.add_item(BackButton(self))
 
     async def load_fixture_options(self) -> None:
         fixtures = await self.db.get_open_fixtures()
@@ -102,7 +103,9 @@ class FixturesPanelView(OwnerRestrictedView):
 
 
 class FixturesDeleteButton(discord.ui.Button):
-    def __init__(self, parent_view: FixturesPanelView, disabled: bool = False):
+    def __init__(
+        self, parent_view: FixturesPanelView | UnifiedAdminPanelView, disabled: bool = False
+    ):
         self.parent_view = parent_view
         super().__init__(
             label="Delete Fixture",

--- a/typer_bot/commands/admin_panel/modals.py
+++ b/typer_bot/commands/admin_panel/modals.py
@@ -15,6 +15,7 @@ from .base import _build_detail_lines, _format_prediction_line, _prediction_stat
 if TYPE_CHECKING:
     from .predictions import PredictionsPanelView
     from .results import ResultsPanelView
+    from .unified import UnifiedAdminPanelView
 
 
 MAX_GAMES = 100
@@ -362,7 +363,12 @@ class EnterResultsModal(discord.ui.Modal):
 class ReplacePredictionModal(discord.ui.Modal):
     """Collect corrected prediction lines and trigger optional score recalculation."""
 
-    def __init__(self, parent_view: PredictionsPanelView, fixture: dict, prediction: dict):
+    def __init__(
+        self,
+        parent_view: PredictionsPanelView | UnifiedAdminPanelView,
+        fixture: dict,
+        prediction: dict,
+    ):
         super().__init__(title=f"Replace Week {fixture['week_number']} Prediction")
         self.parent_view = parent_view
         self.fixture = fixture
@@ -446,9 +452,20 @@ class ReplacePredictionModal(discord.ui.Modal):
 
 
 class CorrectResultsModal(discord.ui.Modal):
-    """Collect corrected results input for a fixture from the admin panel."""
+    """Collect corrected results input for a fixture from the admin panel.
 
-    def __init__(self, parent_view: ResultsPanelView, fixture: dict, results: list[str] | None):
+    Successful submits update the parent panel inline, clear any stale selected
+    prediction user, and may trigger score recalculation. If the fixture
+    disappears mid-flow, the parent panel reloads its selectors before
+    re-rendering the error state.
+    """
+
+    def __init__(
+        self,
+        parent_view: ResultsPanelView | UnifiedAdminPanelView,
+        fixture: dict,
+        results: list[str] | None,
+    ):
         super().__init__(title=f"Correct Week {fixture['week_number']} Results")
         self.parent_view = parent_view
         self.fixture = fixture
@@ -492,9 +509,14 @@ class CorrectResultsModal(discord.ui.Modal):
             if str(exc) == "Fixture not found":
                 self.parent_view.selection.fixture_id = None
                 self.parent_view.selection.fixture_label = ""
+                self.parent_view.selection.user_id = None
+                self.parent_view.selection.user_label = ""
                 self.parent_view.selection.detail_lines = []
                 self.parent_view.selection.status_message = str(exc)
                 await self.parent_view.load_fixture_options()
+                load_user_options = getattr(self.parent_view, "load_user_options", None)
+                if callable(load_user_options):
+                    await load_user_options()
                 self.parent_view._refresh_items()
                 await interaction.response.edit_message(
                     content=self.parent_view.render_content(),
@@ -511,8 +533,13 @@ class CorrectResultsModal(discord.ui.Modal):
         if recalculation is not None:
             self.parent_view.selection.status_message += " Scores were recalculated."
 
+        self.parent_view.selection.user_id = None
+        self.parent_view.selection.user_label = ""
         self.parent_view.selection.detail_lines = _build_detail_lines(fixture["games"], _results)
 
+        load_user_options = getattr(self.parent_view, "load_user_options", None)
+        if callable(load_user_options):
+            await load_user_options()
         self.parent_view._refresh_items()
 
         await interaction.response.edit_message(

--- a/typer_bot/commands/admin_panel/predictions.py
+++ b/typer_bot/commands/admin_panel/predictions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import discord
 
 from typer_bot.database import Database
@@ -9,7 +11,6 @@ from typer_bot.services import AdminService
 
 from .base import (
     MAX_SELECT_OPTIONS,
-    BackButton,
     FixtureSelect,
     OwnerRestrictedView,
     PanelSelectionState,
@@ -18,6 +19,9 @@ from .base import (
     _render_panel_content,
 )
 from .modals import ReplacePredictionModal
+
+if TYPE_CHECKING:
+    from .unified import UnifiedAdminPanelView
 
 
 class PredictionsPanelView(OwnerRestrictedView):
@@ -50,7 +54,6 @@ class PredictionsPanelView(OwnerRestrictedView):
                 disabled=self.selection.fixture_id is None or self.selection.user_id is None,
             )
         )
-        self.add_item(BackButton(self))
 
     async def load_fixture_options(self) -> None:
         fixtures = await self.db.get_recent_fixtures(MAX_SELECT_OPTIONS)
@@ -101,7 +104,7 @@ class PredictionsPanelView(OwnerRestrictedView):
 class PredictionUserSelect(discord.ui.Select):
     """Select a user who already has a prediction for the chosen fixture."""
 
-    def __init__(self, parent_view: PredictionsPanelView):
+    def __init__(self, parent_view: PredictionsPanelView | UnifiedAdminPanelView):
         self.parent_view = parent_view
         super().__init__(
             placeholder="Select user",
@@ -181,7 +184,9 @@ class PredictionUserSelect(discord.ui.Select):
 
 
 class ReplacePredictionButton(discord.ui.Button):
-    def __init__(self, parent_view: PredictionsPanelView, disabled: bool = False):
+    def __init__(
+        self, parent_view: PredictionsPanelView | UnifiedAdminPanelView, disabled: bool = False
+    ):
         self.parent_view = parent_view
         super().__init__(
             label="Replace Prediction",
@@ -233,7 +238,9 @@ class ReplacePredictionButton(discord.ui.Button):
 
 
 class ViewPredictionsButton(discord.ui.Button):
-    def __init__(self, parent_view: PredictionsPanelView, disabled: bool = False):
+    def __init__(
+        self, parent_view: PredictionsPanelView | UnifiedAdminPanelView, disabled: bool = False
+    ):
         self.parent_view = parent_view
         super().__init__(
             label="View Predictions",
@@ -293,7 +300,9 @@ class ViewPredictionsButton(discord.ui.Button):
 
 
 class ToggleWaiverButton(discord.ui.Button):
-    def __init__(self, parent_view: PredictionsPanelView, disabled: bool = False):
+    def __init__(
+        self, parent_view: PredictionsPanelView | UnifiedAdminPanelView, disabled: bool = False
+    ):
         self.parent_view = parent_view
         super().__init__(
             label="Toggle Late Waiver",

--- a/typer_bot/commands/admin_panel/results.py
+++ b/typer_bot/commands/admin_panel/results.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import discord
 
 from typer_bot.database import Database
@@ -9,7 +11,6 @@ from typer_bot.services import AdminService
 
 from .base import (
     MAX_SELECT_OPTIONS,
-    BackButton,
     FixtureSelect,
     OwnerRestrictedView,
     PanelSelectionState,
@@ -17,6 +18,9 @@ from .base import (
     _render_panel_content,
 )
 from .modals import CorrectResultsModal
+
+if TYPE_CHECKING:
+    from .unified import UnifiedAdminPanelView
 
 
 class ResultsPanelView(OwnerRestrictedView):
@@ -32,7 +36,6 @@ class ResultsPanelView(OwnerRestrictedView):
         self.clear_items()
         self.add_item(self.fixture_select)
         self.add_item(CorrectResultsButton(self, disabled=self.selection.fixture_id is None))
-        self.add_item(BackButton(self))
 
     async def load_fixture_options(self) -> None:
         fixtures = await self.db.get_recent_fixtures(MAX_SELECT_OPTIONS)
@@ -70,7 +73,9 @@ class ResultsPanelView(OwnerRestrictedView):
 
 
 class CorrectResultsButton(discord.ui.Button):
-    def __init__(self, parent_view: ResultsPanelView, disabled: bool = False):
+    def __init__(
+        self, parent_view: ResultsPanelView | UnifiedAdminPanelView, disabled: bool = False
+    ):
         self.parent_view = parent_view
         super().__init__(
             label="Correct Results",
@@ -88,9 +93,14 @@ class CorrectResultsButton(discord.ui.Button):
         if fixture is None:
             self.parent_view.selection.fixture_id = None
             self.parent_view.selection.fixture_label = ""
+            self.parent_view.selection.user_id = None
+            self.parent_view.selection.user_label = ""
             self.parent_view.selection.detail_lines = []
             self.parent_view.selection.status_message = "Fixture no longer exists."
             await self.parent_view.load_fixture_options()
+            load_user_options = getattr(self.parent_view, "load_user_options", None)
+            if callable(load_user_options):
+                await load_user_options()
             self.parent_view._refresh_items()
             await interaction.response.edit_message(
                 content=self.parent_view.render_content(),

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -1,0 +1,125 @@
+"""Unified admin panel view."""
+
+from __future__ import annotations
+
+import discord
+
+from typer_bot.database import Database
+from typer_bot.services import AdminService
+
+from .base import (
+    MAX_SELECT_OPTIONS,
+    FixtureSelect,
+    OwnerRestrictedView,
+    PanelSelectionState,
+    _build_detail_lines,
+    _render_panel_content,
+)
+from .fixtures import FixturesDeleteButton
+from .predictions import (
+    PredictionUserSelect,
+    ReplacePredictionButton,
+    ToggleWaiverButton,
+    ViewPredictionsButton,
+)
+from .results import CorrectResultsButton
+
+
+class UnifiedAdminPanelView(OwnerRestrictedView):
+    """Single admin panel containing fixture, prediction, and results actions.
+
+    This is the exported default view for `/admin panel`. Call
+    `load_fixture_options()` before the initial render so the fixture selector is
+    populated. The unified layout keeps fixture and user selectors in one
+    message, and falls back to `View Predictions` when a fixture has more than
+    25 saved predictions and the user selector cannot show them all.
+    """
+
+    def __init__(
+        self,
+        db: Database,
+        service: AdminService,
+        owner_user_id: str,
+        bot: discord.Client | None = None,
+    ):
+        super().__init__(db, service, owner_user_id, bot=bot)
+        self.selection = PanelSelectionState()
+        self.has_user_overflow = False
+        self.fixture_select = FixtureSelect(self)
+        self.user_select = PredictionUserSelect(self)
+        self.user_select.update_options([])
+        self._refresh_items()
+
+    def _refresh_items(self) -> None:
+        self.clear_items()
+        self.add_item(self.fixture_select)
+        self.add_item(self.user_select)
+        self.add_item(FixturesDeleteButton(self, disabled=self.selection.fixture_id is None))
+        self.add_item(
+            ReplacePredictionButton(
+                self,
+                disabled=self.selection.fixture_id is None or self.selection.user_id is None,
+            )
+        )
+        self.add_item(
+            ToggleWaiverButton(
+                self,
+                disabled=self.selection.fixture_id is None or self.selection.user_id is None,
+            )
+        )
+        self.add_item(CorrectResultsButton(self, disabled=self.selection.fixture_id is None))
+        if self.has_user_overflow:
+            self.add_item(ViewPredictionsButton(self, disabled=self.selection.fixture_id is None))
+
+    async def load_fixture_options(self) -> None:
+        fixtures = await self.db.get_recent_fixtures(MAX_SELECT_OPTIONS)
+        self.fixture_select.update_options(fixtures)
+
+    async def load_user_options(self) -> None:
+        if self.selection.fixture_id is None:
+            self.has_user_overflow = False
+            self.user_select.update_options([])
+            return
+
+        predictions = await self.db.get_all_predictions(self.selection.fixture_id)
+        self.has_user_overflow = len(predictions) > MAX_SELECT_OPTIONS
+        self.user_select.update_options(predictions)
+
+    async def populate_fixture_details(self, fixture: dict | None) -> None:
+        self.selection.detail_lines = []
+        if fixture is None:
+            return
+
+        results = await self.db.get_results(fixture["id"])
+        if results:
+            self.selection.detail_lines = _build_detail_lines(fixture["games"], results)
+
+    def render_content(self) -> str:
+        lines = ["**Admin Panel**"]
+        if self.selection.fixture_label:
+            header = f"Fixture: {self.selection.fixture_label}"
+            if self.selection.user_label:
+                header += f"  •  User: {self.selection.user_label}"
+            lines.append(header)
+            if self.selection.status_message:
+                lines.extend(["", self.selection.status_message])
+            if self.selection.detail_lines:
+                lines.extend(["", *self.selection.detail_lines])
+            else:
+                guidance = "Pick a user to inspect or override predictions, correct results, or delete the fixture."
+                lines.extend(["", guidance])
+
+            if self.has_user_overflow:
+                lines.extend(
+                    [
+                        "",
+                        "More than 25 users predicted this fixture. Use View Predictions for the full list.",
+                    ]
+                )
+        else:
+            lines.append(
+                "Select a fixture to inspect predictions, correct results, toggle waivers, or delete it."
+            )
+            if self.selection.status_message:
+                lines.extend(["", self.selection.status_message])
+        return _render_panel_content(lines)

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -585,7 +585,7 @@ class UserCommands(commands.Cog):
 • `15.02.2024 18:00`
 • `15/02/2024 18:00`
 
-⚠️ No DMs are required for `/predict`, `/admin fixture create`, or `/admin results enter`."""
+Use the commands above directly in Discord."""
 
         await interaction.response.send_message(user_help, ephemeral=True)
 


### PR DESCRIPTION
## Summary
- replace the dead `/admin panel` home router with a single unified admin panel view that opens directly from the command
- keep fixture, prediction, waiver, and results actions in the same panel while preserving inline state display and overflow handling for fixtures with more than 25 predictions
- remove the old back-navigation dependency and add unified-only regression coverage for results correction state handling

Closes #154

## Testing
- `uv run pytest --tb=short`
- `uv run ruff check typer_bot/commands/admin_commands.py typer_bot/commands/admin_panel tests/test_admin_panel.py tests/test_admin_commands.py`
- `uv run ty check typer_bot`
