### PR TITLE
style: group admin panel buttons by workflow

### DIFF
--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1130,7 +1130,7 @@ class TestFixturePanelFlows:
         assert rows_by_label["Enter Results"] == 3
         assert rows_by_label["Calculate Scores"] == 3
         assert rows_by_label["Correct Results"] == 3
-        assert rows_by_label["Re-post Results"] == 4
+        assert rows_by_label["Re-post Results"] == 3
         assert rows_by_label["Replace Prediction"] == 4
         assert rows_by_label["Toggle Late Waiver"] == 4
 

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -254,7 +254,7 @@ class PostResultsConfirmView(discord.ui.View):
 class PostResultsButton(discord.ui.Button):
     def __init__(self, parent_view: UnifiedAdminPanelView):
         self.parent_view = parent_view
-        super().__init__(label="Re-post Results", style=discord.ButtonStyle.secondary, row=4)
+        super().__init__(label="Re-post Results", style=discord.ButtonStyle.secondary, row=3)
 
     async def callback(self, interaction: discord.Interaction):
         fixture_data = await self.parent_view.db.get_last_fixture_scores()
@@ -370,7 +370,7 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
             if self.selection.detail_lines:
                 lines.extend(["", *self.selection.detail_lines])
             else:
-                guidance = "Top row: fixture management. Middle row: results workflow. Bottom row: prediction and user actions. Use Jump To Week when the older open week you want is not in the quick list."
+                guidance = "Top row: fixture management. Middle row: results workflow, including re-posting. Bottom row: prediction and user actions. Use Jump To Week when the older open week you want is not in the quick list."
                 lines.extend(["", guidance])
 
             if self.has_user_overflow:


### PR DESCRIPTION
## Summary
- regroup unified admin panel buttons by workflow instead of mixing result and prediction actions across rows
- keep fixture management on the first row, full results flow on the second row, and prediction/user actions on the third row
- update the layout contract test to match the cleaner mobile-oriented grouping

## Testing
- `uv run pytest tests/test_admin_panel.py -k "unified_panel_layout_contract or unified_panel" --tb=short`
- `uv run ruff check typer_bot/commands/admin_panel/unified.py tests/test_admin_panel.py`
- `uv run ty check typer_bot`
