### PR TITLE
feat: notify users about admin corrections

### DIFF
--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -31,6 +31,10 @@ def _has_button(view: discord.ui.View, label: str) -> bool:
     return any(getattr(child, "label", None) == label for child in view.children)
 
 
+def _selected_option_labels(select: discord.ui.Select) -> list[str]:
+    return [option.label for option in select.options if option.default]
+
+
 class TestAdminPanelCommand:
     """The slash entrypoint should open the panel."""
 
@@ -507,6 +511,8 @@ class TestPredictionPanelFlows:
         assert "3. Team E - Team F 0-2" in mock_interaction_admin.response_sent[-1]["content"]
         assert _get_button(view, "Replace Prediction").disabled is False
         assert _get_button(view, "Toggle Late Waiver").disabled is False
+        assert _selected_option_labels(view.fixture_select) == ["Week 1 [OPEN]"]
+        assert _selected_option_labels(view.user_select) == ["User One"]
 
     @pytest.mark.asyncio
     async def test_prediction_panel_shows_no_predictions_inline_after_fixture_selection(
@@ -715,6 +721,116 @@ class TestPredictionPanelFlows:
         await replace_button.callback(mock_interaction_admin)
 
         assert mock_interaction_admin.modal_sent["modal"].title == "Replace Week 1 Prediction"
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_toggle_waiver_dms_affected_user(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            34, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-0", "1-1", "0-2"],
+            True,
+        )
+        target_user = MockUser("111", "User One")
+        admin_cog.bot.get_user.return_value = target_user
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        view.bot = admin_cog.bot
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        toggle_button = _get_button(view, "Toggle Late Waiver")
+        await toggle_button.callback(mock_interaction_admin)
+
+        assert "late waiver" in target_user.dm_sent[-1].lower()
+        assert _selected_option_labels(view.fixture_select) == ["Week 34 [OPEN]"]
+        assert _selected_option_labels(view.user_select) == ["User One"]
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_toggle_waiver_ignores_dm_failures(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            35, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-0", "1-1", "0-2"],
+            True,
+        )
+        failing_user = MagicMock()
+        failing_user.send = AsyncMock(side_effect=discord.HTTPException(MagicMock(), "dm blocked"))
+        admin_cog.bot.get_user.return_value = failing_user
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        view.bot = admin_cog.bot
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        toggle_button = _get_button(view, "Toggle Late Waiver")
+        await toggle_button.callback(mock_interaction_admin)
+
+        assert "waiver enabled" in mock_interaction_admin.response_sent[-1]["content"].lower()
+
+    @pytest.mark.asyncio
+    async def test_prediction_panel_toggle_waiver_fetches_uncached_user(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            40, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-0", "1-1", "0-2"],
+            True,
+        )
+        target_user = MockUser("111", "User One")
+        admin_cog.bot.get_user.return_value = None
+        admin_cog.bot.fetch_user = AsyncMock(return_value=target_user)
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        view.bot = admin_cog.bot
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        toggle_button = _get_button(view, "Toggle Late Waiver")
+        await toggle_button.callback(mock_interaction_admin)
+
+        admin_cog.bot.fetch_user.assert_awaited_once()
+        assert "late waiver" in target_user.dm_sent[-1].lower()
 
     @pytest.mark.asyncio
     async def test_prediction_panel_replace_recovers_when_prediction_is_deleted(
@@ -1220,12 +1336,13 @@ class TestResultsPanelFlows:
         )
         await admin_cog.db.save_prediction(
             fixture_id,
-            "user-1",
+            "111",
             "User One",
             ["1-0", "1-1", "0-2"],
             False,
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+        admin_cog.bot.get_user.return_value = None
 
         view = UnifiedAdminPanelView(
             admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), bot=admin_cog.bot
@@ -1233,7 +1350,7 @@ class TestResultsPanelFlows:
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
         await view.fixture_select.callback(mock_interaction_admin)
-        view.user_select._values = ["user-1"]
+        view.user_select._values = ["111"]
         await view.user_select.callback(mock_interaction_admin)
 
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
@@ -1247,6 +1364,8 @@ class TestResultsPanelFlows:
         assert view.selection.user_label == ""
         assert "User:" not in mock_interaction_admin.response_sent[-1]["content"]
         assert "1. Team A - Team B 2-1" in mock_interaction_admin.response_sent[-1]["content"]
+        assert _selected_option_labels(view.user_select) == []
+        assert _selected_option_labels(view.fixture_select) == ["Week 32 [OPEN]"]
 
     @pytest.mark.asyncio
     async def test_unified_panel_correct_results_clears_stale_user_on_deleted_fixture(
@@ -1260,7 +1379,7 @@ class TestResultsPanelFlows:
         )
         await admin_cog.db.save_prediction(
             fixture_id,
-            "user-1",
+            "111",
             "User One",
             ["1-0", "1-1", "0-2"],
             False,
@@ -1273,7 +1392,7 @@ class TestResultsPanelFlows:
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
         await view.fixture_select.callback(mock_interaction_admin)
-        view.user_select._values = ["user-1"]
+        view.user_select._values = ["111"]
         await view.user_select.callback(mock_interaction_admin)
         await admin_cog.db.delete_fixture(fixture_id)
 
@@ -1629,6 +1748,142 @@ class TestAdminPanelModals:
         assert "User: User One (on time)" in mock_interaction_admin.response_sent[-1]["content"]
 
     @pytest.mark.asyncio
+    async def test_replace_prediction_modal_dms_affected_user(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            36, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-0", "1-1", "0-0"],
+            False,
+        )
+        target_user = MockUser("111", "User One")
+        admin_cog.bot.get_user.return_value = target_user
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        view.bot = admin_cog.bot
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        prediction = await admin_cog.db.get_prediction(fixture_id, "111")
+        assert fixture is not None
+        assert prediction is not None
+
+        modal = ReplacePredictionModal(view, fixture, prediction)
+        modal.predictions_input._value = (
+            "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+        )
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "updated your Week 36 prediction" in target_user.dm_sent[-1]
+        assert _selected_option_labels(view.fixture_select) == ["Week 36 [OPEN]"]
+        assert _selected_option_labels(view.user_select) == ["User One"]
+
+    @pytest.mark.asyncio
+    async def test_replace_prediction_modal_ignores_dm_failures(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            37, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-0", "1-1", "0-0"],
+            False,
+        )
+        failing_user = MagicMock()
+        failing_user.send = AsyncMock(side_effect=discord.HTTPException(MagicMock(), "dm blocked"))
+        admin_cog.bot.get_user.return_value = failing_user
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        view.bot = admin_cog.bot
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        prediction = await admin_cog.db.get_prediction(fixture_id, "111")
+        assert fixture is not None
+        assert prediction is not None
+
+        modal = ReplacePredictionModal(view, fixture, prediction)
+        modal.predictions_input._value = (
+            "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+        )
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert (
+            "Replaced User One's prediction" in mock_interaction_admin.response_sent[-1]["content"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_replace_prediction_modal_fetches_uncached_user(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            41, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-0", "1-1", "0-0"],
+            False,
+        )
+        target_user = MockUser("111", "User One")
+        admin_cog.bot.get_user.return_value = None
+        admin_cog.bot.fetch_user = AsyncMock(return_value=target_user)
+
+        view = PredictionsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        view.bot = admin_cog.bot
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        prediction = await admin_cog.db.get_prediction(fixture_id, "111")
+        assert fixture is not None
+        assert prediction is not None
+
+        modal = ReplacePredictionModal(view, fixture, prediction)
+        modal.predictions_input._value = (
+            "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+        )
+
+        await modal.on_submit(mock_interaction_admin)
+
+        admin_cog.bot.fetch_user.assert_awaited_once()
+        assert "updated your Week 41 prediction" in target_user.dm_sent[-1]
+
+    @pytest.mark.asyncio
     async def test_replace_prediction_modal_recovers_when_prediction_disappears(
         self,
         admin_cog,
@@ -1786,3 +2041,151 @@ class TestAdminPanelModals:
         )
         assert "1. Team A - Team B 2-1" in mock_interaction_admin.response_sent[-1]["content"]
         assert "Fixture: Week 16 [OPEN]" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_correct_results_modal_dms_all_fixture_participants(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            38, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+        await admin_cog.db.save_prediction(
+            fixture_id, "111", "User One", ["1-0", "1-1", "0-0"], False
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id, "222", "User Two", ["0-0", "2-2", "1-1"], False
+        )
+        user_one = MockUser("111", "User One")
+        user_two = MockUser("222", "User Two")
+        admin_cog.bot.get_user.side_effect = lambda user_id: {111: user_one, 222: user_two}.get(
+            user_id
+        )
+
+        view = ResultsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        view.bot = admin_cog.bot
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
+        modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "Results were corrected for Week 38." in user_one.dm_sent[-1]
+        assert "Results were corrected for Week 38." in user_two.dm_sent[-1]
+
+    @pytest.mark.asyncio
+    async def test_correct_results_modal_ignores_dm_failures(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            39, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+        await admin_cog.db.save_prediction(
+            fixture_id, "111", "User One", ["1-0", "1-1", "0-0"], False
+        )
+        failing_user = MagicMock()
+        failing_user.send = AsyncMock(side_effect=discord.HTTPException(MagicMock(), "dm blocked"))
+        admin_cog.bot.get_user.return_value = failing_user
+
+        view = ResultsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        view.bot = admin_cog.bot
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
+        modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert (
+            "Saved corrected results for week 39."
+            in mock_interaction_admin.response_sent[-1]["content"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_correct_results_modal_continues_after_one_dm_failure(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            42, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+        await admin_cog.db.save_prediction(
+            fixture_id, "111", "User One", ["1-0", "1-1", "0-0"], False
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id, "222", "User Two", ["0-0", "2-2", "1-1"], False
+        )
+        failing_user = MagicMock()
+        failing_user.send = AsyncMock(side_effect=discord.HTTPException(MagicMock(), "dm blocked"))
+        user_two = MockUser("222", "User Two")
+        admin_cog.bot.get_user.side_effect = lambda user_id: {111: failing_user, 222: user_two}.get(
+            user_id
+        )
+
+        view = ResultsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        view.bot = admin_cog.bot
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
+        modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "Results were corrected for Week 42." in user_two.dm_sent[-1]
+
+    @pytest.mark.asyncio
+    async def test_correct_results_modal_continues_after_fetch_user_failure(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            43, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+        await admin_cog.db.save_prediction(
+            fixture_id, "111", "User One", ["1-0", "1-1", "0-0"], False
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id, "222", "User Two", ["0-0", "2-2", "1-1"], False
+        )
+        user_two = MockUser("222", "User Two")
+        admin_cog.bot.get_user.return_value = None
+        admin_cog.bot.fetch_user = AsyncMock(
+            side_effect=[discord.HTTPException(MagicMock(), "fetch failed"), user_two]
+        )
+
+        view = ResultsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+        )
+        view.bot = admin_cog.bot
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+
+        modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
+        modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "Results were corrected for Week 43." in user_two.dm_sent[-1]

--- a/typer_bot/commands/admin_panel/base.py
+++ b/typer_bot/commands/admin_panel/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -19,6 +20,8 @@ if TYPE_CHECKING:
 
 MAX_SELECT_OPTIONS = 25
 MAX_PANEL_CONTENT_LENGTH = 1900
+
+logger = logging.getLogger(__name__)
 
 
 def _fixture_select_label(fixture: dict) -> str:
@@ -137,6 +140,45 @@ class OwnerRestrictedView(discord.ui.View):
         return True
 
 
+async def _notify_user_dm(
+    bot: discord.Client | None,
+    user_id: str,
+    message: str,
+    *,
+    context: str,
+) -> None:
+    """Send a best-effort DM notification for admin correction actions.
+
+    This helper expects a numeric Discord user ID string, falls back to
+    `fetch_user()` when the user is uncached, and logs/swallow failures instead
+    of raising so admin actions never depend on DM delivery.
+    """
+    if bot is None:
+        return
+
+    try:
+        discord_user_id = int(user_id)
+    except ValueError:
+        logger.warning("Could not parse user id %s for %s notification", user_id, context)
+        return
+
+    user = bot.get_user(discord_user_id)
+    if user is None:
+        fetch_user = getattr(bot, "fetch_user", None)
+        if fetch_user is None:
+            return
+        try:
+            user = await fetch_user(discord_user_id)
+        except discord.HTTPException:
+            logger.warning("Could not fetch user %s for %s notification", user_id, context)
+            return
+
+    try:
+        await user.send(message)
+    except discord.HTTPException:
+        logger.warning("Could not DM user %s for %s notification", user_id, context)
+
+
 class FixtureSelect(discord.ui.Select):
     """Shared fixture selector that updates panel selection state in place.
 
@@ -144,6 +186,9 @@ class FixtureSelect(discord.ui.Select):
     selected fixture label + status. Subviews can optionally react to fixture
     changes by exposing `populate_fixture_details()` and/or `load_user_options()`.
     The selector calls those hooks before re-rendering the panel.
+
+    Re-rendered Discord selects lose their visible selection unless the active
+    option is re-marked as `default`, so this component re-applies that state.
     """
 
     def __init__(
@@ -172,10 +217,20 @@ class FixtureSelect(discord.ui.Select):
                 label=_fixture_select_label(fixture),
                 value=str(fixture["id"]),
                 description=_fixture_select_description(fixture),
+                default=self.parent_view.selection.fixture_id == fixture["id"],
             )
             for fixture in fixtures[:MAX_SELECT_OPTIONS]
         ]
         self.disabled = False
+
+    def sync_selected_option(self) -> None:
+        selected_value = (
+            str(self.parent_view.selection.fixture_id)
+            if self.parent_view.selection.fixture_id is not None
+            else None
+        )
+        for option in self.options:
+            option.default = option.value == selected_value
 
     async def callback(self, interaction: discord.Interaction):
         if self.values[0] == "none":
@@ -207,6 +262,8 @@ class FixtureSelect(discord.ui.Select):
         load_user_options = getattr(self.parent_view, "load_user_options", None)
         if callable(load_user_options):
             await load_user_options()
+
+        self.sync_selected_option()
 
         refresh_items = getattr(self.parent_view, "_refresh_items", None)
         if callable(refresh_items):

--- a/typer_bot/commands/admin_panel/modals.py
+++ b/typer_bot/commands/admin_panel/modals.py
@@ -10,7 +10,12 @@ import discord
 from typer_bot.database import Database
 from typer_bot.utils import APP_TZ, format_for_discord, is_admin, now, parse_line_predictions
 
-from .base import _build_detail_lines, _format_prediction_line, _prediction_status_text
+from .base import (
+    _build_detail_lines,
+    _format_prediction_line,
+    _notify_user_dm,
+    _prediction_status_text,
+)
 
 if TYPE_CHECKING:
     from .predictions import PredictionsPanelView
@@ -361,7 +366,11 @@ class EnterResultsModal(discord.ui.Modal):
 
 
 class ReplacePredictionModal(discord.ui.Modal):
-    """Collect corrected prediction lines and trigger optional score recalculation."""
+    """Collect corrected prediction lines and trigger optional score recalculation.
+
+    Successful submits also send a best-effort DM to the affected user. DM
+    delivery failures are logged and do not block the admin action.
+    """
 
     def __init__(
         self,
@@ -450,14 +459,28 @@ class ReplacePredictionModal(discord.ui.Modal):
             view=self.parent_view,
         )
 
+        notification_lines = [
+            f"An admin updated your Week {fixture['week_number']} prediction.",
+            "",
+            *self.parent_view.selection.detail_lines,
+        ]
+        if recalculation is not None:
+            notification_lines.extend(["", "Scores were recalculated."])
+        await _notify_user_dm(
+            self.parent_view.bot,
+            updated_prediction["user_id"],
+            "\n".join(notification_lines),
+            context="prediction replacement",
+        )
+
 
 class CorrectResultsModal(discord.ui.Modal):
     """Collect corrected results input for a fixture from the admin panel.
 
     Successful submits update the parent panel inline, clear any stale selected
-    prediction user, and may trigger score recalculation. If the fixture
-    disappears mid-flow, the parent panel reloads its selectors before
-    re-rendering the error state.
+    prediction user, may trigger score recalculation, and send best-effort DMs
+    to all participants for that fixture. If the fixture disappears mid-flow,
+    the parent panel reloads its selectors before re-rendering the error state.
     """
 
     def __init__(
@@ -546,3 +569,20 @@ class CorrectResultsModal(discord.ui.Modal):
             content=self.parent_view.render_content(),
             view=self.parent_view,
         )
+
+        predictions = await self.parent_view.db.get_all_predictions(fixture["id"])
+        dm_message_lines = [
+            f"Results were corrected for Week {fixture['week_number']}.",
+            "",
+            *self.parent_view.selection.detail_lines,
+        ]
+        if recalculation is not None:
+            dm_message_lines.extend(["", "Scores were recalculated."])
+        dm_message = "\n".join(dm_message_lines)
+        for prediction in predictions:
+            await _notify_user_dm(
+                self.parent_view.bot,
+                prediction["user_id"],
+                dm_message,
+                context="results correction",
+            )

--- a/typer_bot/commands/admin_panel/predictions.py
+++ b/typer_bot/commands/admin_panel/predictions.py
@@ -15,6 +15,7 @@ from .base import (
     OwnerRestrictedView,
     PanelSelectionState,
     _build_detail_lines,
+    _notify_user_dm,
     _prediction_status_text,
     _render_panel_content,
 )
@@ -102,7 +103,11 @@ class PredictionsPanelView(OwnerRestrictedView):
 
 
 class PredictionUserSelect(discord.ui.Select):
-    """Select a user who already has a prediction for the chosen fixture."""
+    """Select a user who already has a prediction for the chosen fixture.
+
+    Refreshed option lists re-mark the active user as `default` so Discord keeps
+    the visible selection after panel re-renders.
+    """
 
     def __init__(self, parent_view: PredictionsPanelView | UnifiedAdminPanelView):
         self.parent_view = parent_view
@@ -125,10 +130,16 @@ class PredictionUserSelect(discord.ui.Select):
                 label=prediction["user_name"][:100],
                 value=prediction["user_id"],
                 description=_prediction_status_text(prediction)[:100],
+                default=self.parent_view.selection.user_id == prediction["user_id"],
             )
             for prediction in ordered[:MAX_SELECT_OPTIONS]
         ]
         self.disabled = False
+
+    def sync_selected_option(self) -> None:
+        selected_value = self.parent_view.selection.user_id
+        for option in self.options:
+            option.default = option.value == selected_value
 
     async def callback(self, interaction: discord.Interaction):
         if self.values[0] == "none":
@@ -174,6 +185,8 @@ class PredictionUserSelect(discord.ui.Select):
                 fixture["games"], prediction["predictions"]
             )
             self.parent_view.selection.status_message = ""
+
+        self.sync_selected_option()
 
         self.parent_view._refresh_items()
 
@@ -300,6 +313,8 @@ class ViewPredictionsButton(discord.ui.Button):
 
 
 class ToggleWaiverButton(discord.ui.Button):
+    """Toggle the late waiver flag and best-effort DM the affected user."""
+
     def __init__(
         self, parent_view: PredictionsPanelView | UnifiedAdminPanelView, disabled: bool = False
     ):
@@ -413,4 +428,15 @@ class ToggleWaiverButton(discord.ui.Button):
         await interaction.response.edit_message(
             content=self.parent_view.render_content(),
             view=self.parent_view,
+        )
+
+        status_line = "enabled" if prediction["late_penalty_waived"] else "disabled"
+        notification = f"An admin {status_line} the late waiver for your Week {fixture['week_number']} prediction."
+        if recalculation is not None:
+            notification += " Scores were recalculated."
+        await _notify_user_dm(
+            self.parent_view.bot,
+            prediction["user_id"],
+            notification,
+            context="late waiver update",
         )


### PR DESCRIPTION
## Summary
- retain visible fixture/user selection in the admin panel after refreshes where possible
- send best-effort DMs when admins replace predictions, toggle late waivers, or correct stored results
- add coverage for notification delivery/failure paths and unified-panel selection clearing after results correction

Closes #101

## Testing
- `uv run pytest --tb=short`
- `uv run ruff check typer_bot/commands/admin_commands.py typer_bot/commands/admin_panel tests/test_admin_panel.py tests/test_admin_commands.py`
- `uv run ty check typer_bot`
