### PR TITLE
docs: simplify help and README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 100% vibecoded, no guarantees given but it seems to work.
 
-Discord bot for weekly football prediction leagues. Admins create fixtures and enter results. Players submit score predictions in fixture threads or through `/predict`, which posts publicly into those threads. The bot stores picks, calculates points, and posts standings.
+Discord bot for weekly football prediction leagues. Admins create fixtures and enter results. Players post score predictions in fixture threads, either directly or through `/predict`. The bot stores picks, calculates points, and posts standings.
 
 ## Features
 - Thread predictions on fixture announcement threads
-- `/predict` modal flow that posts publicly into fixture threads
+- `/predict` prediction composer
 - Flexible score parsing: `2-1`, `2:1`, `2 : 1`
 - Per-fixture deadlines with late-pick handling
 - Standings, saved predictions, and weekly results posting
@@ -14,7 +14,7 @@ Discord bot for weekly football prediction leagues. Admins create fixtures and e
 
 ## Commands
 ### Player commands
-- `/predict` - open a modal and post predictions publicly into the fixture thread
+- `/predict` - post predictions to the fixture thread
 - `/fixtures` - show open fixtures and deadlines
 - `/mypredictions` - show your saved predictions for open fixtures
 - `/standings` - show the leaderboard and latest scored fixture
@@ -47,8 +47,8 @@ Admins need a Discord role named `Admin` or `typer-admin`.
 
 ## Prediction flow
 - Reply in the fixture thread with one line per match.
-- Run `/predict` anywhere in the server to fill a modal, then have the bot post your prediction publicly into the fixture thread.
-- To replace a saved prediction, use `/predict` again; the bot posts a new public `Updated prediction` message in the thread.
+- Or run `/predict` anywhere in the server and submit the same scores there.
+- To change a saved prediction, run `/predict` again. The bot posts a new `Updated prediction` message in the thread.
 
 Example:
 

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -499,16 +499,16 @@ class UserCommands(commands.Cog):
         user_help = """## 📖 User Commands
 
 **For Players:**
-• `/predict` - Fill predictions in a modal, then post them publicly to the fixture thread
+• `/predict` - Post predictions to the fixture thread
 • `/fixtures` - View all open fixtures
 • `/standings` - See overall leaderboard
 • `/mypredictions` - Check your submitted predictions for open fixtures
 
-**How to Predict (Two Methods):**
+**How to Predict:**
 
-**Method 1: Thread Predictions (NEW)**
-1. Look for the fixture announcement thread (created when admin posts fixtures)
-2. Reply in the thread with your predictions:
+**Reply in the fixture thread**
+1. Open the fixture thread
+2. Reply with your predictions:
    ```
    Team A - Team B 2:0
    Team C - Team D 1:1
@@ -516,11 +516,11 @@ class UserCommands(commands.Cog):
    ```
 3. Bot will react ✅ when saved
 
-**Method 2: /predict Modal**
+**Or use `/predict`**
 1. Type `/predict` in the channel
 2. If multiple fixtures are open, choose the week from the picker
 3. Enter your predictions in the modal
-4. Submit, and the bot posts them publicly in the fixture thread
+4. Submit to post them in the fixture thread
 5. Use the buttons to continue to other open fixtures
 
 **Scoring:**
@@ -531,16 +531,12 @@ class UserCommands(commands.Cog):
 
 **Input formats:** Use `2:0`, `2-0`, or `2 : 0`
 
-**To change a prediction:** Use `/predict` again. The bot will post your updated prediction publicly in the fixture thread."""
+**To change a prediction:** Use `/predict` again. The bot posts a new updated prediction in the thread."""
 
         admin_help = """\n\n## 🔧 Admin Commands
 
 **For Admins:**
 • `/admin panel` - Open the main admin surface
-
-**Admin workflow:**
-- run `/admin panel` once
-- use the panel buttons and selectors for admin actions
 
 **Inside the panel you can:**
 - create fixtures
@@ -558,7 +554,7 @@ class UserCommands(commands.Cog):
 • `15.02.2024 18:00`
 • `15/02/2024 18:00`
 
-Use the commands above directly in Discord."""
+Use these directly in Discord."""
 
         await interaction.response.send_message(user_help, ephemeral=True)
 


### PR DESCRIPTION
## Summary
- simplify `/help` wording for both players and admins so it describes the current behavior more directly
- shorten README command and prediction-flow copy without changing any behavior
- keep the wording aligned with the panel-first admin model and public-thread prediction model

Closes #174

## Notes
- This PR is stacked on top of #173 because the wording assumes the panel-first admin surface.

## Testing
- `uv run ruff check README.md typer_bot/commands/user_commands.py`
