### PR TITLE
refactor: make admin panel the primary surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,17 @@ Discord bot for weekly football prediction leagues. Admins create fixtures and e
 - `/standings` - show the leaderboard and latest scored fixture
 
 ### Admin commands
-- `/admin panel` - open the admin panel for deletion, overrides, waivers, and result correction
-- `/admin fixture create` - create a fixture by modal and post its prediction thread
-- `/admin fixture delete [week]` - delete an open fixture
-- `/admin results enter [week]` - enter actual results by modal
-- `/admin results calculate [week]` - calculate scores and post results
-- `/admin results post` - repost results with optional mentions
+- `/admin panel` - open the main admin surface
+
+Inside the panel you can:
+- create fixtures
+- delete fixtures
+- jump to older open weeks not shown in the quick list
+- enter or correct results
+- calculate scores
+- re-post the latest completed results with optional mentions
+- replace predictions
+- toggle late waivers
 
 Admins need a Discord role named `Admin` or `typer-admin`.
 
@@ -62,7 +67,7 @@ Team E - Team F 3:2
 ## Operational constraints
 - Match data, predictions, results, and scores are stored in SQLite.
 - Short-lived cooldowns are kept in memory.
-- This includes the thread-post rate limiter and the `/admin results calculate` cooldown.
+- This includes the thread-post rate limiter and the score-calculation cooldown.
 - The bot is intentionally single-process for v1. If the process restarts, in-memory cooldowns reset.
 
 ## Configuration
@@ -154,7 +159,7 @@ uv run ty check typer_bot
 
 ## Backup and Restore
 
-- Automatic: the database is backed up after each successful `/admin results calculate`. The bot keeps the latest 10 backups in `BACKUP_DIR`.
+- Automatic: the database is backed up after each successful score calculation. The bot keeps the latest 10 backups in `BACKUP_DIR`.
 - Manual restore: run from the Railway shell.
 
 ```bash

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -3,16 +3,13 @@
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
-import discord
 import pytest
 
 from typer_bot.commands.admin_commands import (
     CALCULATE_COOLDOWN,
     AdminCommands,
-    PostResultsConfirmView,
 )
-from typer_bot.commands.admin_panel import CreateFixtureModal, EnterResultsModal
-from typer_bot.services.admin_service import FixtureScoreResult
+from typer_bot.commands.admin_panel import PostResultsConfirmView, UnifiedAdminPanelView
 from typer_bot.utils import now
 from typer_bot.utils.permissions import is_admin
 
@@ -50,154 +47,20 @@ class TestAdminOnlyDecorator:
         assert result is True
 
 
-class TestFixtureCreateLogic:
-    """Test suite for fixture create command logic."""
-
+class TestAdminPanelEntry:
     @pytest.fixture
     def admin_cog(self, mock_bot, database):
         mock_bot.db = database
         return AdminCommands(mock_bot)
 
     @pytest.mark.asyncio
-    async def test_fixture_create_opens_modal(self, admin_cog, mock_interaction_admin):
-        channel = MagicMock(spec=discord.TextChannel)
-        channel.id = mock_interaction_admin.channel.id
-        mock_interaction_admin.channel = channel
+    async def test_admin_panel_opens_unified_view(self, admin_cog, mock_interaction_admin):
+        await admin_cog.panel.callback(admin_cog, mock_interaction_admin)
 
-        await admin_cog.fixture_create.callback(admin_cog, mock_interaction_admin)
+        assert isinstance(mock_interaction_admin.response_sent[0]["view"], UnifiedAdminPanelView)
 
-        assert isinstance(mock_interaction_admin.modal_sent["modal"], CreateFixtureModal)
-
-    @pytest.mark.asyncio
-    async def test_fixture_create_from_thread_uses_parent_channel(
-        self, admin_cog, mock_interaction_admin
-    ):
-        parent_channel = MagicMock(spec=discord.TextChannel)
-        parent_channel.id = 123456
-        thread = MagicMock(spec=discord.Thread)
-        thread.parent = parent_channel
-        mock_interaction_admin.channel = thread
-
-        await admin_cog.fixture_create.callback(admin_cog, mock_interaction_admin)
-
-        assert mock_interaction_admin.modal_sent["modal"].channel is parent_channel
-
-    @pytest.mark.asyncio
-    async def test_fixture_create_still_opens_modal_when_open_fixture_exists(
-        self, admin_cog, mock_interaction_admin, sample_games
-    ):
-        channel = MagicMock(spec=discord.TextChannel)
-        channel.id = mock_interaction_admin.channel.id
-        mock_interaction_admin.channel = channel
-        await admin_cog.db.create_fixture(5, sample_games, datetime.now(UTC) + timedelta(days=1))
-
-        await admin_cog.fixture_create.callback(admin_cog, mock_interaction_admin)
-
-        assert isinstance(mock_interaction_admin.modal_sent["modal"], CreateFixtureModal)
-
-    @pytest.mark.asyncio
-    async def test_fixture_create_opens_modal_when_no_open_fixtures(
-        self, admin_cog, mock_interaction_admin
-    ):
-        channel = MagicMock(spec=discord.TextChannel)
-        channel.id = mock_interaction_admin.channel.id
-        mock_interaction_admin.channel = channel
-        await admin_cog.fixture_create.callback(admin_cog, mock_interaction_admin)
-
-        assert isinstance(mock_interaction_admin.modal_sent["modal"], CreateFixtureModal)
-
-
-class TestFixtureDeleteLogic:
-    """Test suite for fixture delete command logic."""
-
-    @pytest.fixture
-    def admin_cog(self, mock_bot, database):
-        mock_bot.db = database
-        return AdminCommands(mock_bot)
-
-    @pytest.mark.asyncio
-    async def test_fixture_delete_no_active_fixture(self, database):
-        """Deleting without an active fixture fails gracefully."""
-        fixture = await database.get_current_fixture()
-        assert fixture is None
-
-    @pytest.mark.asyncio
-    async def test_fixture_delete_deletes_fixture(self, database, sample_games):
-        """Fixture deletion cascades to predictions and results."""
-        deadline = datetime.now(UTC) + timedelta(days=1)
-        fixture_id = await database.create_fixture(1, sample_games, deadline)
-
-        fixture = await database.get_fixture_by_id(fixture_id)
-        assert fixture is not None
-
-        await database.delete_fixture(fixture_id)
-
-        fixture = await database.get_fixture_by_id(fixture_id)
-        assert fixture is None
-
-    @pytest.mark.asyncio
-    async def test_fixture_delete_shows_picker_when_multiple_open(
-        self, admin_cog, mock_interaction_admin, sample_games
-    ):
-        deadline = datetime.now(UTC) + timedelta(days=1)
-        await admin_cog.db.create_fixture(1, sample_games, deadline)
-        await admin_cog.db.create_fixture(2, sample_games, deadline)
-
-        await admin_cog.fixture_delete.callback(admin_cog, mock_interaction_admin, None)
-
-        assert "Multiple fixtures are open" in mock_interaction_admin.response_sent[0]["content"]
-        assert isinstance(mock_interaction_admin.response_sent[0]["view"], discord.ui.View)
-
-    @pytest.mark.asyncio
-    async def test_fixture_delete_picker_opens_confirmation(
-        self, admin_cog, mock_interaction_admin, sample_games
-    ):
-        deadline = datetime.now(UTC) + timedelta(days=1)
-        first_id = await admin_cog.db.create_fixture(1, sample_games, deadline)
-        await admin_cog.db.create_fixture(2, sample_games, deadline)
-
-        await admin_cog.fixture_delete.callback(admin_cog, mock_interaction_admin, None)
-
-        view = mock_interaction_admin.response_sent[0]["view"]
-        select = view.children[0]
-        select._values = [str(first_id)]
-        await select.callback(mock_interaction_admin)
-
-        assert "Delete Week 1?" in mock_interaction_admin.response_sent[-1]["content"]
-
-
-class TestResultsEnterLogic:
-    """Test suite for results enter command logic."""
-
-    @pytest.fixture
-    def admin_cog(self, mock_bot, database):
-        mock_bot.db = database
-        return AdminCommands(mock_bot)
-
-    @pytest.mark.asyncio
-    async def test_results_enter_opens_modal(self, admin_cog, mock_interaction_admin, sample_games):
-        deadline = datetime.now(UTC) + timedelta(days=1)
-        await admin_cog.db.create_fixture(1, sample_games, deadline)
-
-        await admin_cog.results_enter.callback(admin_cog, mock_interaction_admin, 1)
-
-        assert isinstance(mock_interaction_admin.modal_sent["modal"], EnterResultsModal)
-        assert mock_interaction_admin.modal_sent["modal"].title == "Enter Week 1 Results"
-
-    @pytest.mark.asyncio
-    async def test_results_enter_rejects_fixture_that_already_has_results(
-        self, admin_cog, mock_interaction_admin, sample_games
-    ):
-        """Re-entering results routes admins to correction/calculate flows instead of starting a DM."""
-        deadline = datetime.now(UTC) + timedelta(days=1)
-        fixture_id = await admin_cog.db.create_fixture(1, sample_games, deadline)
-        await admin_cog.db.save_results(fixture_id, ["2-1", "1-1", "0-2"])
-        mock_interaction_admin.guild_id = mock_interaction_admin.guild.id
-
-        await admin_cog.results_enter.callback(admin_cog, mock_interaction_admin, 1)
-
-        assert "Results already entered" in mock_interaction_admin.response_sent[0]["content"]
-        assert mock_interaction_admin.user.dm_sent == []
+    def test_admin_group_exposes_only_panel_command(self, admin_cog):
+        assert [command.name for command in admin_cog.admin.commands] == ["panel"]
 
 
 class TestResultsCalculateLogic:
@@ -270,148 +133,12 @@ class TestResultsCalculateLogic:
         assert standings[0]["user_name"] == "User1"
         assert standings[0]["total_points"] == 9
 
-    @pytest.mark.asyncio
-    async def test_results_calculate_records_cooldown_and_calls_followup_steps(
-        self, admin_cog, mock_interaction_admin, monkeypatch
-    ):
-        """Successful calculation records cooldown, creates a backup, and posts results."""
-        fixture = {"id": 7, "week_number": 7, "games": ["A - B"], "deadline": datetime.now(UTC)}
-        score_result = FixtureScoreResult(
-            fixture=fixture,
-            results=["2-1"],
-            predictions=[
-                {
-                    "user_id": "123",
-                    "user_name": "User1",
-                    "predictions": ["2-1"],
-                    "is_late": False,
-                    "late_penalty_waived": False,
-                }
-            ],
-            scores=[
-                {
-                    "user_id": "123",
-                    "user_name": "User1",
-                    "points": 3,
-                    "exact_scores": 1,
-                    "correct_results": 1,
-                }
-            ],
-            standings=[
-                {
-                    "user_id": "123",
-                    "user_name": "User1",
-                    "total_points": 3,
-                    "total_exact": 1,
-                    "total_correct": 1,
-                }
-            ],
-            last_fixture=None,
-        )
-        monkeypatch.setattr(admin_cog.db, "get_open_fixtures", AsyncMock(return_value=[fixture]))
-        admin_cog.service.calculate_fixture_scores = AsyncMock(return_value=score_result)
-        admin_cog._create_backup = AsyncMock()
-        admin_cog._post_calculation_to_channel = AsyncMock()
-
-        await admin_cog.results_calculate.callback(admin_cog, mock_interaction_admin, None)
-
-        user_id = str(mock_interaction_admin.user.id)
-        assert admin_cog.get_calculate_cooldown(user_id) is not None
-        admin_cog.service.calculate_fixture_scores.assert_called_once_with(7)
-        admin_cog._create_backup.assert_called_once()
-        admin_cog._post_calculation_to_channel.assert_called_once_with(
-            mock_interaction_admin, score_result
-        )
-
-    @pytest.mark.asyncio
-    async def test_results_calculate_does_not_record_cooldown_when_scoring_fails(
-        self, admin_cog, mock_interaction_admin, monkeypatch
-    ):
-        """Validation failures should not throttle a retry after the admin fixes results state."""
-        fixture = {"id": 7, "week_number": 7, "games": ["A - B"], "deadline": datetime.now(UTC)}
-
-        monkeypatch.setattr(admin_cog.db, "get_open_fixtures", AsyncMock(return_value=[fixture]))
-        admin_cog.service.calculate_fixture_scores = AsyncMock(
-            side_effect=ValueError("No results entered")
-        )
-        admin_cog._create_backup = AsyncMock()
-        admin_cog._post_calculation_to_channel = AsyncMock()
-
-        await admin_cog.results_calculate.callback(admin_cog, mock_interaction_admin, None)
-
-        user_id = str(mock_interaction_admin.user.id)
-        assert admin_cog.get_calculate_cooldown(user_id) is None
-        assert mock_interaction_admin.response_sent[-1]["content"] == "No results entered"
-        admin_cog._create_backup.assert_not_called()
-        admin_cog._post_calculation_to_channel.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_results_calculate_rejects_active_cooldown(
-        self, admin_cog, mock_interaction_admin
-    ):
-        """Cooldown should stop duplicate clicks before any scoring work starts."""
-        user_id = str(mock_interaction_admin.user.id)
-        admin_cog.record_calculate_cooldown(user_id, current_time=now().timestamp())
-        admin_cog.service.calculate_fixture_scores = AsyncMock()
-
-        await admin_cog.results_calculate.callback(admin_cog, mock_interaction_admin, None)
-
-        assert "Please wait" in mock_interaction_admin.response_sent[-1]["content"]
-        admin_cog.service.calculate_fixture_scores.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_results_calculate_reports_missing_open_fixture(
-        self, admin_cog, mock_interaction_admin
-    ):
-        """Missing fixture selection should fail through the slash-command response path."""
-        await admin_cog.results_calculate.callback(admin_cog, mock_interaction_admin, None)
-
-        assert mock_interaction_admin.response_sent[-1]["content"] == "No open fixtures found!"
-
 
 class TestResultsPostFlow:
     @pytest.fixture
     def admin_cog(self, mock_bot, database):
         mock_bot.db = database
         return AdminCommands(mock_bot)
-
-    @pytest.mark.asyncio
-    async def test_results_post_rejects_non_text_channel(self, admin_cog, mock_interaction_admin):
-        """Slash command rejects preview posting outside text channels."""
-        admin_cog.db.get_last_fixture_scores = AsyncMock(
-            return_value={
-                "week_number": 1,
-                "games": ["A - B"],
-                "results": ["2-1"],
-                "scores": [
-                    {
-                        "user_id": "123",
-                        "user_name": "User1",
-                        "points": 3,
-                        "exact_scores": 1,
-                        "correct_results": 1,
-                    }
-                ],
-            }
-        )
-        admin_cog.db.get_standings = AsyncMock(
-            return_value=[
-                {
-                    "user_id": "123",
-                    "user_name": "User1",
-                    "total_points": 3,
-                    "total_exact": 1,
-                    "total_correct": 1,
-                }
-            ]
-        )
-
-        await admin_cog.results_post.callback(admin_cog, mock_interaction_admin)
-
-        assert (
-            mock_interaction_admin.response_sent[0]["content"]
-            == "This command can only be used in text channels."
-        )
 
     @pytest.mark.asyncio
     async def test_post_results_view_posts_without_mentions(
@@ -441,8 +168,8 @@ class TestResultsPostFlow:
                 "total_correct": 1,
             }
         ]
-        view = PostResultsConfirmView(MagicMock(), fixture_data, standings, mock_text_channel)
-        no_button = next(child for child in view.children if child.label == "NO")
+        view = PostResultsConfirmView(fixture_data, standings, mock_text_channel)
+        no_button = next(child for child in view.children if child.label == "No Mentions")
 
         await no_button.callback(mock_interaction_admin)
 
@@ -481,8 +208,8 @@ class TestResultsPostFlow:
                 "total_correct": 1,
             }
         ]
-        view = PostResultsConfirmView(MagicMock(), fixture_data, standings, mock_text_channel)
-        yes_button = next(child for child in view.children if child.label == "YES")
+        view = PostResultsConfirmView(fixture_data, standings, mock_text_channel)
+        yes_button = next(child for child in view.children if child.label == "Mention Users")
 
         await yes_button.callback(mock_interaction_admin)
 
@@ -520,8 +247,8 @@ class TestResultsPostFlow:
             }
         ]
         mock_text_channel.send = AsyncMock(side_effect=RuntimeError("boom"))
-        view = PostResultsConfirmView(MagicMock(), fixture_data, standings, mock_text_channel)
-        no_button = next(child for child in view.children if child.label == "NO")
+        view = PostResultsConfirmView(fixture_data, standings, mock_text_channel)
+        no_button = next(child for child in view.children if child.label == "No Mentions")
 
         await no_button.callback(mock_interaction_admin)
 
@@ -530,6 +257,80 @@ class TestResultsPostFlow:
             == "Results posted without mentions!"
         )
         assert mock_interaction_admin.followup_sent[-1]["content"] == "Failed to post results: boom"
+
+    @pytest.mark.asyncio
+    async def test_post_results_view_aborts_when_acknowledgement_fails(
+        self, mock_text_channel, mock_interaction_admin
+    ):
+        fixture_data = {
+            "week_number": 1,
+            "games": ["A - B"],
+            "results": ["2-1"],
+            "scores": [
+                {
+                    "user_id": "123",
+                    "user_name": "User1",
+                    "points": 3,
+                    "exact_scores": 1,
+                    "correct_results": 1,
+                }
+            ],
+        }
+        standings = [
+            {
+                "user_id": "123",
+                "user_name": "User1",
+                "total_points": 3,
+                "total_exact": 1,
+                "total_correct": 1,
+            }
+        ]
+        mock_interaction_admin.response.edit_message = AsyncMock(
+            side_effect=RuntimeError("expired")
+        )
+        view = PostResultsConfirmView(fixture_data, standings, mock_text_channel)
+        no_button = next(child for child in view.children if child.label == "No Mentions")
+
+        await no_button.callback(mock_interaction_admin)
+
+        assert mock_text_channel.messages_sent == []
+
+    @pytest.mark.asyncio
+    async def test_post_results_view_mentions_branch_aborts_when_acknowledgement_fails(
+        self, mock_text_channel, mock_interaction_admin
+    ):
+        fixture_data = {
+            "week_number": 1,
+            "games": ["A - B"],
+            "results": ["2-1"],
+            "scores": [
+                {
+                    "user_id": "123",
+                    "user_name": "User1",
+                    "points": 3,
+                    "exact_scores": 1,
+                    "correct_results": 1,
+                }
+            ],
+        }
+        standings = [
+            {
+                "user_id": "123",
+                "user_name": "User1",
+                "total_points": 3,
+                "total_exact": 1,
+                "total_correct": 1,
+            }
+        ]
+        mock_interaction_admin.response.edit_message = AsyncMock(
+            side_effect=RuntimeError("expired")
+        )
+        view = PostResultsConfirmView(fixture_data, standings, mock_text_channel)
+        yes_button = next(child for child in view.children if child.label == "Mention Users")
+
+        await yes_button.callback(mock_interaction_admin)
+
+        assert mock_text_channel.messages_sent == []
 
 
 class TestCalculationPostFormat:
@@ -595,85 +396,3 @@ class TestCooldownLogic:
         removed = admin_cog.cleanup_expired_state()
 
         assert removed == 1
-
-
-class TestMultiOpenFixtureTargeting:
-    """Test suite for explicit week targeting when multiple fixtures are open."""
-
-    @pytest.fixture
-    def admin_cog(self, mock_bot, database):
-        mock_bot.db = database
-        return AdminCommands(mock_bot)
-
-    @pytest.mark.asyncio
-    async def test_fixture_delete_requires_week_when_multiple_open(
-        self,
-        admin_cog,
-        mock_interaction_admin,
-        sample_games,
-    ):
-        """Delete command shows a picker when multiple fixtures are open."""
-        deadline = datetime.now(UTC) + timedelta(days=1)
-        await admin_cog.db.create_fixture(1, sample_games, deadline)
-        await admin_cog.db.create_fixture(2, sample_games, deadline)
-
-        await admin_cog.fixture_delete.callback(admin_cog, mock_interaction_admin, None)
-
-        assert len(mock_interaction_admin.response_sent) == 1
-        content = mock_interaction_admin.response_sent[0]["content"]
-        assert "Multiple fixtures are open" in content
-        assert mock_interaction_admin.response_sent[0]["view"] is not None
-
-    @pytest.mark.asyncio
-    async def test_results_enter_targets_explicit_week(
-        self,
-        admin_cog,
-        mock_interaction_admin,
-        sample_games,
-    ):
-        """Results modal targets the requested open fixture week."""
-        deadline = datetime.now(UTC) + timedelta(days=1)
-        await admin_cog.db.create_fixture(1, sample_games, deadline)
-        await admin_cog.db.create_fixture(2, sample_games, deadline)
-
-        await admin_cog.results_enter.callback(admin_cog, mock_interaction_admin, 1)
-
-        assert mock_interaction_admin.modal_sent["modal"].title == "Enter Week 1 Results"
-
-    @pytest.mark.asyncio
-    async def test_results_calculate_requires_week_when_multiple_open(
-        self,
-        admin_cog,
-        mock_interaction_admin,
-        sample_games,
-    ):
-        """Calculate command requires explicit week when more than one fixture is open."""
-        deadline = datetime.now(UTC) + timedelta(days=1)
-        await admin_cog.db.create_fixture(1, sample_games, deadline)
-        await admin_cog.db.create_fixture(2, sample_games, deadline)
-
-        user_id = str(mock_interaction_admin.user.id)
-        await admin_cog.results_calculate.callback(admin_cog, mock_interaction_admin, None)
-
-        assert len(mock_interaction_admin.response_sent) == 1
-        content = mock_interaction_admin.response_sent[0]["content"]
-        assert "Multiple fixtures are currently open" in content
-        assert admin_cog.get_calculate_cooldown(user_id) is None
-
-    @pytest.mark.asyncio
-    async def test_results_enter_rejects_duplicate_open_week_numbers(
-        self,
-        admin_cog,
-        mock_interaction_admin,
-        sample_games,
-    ):
-        """Duplicate open week numbers are rejected to avoid targeting wrong fixture."""
-        deadline = datetime.now(UTC) + timedelta(days=1)
-        await admin_cog.db.create_fixture(5, sample_games, deadline)
-        await admin_cog.db.create_fixture(5, sample_games, deadline)
-
-        await admin_cog.results_enter.callback(admin_cog, mock_interaction_admin, 5)
-
-        assert len(mock_interaction_admin.response_sent) == 1
-        content = mock_interaction_admin.response_sent[0]["content"]
-        assert "More than one open fixture was found for week 5" in content

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -14,6 +14,7 @@ from typer_bot.commands.admin_panel import (
     DeleteConfirmView,
     EnterResultsModal,
     FixturesPanelView,
+    PostResultsConfirmView,
     PredictionsPanelView,
     ReplacePredictionModal,
     ResultsPanelView,
@@ -21,6 +22,7 @@ from typer_bot.commands.admin_panel import (
 )
 from typer_bot.commands.admin_panel.fixtures import _cleanup_discord_announcement
 from typer_bot.database import Database
+from typer_bot.utils import now
 
 
 def _get_button(view: discord.ui.View, label: str) -> discord.ui.Button:
@@ -457,7 +459,11 @@ class TestPredictionPanelFlows:
         await admin_cog.db.create_fixture(1, sample_games, datetime.now(UTC) + timedelta(days=1))
 
         unified_view = UnifiedAdminPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), bot=admin_cog.bot
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
         )
         await unified_view.load_fixture_options()
 
@@ -1000,7 +1006,11 @@ class TestFixturePanelFlows:
         await admin_cog.db.create_fixture(4, sample_games, datetime.now(UTC) + timedelta(days=1))
 
         view = UnifiedAdminPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), bot=admin_cog.bot
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
         )
         await view.load_fixture_options()
 
@@ -1044,7 +1054,11 @@ class TestFixturePanelFlows:
         )
 
         view = UnifiedAdminPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), bot=admin_cog.bot
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
         )
         await view.load_fixture_options()
 
@@ -1059,6 +1073,429 @@ class TestFixturePanelFlows:
         confirmation_content = mock_interaction_admin.response_sent[-1]["content"]
         assert "Delete Week 6?" in confirmation_content
         assert "Team A - Team B" in confirmation_content
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_create_fixture_button_opens_modal(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+    ):
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.id = mock_interaction_admin.channel.id
+        mock_interaction_admin.channel = channel
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        create_button = _get_button(view, "Create Fixture")
+
+        await create_button.callback(mock_interaction_admin)
+
+        assert isinstance(mock_interaction_admin.modal_sent["modal"], CreateFixtureModal)
+
+    def test_unified_panel_layout_contract(self, admin_cog, mock_interaction_admin):
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+
+        labels = [getattr(child, "label", None) for child in view.children]
+        assert labels == [
+            None,
+            None,
+            "Create Fixture",
+            "Enter Results",
+            "Delete Fixture",
+            "Replace Prediction",
+            "Toggle Late Waiver",
+            "Calculate Scores",
+            "Correct Results",
+            "Jump To Week",
+            "Re-post Results",
+        ]
+        assert {child.row for child in view.children[2:5]} == {2}
+        assert {child.row for child in view.children[5:8]} == {3}
+        assert view.children[8].row == 4
+        assert view.children[9].row == 4
+        assert view.children[10].row == 3
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_create_fixture_button_uses_parent_channel_from_thread(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+    ):
+        parent_channel = MagicMock(spec=discord.TextChannel)
+        parent_channel.id = 123456
+        thread = MagicMock(spec=discord.Thread)
+        thread.parent = parent_channel
+        mock_interaction_admin.channel = thread
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        create_button = _get_button(view, "Create Fixture")
+        await create_button.callback(mock_interaction_admin)
+
+        assert mock_interaction_admin.modal_sent["modal"].channel is parent_channel
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_create_fixture_button_rejects_invalid_context(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+    ):
+        mock_interaction_admin.channel = MagicMock()
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        create_button = _get_button(view, "Create Fixture")
+        await create_button.callback(mock_interaction_admin)
+
+        assert "text channel" in mock_interaction_admin.response_sent[-1]["content"].lower()
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_enter_results_button_opens_modal(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            44, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        enter_button = _get_button(view, "Enter Results")
+        await enter_button.callback(mock_interaction_admin)
+
+        assert isinstance(mock_interaction_admin.modal_sent["modal"], EnterResultsModal)
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_enter_results_button_rejects_existing_results(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            46, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        enter_button = _get_button(view, "Enter Results")
+        await enter_button.callback(mock_interaction_admin)
+
+        assert "Correct Results" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_calculate_scores_button_uses_admin_helpers(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            45, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        score_result = MagicMock()
+        admin_cog.service.calculate_fixture_scores = AsyncMock(return_value=score_result)
+        admin_cog._create_backup = AsyncMock()
+        admin_cog._post_calculation_to_channel = AsyncMock()
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        calculate_button = _get_button(view, "Calculate Scores")
+        await calculate_button.callback(mock_interaction_admin)
+
+        assert admin_cog.get_calculate_cooldown(str(mock_interaction_admin.user.id)) is not None
+        admin_cog.service.calculate_fixture_scores.assert_awaited_once_with(fixture_id)
+        admin_cog._create_backup.assert_awaited_once()
+        admin_cog._post_calculation_to_channel.assert_awaited_once_with(
+            mock_interaction_admin, score_result
+        )
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_calculate_scores_button_rejects_active_cooldown(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            47, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        admin_cog.record_calculate_cooldown(
+            str(mock_interaction_admin.user.id), current_time=now().timestamp()
+        )
+        admin_cog.service.calculate_fixture_scores = AsyncMock()
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        calculate_button = _get_button(view, "Calculate Scores")
+        await calculate_button.callback(mock_interaction_admin)
+
+        assert "Please wait" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_calculate_scores_button_handles_service_error(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            48, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        admin_cog.service.calculate_fixture_scores = AsyncMock(
+            side_effect=ValueError("No results entered")
+        )
+        admin_cog._create_backup = AsyncMock()
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        calculate_button = _get_button(view, "Calculate Scores")
+        await calculate_button.callback(mock_interaction_admin)
+
+        assert mock_interaction_admin.response_sent[-1]["content"] == "No results entered"
+        admin_cog._create_backup.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_post_results_button_opens_confirmation(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+    ):
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.id = mock_interaction_admin.channel.id
+        mock_interaction_admin.channel = channel
+        admin_cog.db.get_last_fixture_scores = AsyncMock(
+            return_value={
+                "week_number": 1,
+                "games": ["A - B"],
+                "results": ["2-1"],
+                "scores": [
+                    {
+                        "user_id": "123",
+                        "user_name": "User1",
+                        "points": 3,
+                        "exact_scores": 1,
+                        "correct_results": 1,
+                    }
+                ],
+            }
+        )
+        admin_cog.db.get_standings = AsyncMock(
+            return_value=[
+                {
+                    "user_id": "123",
+                    "user_name": "User1",
+                    "total_points": 3,
+                    "total_exact": 1,
+                    "total_correct": 1,
+                }
+            ]
+        )
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        post_button = _get_button(view, "Re-post Results")
+        await post_button.callback(mock_interaction_admin)
+
+        assert isinstance(mock_interaction_admin.response_sent[-1]["view"], PostResultsConfirmView)
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_jump_to_week_reaches_older_open_fixture(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        for week in range(1, 28):
+            await admin_cog.db.create_fixture(week, sample_games, deadline)
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+
+        assert all(option.label != "Week 1 [OPEN]" for option in view.fixture_select.options)
+
+        jump_button = _get_button(view, "Jump To Week")
+        await jump_button.callback(mock_interaction_admin)
+        modal = mock_interaction_admin.modal_sent["modal"]
+        modal.week_input._value = "1"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert view.selection.fixture_label == "Week 1 [OPEN]"
+        assert "Fixture: Week 1 [OPEN]" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_jump_to_week_rejects_invalid_input(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+    ):
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        jump_button = _get_button(view, "Jump To Week")
+        await jump_button.callback(mock_interaction_admin)
+        modal = mock_interaction_admin.modal_sent["modal"]
+        modal.week_input._value = "abc"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "whole number" in mock_interaction_admin.response_sent[-1]["content"]
+        assert view.selection.fixture_id is None
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_jump_to_week_rejects_duplicate_open_weeks(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        await admin_cog.db.create_fixture(5, sample_games, deadline)
+        await admin_cog.db.create_fixture(5, sample_games, deadline)
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        jump_button = _get_button(view, "Jump To Week")
+        await jump_button.callback(mock_interaction_admin)
+        modal = mock_interaction_admin.modal_sent["modal"]
+        modal.week_input._value = "5"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "More than one open fixture" in mock_interaction_admin.response_sent[-1]["content"]
+        assert view.selection.fixture_id is None
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_post_results_button_rejects_non_text_channel(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+    ):
+        admin_cog.db.get_last_fixture_scores = AsyncMock(return_value={"scores": []})
+        admin_cog.db.get_standings = AsyncMock(return_value=[])
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        post_button = _get_button(view, "Re-post Results")
+        await post_button.callback(mock_interaction_admin)
+
+        assert "text channels" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_post_results_button_rejects_missing_scores(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+    ):
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.id = mock_interaction_admin.channel.id
+        mock_interaction_admin.channel = channel
+        admin_cog.db.get_last_fixture_scores = AsyncMock(return_value=None)
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        post_button = _get_button(view, "Re-post Results")
+        await post_button.callback(mock_interaction_admin)
+
+        assert "No completed fixtures found" in mock_interaction_admin.response_sent[-1]["content"]
 
     @pytest.mark.asyncio
     async def test_fixture_panel_delete_confirm_shows_error_on_db_failure(
@@ -1246,7 +1683,7 @@ class TestResultsPanelFlows:
         await correct_button.callback(mock_interaction_admin)
 
         assert (
-            "Use `/admin results enter` first"
+            "Enter Results button in `/admin panel`"
             in mock_interaction_admin.response_sent[-1]["content"]
         )
 
@@ -1345,7 +1782,11 @@ class TestResultsPanelFlows:
         admin_cog.bot.get_user.return_value = None
 
         view = UnifiedAdminPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), bot=admin_cog.bot
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -1387,7 +1828,11 @@ class TestResultsPanelFlows:
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
 
         view = UnifiedAdminPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), bot=admin_cog.bot
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1110,20 +1110,29 @@ class TestFixturePanelFlows:
             None,
             None,
             "Create Fixture",
-            "Enter Results",
             "Delete Fixture",
-            "Replace Prediction",
-            "Toggle Late Waiver",
+            "Jump To Week",
+            "Enter Results",
             "Calculate Scores",
             "Correct Results",
-            "Jump To Week",
             "Re-post Results",
+            "Replace Prediction",
+            "Toggle Late Waiver",
         ]
-        assert {child.row for child in view.children[2:5]} == {2}
-        assert {child.row for child in view.children[5:8]} == {3}
-        assert view.children[8].row == 4
-        assert view.children[9].row == 4
-        assert view.children[10].row == 3
+        rows_by_label = {
+            getattr(child, "label", None): child.row
+            for child in view.children
+            if getattr(child, "label", None)
+        }
+        assert rows_by_label["Create Fixture"] == 2
+        assert rows_by_label["Delete Fixture"] == 2
+        assert rows_by_label["Jump To Week"] == 2
+        assert rows_by_label["Enter Results"] == 3
+        assert rows_by_label["Calculate Scores"] == 3
+        assert rows_by_label["Correct Results"] == 3
+        assert rows_by_label["Re-post Results"] == 4
+        assert rows_by_label["Replace Prediction"] == 4
+        assert rows_by_label["Toggle Late Waiver"] == 4
 
     @pytest.mark.asyncio
     async def test_unified_panel_create_fixture_button_uses_parent_channel_from_thread(

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -10,11 +10,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from typer_bot.commands.admin_panel import (
-    CreateFixtureModal,
-    DeleteConfirmView,
-    EnterResultsModal,
     UnifiedAdminPanelView,
-    _build_delete_confirmation_content,
 )
 from typer_bot.database import Database
 from typer_bot.services import AdminService
@@ -27,77 +23,6 @@ CALCULATE_COOLDOWN = 30.0
 COOLDOWN_ENTRY_EXPIRY = timedelta(hours=1)
 
 logger = logging.getLogger(__name__)
-
-
-class FixtureDeleteSelect(discord.ui.Select):
-    """Owner-only fixture picker for ambiguous delete flows.
-
-    This is only shown when multiple open fixtures exist and the admin omitted
-    the `week` argument. Options are capped at Discord's 25-item select limit.
-    """
-
-    def __init__(self, fixtures: list[dict]):
-        options = [
-            discord.SelectOption(
-                label=f"Week {fixture['week_number']}",
-                value=str(fixture["id"]),
-                description=f"{fixture['status']} fixture",
-            )
-            for fixture in fixtures[:25]
-        ]
-        super().__init__(placeholder="Select a fixture to delete", options=options)
-
-    async def callback(self, interaction: discord.Interaction):
-        view = self.view
-        if not isinstance(view, FixtureSelectForDeleteView):
-            await interaction.response.send_message(
-                "Fixture picker is no longer available.", ephemeral=True
-            )
-            return
-        if str(interaction.user.id) != view.owner_user_id:
-            await interaction.response.send_message(
-                "You don't have permission to do this!", ephemeral=True
-            )
-            return
-        if not is_admin(interaction):
-            await interaction.response.send_message(
-                "You no longer have permission to use admin commands.", ephemeral=True
-            )
-            return
-
-        fixture_id = int(self.values[0])
-        fixture = await view.db.get_fixture_by_id(fixture_id)
-        if fixture is None or fixture["status"] != "open":
-            await interaction.response.edit_message(
-                content="That fixture is no longer open. Use `/admin fixture delete` again to refresh the list.",
-                view=None,
-            )
-            return
-
-        delete_view = DeleteConfirmView(
-            view.db,
-            view.owner_user_id,
-            fixture["id"],
-            fixture["week_number"],
-            bot=view.bot,
-            message_id=fixture.get("message_id"),
-            channel_id=fixture.get("channel_id"),
-        )
-        await interaction.response.edit_message(
-            content=_build_delete_confirmation_content(fixture),
-            view=delete_view,
-        )
-
-
-class FixtureSelectForDeleteView(discord.ui.View):
-    """Ephemeral wrapper around the delete fixture picker."""
-
-    def __init__(self, db: Database, owner_user_id: str, fixtures: list[dict], bot: commands.Bot):
-        super().__init__(timeout=3600)
-        self.db = db
-        self.owner_user_id = owner_user_id
-        self.bot = bot
-        self.add_item(FixtureDeleteSelect(fixtures))
 
 
 def admin_only():
@@ -168,54 +93,6 @@ class AdminCommands(commands.Cog):
             self._calculate_cooldowns.pop(uid, None)
         return len(expired)
 
-    @staticmethod
-    def _format_open_weeks(open_fixtures: list[dict]) -> str:
-        return ", ".join(str(fixture["week_number"]) for fixture in open_fixtures)
-
-    async def _resolve_open_fixture(
-        self,
-        interaction: discord.Interaction,
-        week: int | None,
-        command_example: str,
-    ) -> dict | None:
-        open_fixtures = await self.db.get_open_fixtures()
-
-        if not open_fixtures:
-            await interaction.response.send_message("No open fixtures found!", ephemeral=True)
-            return None
-
-        if week is None:
-            if len(open_fixtures) == 1:
-                return open_fixtures[0]
-
-            open_weeks = self._format_open_weeks(open_fixtures)
-            await interaction.response.send_message(
-                "Multiple fixtures are currently open. "
-                "Please specify the `week` argument to choose one.\n"
-                f"Open weeks: {open_weeks}\n"
-                f"Example: `{command_example}`",
-                ephemeral=True,
-            )
-            return None
-
-        matching = [fixture for fixture in open_fixtures if fixture["week_number"] == week]
-        if len(matching) == 1:
-            return matching[0]
-        if len(matching) > 1:
-            await interaction.response.send_message(
-                f"More than one open fixture was found for week {week}. "
-                "Please resolve duplicate week numbers in the database before continuing.",
-                ephemeral=True,
-            )
-            return None
-
-        open_weeks = self._format_open_weeks(open_fixtures)
-        await interaction.response.send_message(
-            f"No open fixture found for week {week}.\nOpen weeks: {open_weeks}",
-            ephemeral=True,
-        )
-        return None
-
     async def _create_backup(self) -> None:
         try:
             await self.bot.loop.run_in_executor(
@@ -262,236 +139,26 @@ class AdminCommands(commands.Cog):
                 "Scores calculated but failed to post to channel.", ephemeral=True
             )
 
-    admin = app_commands.Group(name="admin", description="Admin commands for managing fixtures")
-    fixture = app_commands.Group(name="fixture", description="Manage fixtures", parent=admin)
-    results = app_commands.Group(name="results", description="Manage results", parent=admin)
+    admin = app_commands.Group(
+        name="admin", description="Open the admin panel and manage fixtures/results"
+    )
 
     @admin.command(name="panel", description="Open the admin management panel")
     @admin_only()
     async def panel(self, interaction: discord.Interaction):
-        view = UnifiedAdminPanelView(self.db, self.service, str(interaction.user.id), bot=self.bot)
+        view = UnifiedAdminPanelView(
+            self.db,
+            self.service,
+            str(interaction.user.id),
+            admin_commands=self,
+            bot=self.bot,
+        )
         await view.load_fixture_options()
         await interaction.response.send_message(
             view.render_content(),
             view=view,
             ephemeral=True,
         )
-
-    @fixture.command(name="create", description="Create a new fixture via modal")
-    @admin_only()
-    async def fixture_create(self, interaction: discord.Interaction):
-        if interaction.channel is None or interaction.guild is None:
-            await interaction.response.send_message(
-                "Error: Invalid interaction context.", ephemeral=True
-            )
-            return
-
-        channel = interaction.channel
-        if isinstance(channel, discord.Thread):
-            parent = channel.parent
-            if not isinstance(parent, discord.TextChannel):
-                await interaction.response.send_message(
-                    "Fixture creation must be started from a server text channel.",
-                    ephemeral=True,
-                )
-                return
-            channel = parent
-        elif not isinstance(channel, discord.TextChannel):
-            await interaction.response.send_message(
-                "Fixture creation must be started from a server text channel.",
-                ephemeral=True,
-            )
-            return
-
-        modal = CreateFixtureModal(self.db, channel, str(interaction.user.id))
-        await interaction.response.send_modal(modal)
-
-    @fixture.command(name="delete", description="Delete an open fixture")
-    @admin_only()
-    async def fixture_delete(self, interaction: discord.Interaction, week: int | None = None):
-        if week is None:
-            open_fixtures = await self.db.get_open_fixtures()
-            if not open_fixtures:
-                await interaction.response.send_message("No open fixtures found!", ephemeral=True)
-                return
-            if len(open_fixtures) > 1:
-                view = FixtureSelectForDeleteView(
-                    self.db,
-                    str(interaction.user.id),
-                    open_fixtures,
-                    self.bot,
-                )
-                await interaction.response.send_message(
-                    "Multiple fixtures are open. Choose which one to delete.",
-                    view=view,
-                    ephemeral=True,
-                )
-                return
-
-        fixture = await self._resolve_open_fixture(
-            interaction,
-            week,
-            "/admin fixture delete week:12",
-        )
-        if not fixture:
-            return
-
-        view = DeleteConfirmView(
-            self.db,
-            str(interaction.user.id),
-            fixture["id"],
-            fixture["week_number"],
-            bot=self.bot,
-            message_id=fixture.get("message_id"),
-            channel_id=fixture.get("channel_id"),
-        )
-
-        await interaction.response.send_message(
-            _build_delete_confirmation_content(fixture),
-            view=view,
-            ephemeral=True,
-        )
-
-    @results.command(name="enter", description="Enter results for an open fixture")
-    @admin_only()
-    async def results_enter(self, interaction: discord.Interaction, week: int | None = None):
-        fixture = await self._resolve_open_fixture(
-            interaction,
-            week,
-            "/admin results enter week:12",
-        )
-        if not fixture:
-            return
-
-        existing_results = await self.db.get_results(fixture["id"])
-        if existing_results:
-            await interaction.response.send_message(
-                "Results already entered for this fixture. "
-                "Use `/admin panel` to correct them or `/admin results calculate` to post scores.",
-                ephemeral=True,
-            )
-            return
-
-        modal = EnterResultsModal(fixture, self.db)
-        await interaction.response.send_modal(modal)
-
-    @results.command(name="calculate", description="Calculate scores and post results")
-    @admin_only()
-    async def results_calculate(self, interaction: discord.Interaction, week: int | None = None):
-        user_id = str(interaction.user.id)
-        current_time = now().timestamp()
-        remaining = self.get_calculate_cooldown_remaining(
-            user_id,
-            current_time=current_time,
-            cooldown_seconds=CALCULATE_COOLDOWN,
-        )
-        if remaining > 0:
-            await interaction.response.send_message(
-                f"Please wait {remaining:.1f}s before calculating again.",
-                ephemeral=True,
-            )
-            return
-
-        fixture = await self._resolve_open_fixture(
-            interaction,
-            week,
-            "/admin results calculate week:12",
-        )
-        if not fixture:
-            return
-
-        try:
-            score_result = await self.service.calculate_fixture_scores(fixture["id"])
-        except ValueError as exc:
-            await interaction.response.send_message(str(exc), ephemeral=True)
-            return
-
-        self.record_calculate_cooldown(user_id, current_time=current_time)
-
-        await self._create_backup()
-        await self._post_calculation_to_channel(interaction, score_result)
-
-    @results.command(name="post", description="Post results with optional user mentions")
-    @admin_only()
-    async def results_post(self, interaction: discord.Interaction):
-        fixture_data = await self.db.get_last_fixture_scores()
-        standings = await self.db.get_standings()
-
-        if not fixture_data:
-            await interaction.response.send_message(
-                "No completed fixtures found with scores!", ephemeral=True
-            )
-            return
-
-        preview = format_standings(standings, fixture_data)
-
-        if not isinstance(interaction.channel, discord.TextChannel):
-            await interaction.response.send_message(
-                "This command can only be used in text channels.", ephemeral=True
-            )
-            return
-
-        view = PostResultsConfirmView(self.db, fixture_data, standings, interaction.channel)
-        await interaction.response.send_message(
-            f"{preview}\n\nMention users in this post?",
-            view=view,
-            ephemeral=True,
-        )
-
-
-class PostResultsConfirmView(discord.ui.View):
-    """View for confirming results posting with mentions."""
-
-    def __init__(
-        self,
-        db: Database,
-        fixture_data: dict,
-        standings: list[dict],
-        channel: discord.TextChannel,
-    ):
-        super().__init__(timeout=60)
-        self.db = db
-        self.fixture_data = fixture_data
-        self.standings = standings
-        self.channel = channel
-
-    @discord.ui.button(label="NO", style=discord.ButtonStyle.primary)
-    async def no_mentions(self, interaction: discord.Interaction, _button: discord.ui.Button):
-        message = format_standings(self.standings, self.fixture_data)
-
-        try:
-            await interaction.response.edit_message(
-                content="Results posted without mentions!", view=None
-            )
-        except Exception as exc:
-            logger.error(f"Failed to acknowledge interaction: {exc}")
-            return
-
-        try:
-            await self.channel.send(message)
-        except Exception as exc:
-            logger.error(f"Failed to post results: {exc}")
-            await interaction.followup.send(f"Failed to post results: {exc}")
-
-    @discord.ui.button(label="YES", style=discord.ButtonStyle.green)
-    async def with_mentions(self, interaction: discord.Interaction, _button: discord.ui.Button):
-        message = format_standings(self.standings, self.fixture_data)
-        mentions = [f"<@{score['user_id']}>" for score in self.fixture_data["scores"]]
-        message += f"\n\n**Participants:**\n{' '.join(mentions)}"
-
-        try:
-            await interaction.response.edit_message(
-                content="Results posted with mentions!", view=None
-            )
-        except Exception as exc:
-            logger.error(f"Failed to acknowledge interaction: {exc}")
-            return
-
-        try:
-            await self.channel.send(message)
-        except Exception as exc:
-            logger.error(f"Failed to post results: {exc}")
-            await interaction.followup.send(f"Failed to post results: {exc}")
 
 
 async def setup(bot: commands.Bot):

--- a/typer_bot/commands/admin_panel/__init__.py
+++ b/typer_bot/commands/admin_panel/__init__.py
@@ -13,7 +13,7 @@ from .modals import (
 )
 from .predictions import PredictionsPanelView
 from .results import ResultsPanelView
-from .unified import UnifiedAdminPanelView
+from .unified import PostResultsConfirmView, UnifiedAdminPanelView
 
 __all__ = [
     "CorrectResultsModal",
@@ -24,6 +24,7 @@ __all__ = [
     "PredictionsPanelView",
     "ReplacePredictionModal",
     "ResultsPanelView",
+    "PostResultsConfirmView",
     "UnifiedAdminPanelView",
     "_build_delete_confirmation_content",
 ]

--- a/typer_bot/commands/admin_panel/fixtures.py
+++ b/typer_bot/commands/admin_panel/fixtures.py
@@ -89,12 +89,12 @@ class FixturesPanelView(OwnerRestrictedView):
             lines.extend(
                 [
                     "",
-                    "Delete the selected open fixture, or use `/admin fixture create` for new fixtures.",
+                    "Delete the selected open fixture, or use the Create Fixture button in `/admin panel` for new fixtures.",
                 ]
             )
         else:
             lines.append(
-                "Select an open fixture to delete, or use `/admin fixture create` for new fixtures."
+                "Select an open fixture to delete, or use the Create Fixture button in `/admin panel` for new fixtures."
             )
 
         if self.selection.status_message:
@@ -104,13 +104,17 @@ class FixturesPanelView(OwnerRestrictedView):
 
 class FixturesDeleteButton(discord.ui.Button):
     def __init__(
-        self, parent_view: FixturesPanelView | UnifiedAdminPanelView, disabled: bool = False
+        self,
+        parent_view: FixturesPanelView | UnifiedAdminPanelView,
+        disabled: bool = False,
+        row: int | None = None,
     ):
         self.parent_view = parent_view
         super().__init__(
             label="Delete Fixture",
             style=discord.ButtonStyle.danger,
             disabled=disabled,
+            row=row,
         )
 
     async def callback(self, interaction: discord.Interaction):

--- a/typer_bot/commands/admin_panel/modals.py
+++ b/typer_bot/commands/admin_panel/modals.py
@@ -297,7 +297,7 @@ class EnterResultsConfirmView(discord.ui.View):
             return
 
         await interaction.response.edit_message(
-            content=f"**Results Saved!**\n\n{self.preview}\n\nUse `/admin results calculate` to calculate scores.",
+            content=f"**Results Saved!**\n\n{self.preview}\n\nUse the Calculate Scores button in `/admin panel` to post standings now. Use Re-post Results later only if you need to post them again with optional mentions.",
             view=None,
         )
 
@@ -310,7 +310,7 @@ class EnterResultsConfirmView(discord.ui.View):
             return
 
         await interaction.response.edit_message(
-            content="Results entry cancelled. Use `/admin results enter` to try again.",
+            content="Results entry cancelled. Use the Enter Results button in `/admin panel` to try again.",
             view=None,
         )
 

--- a/typer_bot/commands/admin_panel/predictions.py
+++ b/typer_bot/commands/admin_panel/predictions.py
@@ -198,13 +198,17 @@ class PredictionUserSelect(discord.ui.Select):
 
 class ReplacePredictionButton(discord.ui.Button):
     def __init__(
-        self, parent_view: PredictionsPanelView | UnifiedAdminPanelView, disabled: bool = False
+        self,
+        parent_view: PredictionsPanelView | UnifiedAdminPanelView,
+        disabled: bool = False,
+        row: int | None = None,
     ):
         self.parent_view = parent_view
         super().__init__(
             label="Replace Prediction",
             style=discord.ButtonStyle.primary,
             disabled=disabled,
+            row=row,
         )
 
     async def callback(self, interaction: discord.Interaction):
@@ -252,13 +256,17 @@ class ReplacePredictionButton(discord.ui.Button):
 
 class ViewPredictionsButton(discord.ui.Button):
     def __init__(
-        self, parent_view: PredictionsPanelView | UnifiedAdminPanelView, disabled: bool = False
+        self,
+        parent_view: PredictionsPanelView | UnifiedAdminPanelView,
+        disabled: bool = False,
+        row: int | None = None,
     ):
         self.parent_view = parent_view
         super().__init__(
             label="View Predictions",
             style=discord.ButtonStyle.secondary,
             disabled=disabled,
+            row=row,
         )
 
     async def callback(self, interaction: discord.Interaction):
@@ -316,13 +324,17 @@ class ToggleWaiverButton(discord.ui.Button):
     """Toggle the late waiver flag and best-effort DM the affected user."""
 
     def __init__(
-        self, parent_view: PredictionsPanelView | UnifiedAdminPanelView, disabled: bool = False
+        self,
+        parent_view: PredictionsPanelView | UnifiedAdminPanelView,
+        disabled: bool = False,
+        row: int | None = None,
     ):
         self.parent_view = parent_view
         super().__init__(
             label="Toggle Late Waiver",
             style=discord.ButtonStyle.success,
             disabled=disabled,
+            row=row,
         )
 
     async def callback(self, interaction: discord.Interaction):

--- a/typer_bot/commands/admin_panel/results.py
+++ b/typer_bot/commands/admin_panel/results.py
@@ -74,13 +74,17 @@ class ResultsPanelView(OwnerRestrictedView):
 
 class CorrectResultsButton(discord.ui.Button):
     def __init__(
-        self, parent_view: ResultsPanelView | UnifiedAdminPanelView, disabled: bool = False
+        self,
+        parent_view: ResultsPanelView | UnifiedAdminPanelView,
+        disabled: bool = False,
+        row: int | None = None,
     ):
         self.parent_view = parent_view
         super().__init__(
             label="Correct Results",
             style=discord.ButtonStyle.primary,
             disabled=disabled,
+            row=row,
         )
 
     async def callback(self, interaction: discord.Interaction):
@@ -110,7 +114,7 @@ class CorrectResultsButton(discord.ui.Button):
         results = await self.parent_view.db.get_results(fixture_id)
         if not results:
             await interaction.response.send_message(
-                "No results are stored for that fixture yet. Use `/admin results enter` first.",
+                "No results are stored for that fixture yet. Use the Enter Results button in `/admin panel` first.",
                 ephemeral=True,
             )
             return

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -119,7 +119,7 @@ class JumpToWeekModal(discord.ui.Modal):
 class JumpToWeekButton(discord.ui.Button):
     def __init__(self, parent_view: UnifiedAdminPanelView):
         self.parent_view = parent_view
-        super().__init__(label="Jump To Week", style=discord.ButtonStyle.secondary, row=4)
+        super().__init__(label="Jump To Week", style=discord.ButtonStyle.secondary, row=2)
 
     async def callback(self, interaction: discord.Interaction):
         await interaction.response.send_modal(JumpToWeekModal(self.parent_view))
@@ -132,7 +132,7 @@ class EnterResultsButton(discord.ui.Button):
             label="Enter Results",
             style=discord.ButtonStyle.secondary,
             disabled=parent_view.selection.fixture_id is None,
-            row=2,
+            row=3,
         )
 
     async def callback(self, interaction: discord.Interaction):
@@ -254,7 +254,7 @@ class PostResultsConfirmView(discord.ui.View):
 class PostResultsButton(discord.ui.Button):
     def __init__(self, parent_view: UnifiedAdminPanelView):
         self.parent_view = parent_view
-        super().__init__(label="Re-post Results", style=discord.ButtonStyle.secondary, row=3)
+        super().__init__(label="Re-post Results", style=discord.ButtonStyle.secondary, row=4)
 
     async def callback(self, interaction: discord.Interaction):
         fixture_data = await self.parent_view.db.get_last_fixture_scores()
@@ -310,26 +310,26 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
         self.add_item(self.fixture_select)
         self.add_item(self.user_select)
         self.add_item(CreateFixtureButton(self))
-        self.add_item(EnterResultsButton(self))
         self.add_item(FixturesDeleteButton(self, disabled=self.selection.fixture_id is None, row=2))
+        self.add_item(JumpToWeekButton(self))
+        self.add_item(EnterResultsButton(self))
+        self.add_item(CalculateScoresButton(self))
+        self.add_item(CorrectResultsButton(self, disabled=self.selection.fixture_id is None, row=3))
+        self.add_item(PostResultsButton(self))
         self.add_item(
             ReplacePredictionButton(
                 self,
                 disabled=self.selection.fixture_id is None or self.selection.user_id is None,
-                row=3,
+                row=4,
             )
         )
         self.add_item(
             ToggleWaiverButton(
                 self,
                 disabled=self.selection.fixture_id is None or self.selection.user_id is None,
-                row=3,
+                row=4,
             )
         )
-        self.add_item(CalculateScoresButton(self))
-        self.add_item(CorrectResultsButton(self, disabled=self.selection.fixture_id is None, row=4))
-        self.add_item(JumpToWeekButton(self))
-        self.add_item(PostResultsButton(self))
         if self.has_user_overflow:
             self.add_item(
                 ViewPredictionsButton(self, disabled=self.selection.fixture_id is None, row=4)
@@ -370,7 +370,7 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
             if self.selection.detail_lines:
                 lines.extend(["", *self.selection.detail_lines])
             else:
-                guidance = "Pick a user to inspect or override predictions, correct results, calculate scores, or delete the fixture. Use Jump To Week when the older open week you want is not in the quick list."
+                guidance = "Top row: fixture management. Middle row: results workflow. Bottom row: prediction and user actions. Use Jump To Week when the older open week you want is not in the quick list."
                 lines.extend(["", guidance])
 
             if self.has_user_overflow:
@@ -382,7 +382,7 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
                 )
         else:
             lines.append(
-                "Select a fixture to enter or correct results, calculate scores, inspect predictions, toggle waivers, or delete it. Use Create Fixture for new rounds, Jump To Week for older open fixtures, and Re-post Results to post the latest completed standings again."
+                "Use the top row for fixture management, the middle row for results, and the bottom row for prediction-level actions."
             )
             if self.selection.status_message:
                 lines.extend(["", self.selection.status_message])

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import discord
 
 from typer_bot.database import Database
 from typer_bot.services import AdminService
+from typer_bot.utils import format_standings, now
 
 from .base import (
     MAX_SELECT_OPTIONS,
@@ -16,6 +19,7 @@ from .base import (
     _render_panel_content,
 )
 from .fixtures import FixturesDeleteButton
+from .modals import CreateFixtureModal, EnterResultsModal
 from .predictions import (
     PredictionUserSelect,
     ReplacePredictionButton,
@@ -23,6 +27,255 @@ from .predictions import (
     ViewPredictionsButton,
 )
 from .results import CorrectResultsButton
+
+if TYPE_CHECKING:
+    from typer_bot.commands.admin_commands import AdminCommands
+
+
+class CreateFixtureButton(discord.ui.Button):
+    def __init__(self, parent_view: UnifiedAdminPanelView):
+        self.parent_view = parent_view
+        super().__init__(label="Create Fixture", style=discord.ButtonStyle.success, row=2)
+
+    async def callback(self, interaction: discord.Interaction):
+        channel = interaction.channel
+        if interaction.guild is None or channel is None:
+            await interaction.response.send_message(
+                "Error: Invalid interaction context.", ephemeral=True
+            )
+            return
+        if isinstance(channel, discord.Thread):
+            parent = channel.parent
+            if not isinstance(parent, discord.TextChannel):
+                await interaction.response.send_message(
+                    "Fixture creation must be started from a server text channel.", ephemeral=True
+                )
+                return
+            channel = parent
+        elif not isinstance(channel, discord.TextChannel):
+            await interaction.response.send_message(
+                "Fixture creation must be started from a server text channel.", ephemeral=True
+            )
+            return
+
+        modal = CreateFixtureModal(self.parent_view.db, channel, str(interaction.user.id))
+        await interaction.response.send_modal(modal)
+
+
+class JumpToWeekModal(discord.ui.Modal):
+    def __init__(self, parent_view: UnifiedAdminPanelView):
+        super().__init__(title="Jump To Week")
+        self.parent_view = parent_view
+        self.week_input = discord.ui.TextInput(
+            label="Week Number",
+            placeholder="e.g. 12",
+            required=True,
+            max_length=8,
+        )
+        self.add_item(self.week_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        try:
+            week_number = int(self.week_input.value.strip())
+        except ValueError:
+            await interaction.response.send_message(
+                "Week number must be a whole number.", ephemeral=True
+            )
+            return
+
+        open_fixtures = await self.parent_view.db.get_open_fixtures()
+        matching = [fixture for fixture in open_fixtures if fixture["week_number"] == week_number]
+        if not matching:
+            await interaction.response.send_message(
+                f"No open fixture found for week {week_number}.", ephemeral=True
+            )
+            return
+        if len(matching) > 1:
+            await interaction.response.send_message(
+                f"More than one open fixture was found for week {week_number}. Resolve duplicate week numbers first.",
+                ephemeral=True,
+            )
+            return
+
+        fixture = matching[0]
+        self.parent_view.selection.fixture_id = fixture["id"]
+        self.parent_view.selection.fixture_label = (
+            f"Week {fixture['week_number']} [{fixture['status'].upper()}]"
+        )
+        self.parent_view.selection.user_id = None
+        self.parent_view.selection.user_label = ""
+        self.parent_view.selection.detail_lines = []
+        self.parent_view.selection.status_message = ""
+        await self.parent_view.populate_fixture_details(fixture)
+        await self.parent_view.load_user_options()
+        self.parent_view.fixture_select.sync_selected_option()
+        self.parent_view._refresh_items()
+        await interaction.response.edit_message(
+            content=self.parent_view.render_content(),
+            view=self.parent_view,
+        )
+
+
+class JumpToWeekButton(discord.ui.Button):
+    def __init__(self, parent_view: UnifiedAdminPanelView):
+        self.parent_view = parent_view
+        super().__init__(label="Jump To Week", style=discord.ButtonStyle.secondary, row=4)
+
+    async def callback(self, interaction: discord.Interaction):
+        await interaction.response.send_modal(JumpToWeekModal(self.parent_view))
+
+
+class EnterResultsButton(discord.ui.Button):
+    def __init__(self, parent_view: UnifiedAdminPanelView):
+        self.parent_view = parent_view
+        super().__init__(
+            label="Enter Results",
+            style=discord.ButtonStyle.secondary,
+            disabled=parent_view.selection.fixture_id is None,
+            row=2,
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        fixture_id = self.parent_view.selection.fixture_id
+        if fixture_id is None:
+            await interaction.response.send_message("Select a fixture first.", ephemeral=True)
+            return
+        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
+        if fixture is None or fixture["status"] != "open":
+            await interaction.response.send_message(
+                "That fixture is no longer open.", ephemeral=True
+            )
+            return
+        existing_results = await self.parent_view.db.get_results(fixture_id)
+        if existing_results:
+            await interaction.response.send_message(
+                "Results already entered for this fixture. Use Correct Results instead.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_modal(EnterResultsModal(fixture, self.parent_view.db))
+
+
+class CalculateScoresButton(discord.ui.Button):
+    def __init__(self, parent_view: UnifiedAdminPanelView):
+        self.parent_view = parent_view
+        super().__init__(
+            label="Calculate Scores",
+            style=discord.ButtonStyle.secondary,
+            disabled=parent_view.selection.fixture_id is None,
+            row=3,
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        fixture_id = self.parent_view.selection.fixture_id
+        if fixture_id is None:
+            await interaction.response.send_message("Select a fixture first.", ephemeral=True)
+            return
+        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
+        if fixture is None or fixture["status"] != "open":
+            await interaction.response.send_message(
+                "That fixture is no longer open.", ephemeral=True
+            )
+            return
+
+        admin_commands = self.parent_view.admin_commands
+        if admin_commands is None:
+            await interaction.response.send_message(
+                "Calculate Scores is unavailable in this context.", ephemeral=True
+            )
+            return
+        user_id = str(interaction.user.id)
+        current_time = now().timestamp()
+        remaining = admin_commands.get_calculate_cooldown_remaining(
+            user_id,
+            current_time=current_time,
+            cooldown_seconds=30.0,
+        )
+        if remaining > 0:
+            await interaction.response.send_message(
+                f"Please wait {remaining:.1f}s before calculating again.", ephemeral=True
+            )
+            return
+
+        try:
+            score_result = await self.parent_view.service.calculate_fixture_scores(fixture_id)
+        except ValueError as exc:
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
+
+        admin_commands.record_calculate_cooldown(user_id, current_time=current_time)
+        await admin_commands._create_backup()
+        await admin_commands._post_calculation_to_channel(interaction, score_result)
+
+
+class PostResultsConfirmView(discord.ui.View):
+    def __init__(
+        self,
+        fixture_data: dict,
+        standings: list[dict],
+        channel: discord.TextChannel,
+    ):
+        super().__init__(timeout=60)
+        self.fixture_data = fixture_data
+        self.standings = standings
+        self.channel = channel
+
+    @discord.ui.button(label="No Mentions", style=discord.ButtonStyle.primary)
+    async def no_mentions(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        message = format_standings(self.standings, self.fixture_data)
+        try:
+            await interaction.response.edit_message(
+                content="Results posted without mentions!", view=None
+            )
+        except Exception:
+            return
+        try:
+            await self.channel.send(message)
+        except Exception as exc:
+            await interaction.followup.send(f"Failed to post results: {exc}")
+
+    @discord.ui.button(label="Mention Users", style=discord.ButtonStyle.green)
+    async def with_mentions(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        message = format_standings(self.standings, self.fixture_data)
+        mentions = [f"<@{score['user_id']}>" for score in self.fixture_data["scores"]]
+        message += f"\n\n**Participants:**\n{' '.join(mentions)}"
+        try:
+            await interaction.response.edit_message(
+                content="Results posted with mentions!", view=None
+            )
+        except Exception:
+            return
+        try:
+            await self.channel.send(message)
+        except Exception as exc:
+            await interaction.followup.send(f"Failed to post results: {exc}")
+
+
+class PostResultsButton(discord.ui.Button):
+    def __init__(self, parent_view: UnifiedAdminPanelView):
+        self.parent_view = parent_view
+        super().__init__(label="Re-post Results", style=discord.ButtonStyle.secondary, row=3)
+
+    async def callback(self, interaction: discord.Interaction):
+        fixture_data = await self.parent_view.db.get_last_fixture_scores()
+        standings = await self.parent_view.db.get_standings()
+        if not fixture_data:
+            await interaction.response.send_message(
+                "No completed fixtures found with scores!", ephemeral=True
+            )
+            return
+        if not isinstance(interaction.channel, discord.TextChannel):
+            await interaction.response.send_message(
+                "This action can only be used in text channels.", ephemeral=True
+            )
+            return
+        preview = format_standings(standings, fixture_data)
+        view = PostResultsConfirmView(fixture_data, standings, interaction.channel)
+        await interaction.response.send_message(
+            f"{preview}\n\nMention users in this post?",
+            view=view,
+            ephemeral=True,
+        )
 
 
 class UnifiedAdminPanelView(OwnerRestrictedView):
@@ -40,9 +293,11 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
         db: Database,
         service: AdminService,
         owner_user_id: str,
+        admin_commands: AdminCommands | None = None,
         bot: discord.Client | None = None,
     ):
         super().__init__(db, service, owner_user_id, bot=bot)
+        self.admin_commands = admin_commands
         self.selection = PanelSelectionState()
         self.has_user_overflow = False
         self.fixture_select = FixtureSelect(self)
@@ -54,22 +309,31 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
         self.clear_items()
         self.add_item(self.fixture_select)
         self.add_item(self.user_select)
-        self.add_item(FixturesDeleteButton(self, disabled=self.selection.fixture_id is None))
+        self.add_item(CreateFixtureButton(self))
+        self.add_item(EnterResultsButton(self))
+        self.add_item(FixturesDeleteButton(self, disabled=self.selection.fixture_id is None, row=2))
         self.add_item(
             ReplacePredictionButton(
                 self,
                 disabled=self.selection.fixture_id is None or self.selection.user_id is None,
+                row=3,
             )
         )
         self.add_item(
             ToggleWaiverButton(
                 self,
                 disabled=self.selection.fixture_id is None or self.selection.user_id is None,
+                row=3,
             )
         )
-        self.add_item(CorrectResultsButton(self, disabled=self.selection.fixture_id is None))
+        self.add_item(CalculateScoresButton(self))
+        self.add_item(CorrectResultsButton(self, disabled=self.selection.fixture_id is None, row=4))
+        self.add_item(JumpToWeekButton(self))
+        self.add_item(PostResultsButton(self))
         if self.has_user_overflow:
-            self.add_item(ViewPredictionsButton(self, disabled=self.selection.fixture_id is None))
+            self.add_item(
+                ViewPredictionsButton(self, disabled=self.selection.fixture_id is None, row=4)
+            )
 
     async def load_fixture_options(self) -> None:
         fixtures = await self.db.get_recent_fixtures(MAX_SELECT_OPTIONS)
@@ -106,7 +370,7 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
             if self.selection.detail_lines:
                 lines.extend(["", *self.selection.detail_lines])
             else:
-                guidance = "Pick a user to inspect or override predictions, correct results, or delete the fixture."
+                guidance = "Pick a user to inspect or override predictions, correct results, calculate scores, or delete the fixture. Use Jump To Week when the older open week you want is not in the quick list."
                 lines.extend(["", guidance])
 
             if self.has_user_overflow:
@@ -118,7 +382,7 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
                 )
         else:
             lines.append(
-                "Select a fixture to inspect predictions, correct results, toggle waivers, or delete it."
+                "Select a fixture to enter or correct results, calculate scores, inspect predictions, toggle waivers, or delete it. Use Create Fixture for new rounds, Jump To Week for older open fixtures, and Re-post Results to post the latest completed standings again."
             )
             if self.selection.status_message:
                 lines.extend(["", self.selection.status_message])

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -536,49 +536,22 @@ class UserCommands(commands.Cog):
         admin_help = """\n\n## 🔧 Admin Commands
 
 **For Admins:**
-• `/admin panel` - Open the admin hub for fixture deletion, overrides, waivers, and result correction
-**Fixture Management:**
-• `/admin fixture create` - Create new fixture (modal + confirm, auto-creates thread)
-• `/admin fixture delete [week]` - Delete an open fixture
+• `/admin panel` - Open the main admin surface
 
-**Results Management:**
-• `/admin results enter [week]` - Enter actual scores (modal + confirm)
-• `/admin results calculate [week]` - Calculate and post scores
-• `/admin results post` - Re-post results with optional mentions
+**Admin workflow:**
+- run `/admin panel` once
+- use the panel buttons and selectors for admin actions
 
-**Admin Workflow:**
-1. **Create Fixture:**
-   - `/admin fixture create`
-   - Modal opens in Discord
-   - Enter game list and optional deadline
-   - Review preview and confirm
-   - Bot auto-creates thread for predictions
-
-2. **Enter Results:**
-   - `/admin results enter` (add `week:` if multiple fixtures are open)
-   - Modal opens in Discord
-   - Enter actual scores:
-      ```
-      Team A - Team B 1:0
-      Team C - Team D 2:2
-      ...
-      ```
-   - Review preview and confirm
-
-3. **Calculate Scores:**
-   - `/admin results calculate` (add `week:` if multiple fixtures are open)
-   - Bot posts results (overall + week) to channel
-
-4. **Re-post Results:**
-   - `/admin results post`
-   - Choose whether to mention users
-
-5. **Corrections / Exceptions:**
-   - `/admin panel`
-   - View fixture predictions
-   - Replace a stored prediction without changing original submit time
-   - Toggle a late-penalty waiver for an approved late pick
-   - Correct stored results and auto-recalculate scored fixtures
+**Inside the panel you can:**
+- create fixtures
+- delete fixtures
+- jump to an older open week that is not shown in the quick list
+- enter or correct results
+- calculate scores
+- re-post the latest completed results with optional mentions
+- replace predictions
+- toggle late waivers
+- inspect overflow prediction lists when a fixture has more than 25 users
 
 **Custom Deadline Format:**
 • `2024-02-15 18:00`


### PR DESCRIPTION
## Summary
- make `/admin panel` the primary admin surface by removing redundant `/admin fixture ...` and `/admin results ...` slash workflows
- move fixture create/delete, results enter/calculate/repost, and week targeting into the unified admin panel itself
- update help text and tests for the panel-first contract, including older open-week targeting through `Jump To Week`

Closes #173

## Testing
- `uv run pytest --tb=short`
- `uv run ruff check typer_bot/commands/admin_commands.py typer_bot/commands/admin_panel typer_bot/commands/user_commands.py tests/test_admin_panel.py tests/test_admin_commands.py`
- `uv run ty check typer_bot`
