### PR TITLE
feat: add admin review for late predictions with missing games

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Admins need a Discord role named `Admin` or `typer-admin`.
 - Reply in the fixture thread with one line per match.
 - Run `/predict` anywhere in the server to fill a modal, then have the bot post your prediction publicly into the fixture thread.
 - To replace a saved prediction, use `/predict` again; the bot posts a new public `Updated prediction` message in the thread.
+- Partial predictions are allowed. Each partial line must name the game it applies to.
+- Missing games count as no prediction.
+- Late partial predictions stay pending admin approval until an admin approves or rejects them.
 
 Example:
 
@@ -62,7 +65,8 @@ Team E - Team F 3:2
 - Exact score: 3 points
 - Correct outcome: 1 point
 - Wrong outcome: 0 points
-- Late predictions: 0 points unless an admin waives the penalty
+- Late full predictions: 0 points unless an admin waives the penalty
+- Late partial predictions: excluded from scoring until approved or rejected by an admin
 
 ## Operational constraints
 - Match data, predictions, results, and scores are stored in SQLite.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Admins need a Discord role named `Admin` or `typer-admin`.
 - Partial predictions are allowed, but before the deadline players should still try to fill the whole fixture. Each partial line must name the game it applies to.
 - Missing games count as no prediction.
 - Late predictions with missing games stay under admin review until an admin approves or rejects them.
+- If approved, the submitted lines count normally and any missing games still count as no prediction.
+- If rejected, that late submission is discarded and does not count.
+- Public review status stays visible in the fixture thread: `/predict` posts are edited after review, and thread replies switch from `⏳` to `✅` or `❌`.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Admins need a Discord role named `Admin` or `typer-admin`.
 - Reply in the fixture thread with one line per match.
 - Run `/predict` anywhere in the server to fill a modal, then have the bot post your prediction publicly into the fixture thread.
 - To replace a saved prediction, use `/predict` again; the bot posts a new public `Updated prediction` message in the thread.
-- Partial predictions are allowed. Each partial line must name the game it applies to.
+- Partial predictions are allowed, but before the deadline players should still try to fill the whole fixture. Each partial line must name the game it applies to.
 - Missing games count as no prediction.
-- Late partial predictions stay pending admin approval until an admin approves or rejects them.
+- Late predictions with missing games stay under admin review until an admin approves or rejects them.
 
 Example:
 
@@ -66,7 +66,7 @@ Team E - Team F 3:2
 - Correct outcome: 1 point
 - Wrong outcome: 0 points
 - Late full predictions: 0 points unless an admin waives the penalty
-- Late partial predictions: excluded from scoring until approved or rejected by an admin
+- Late predictions with missing games: excluded from scoring until reviewed by an admin
 
 ## Operational constraints
 - Match data, predictions, results, and scores are stored in SQLite.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,7 @@ class MockGuild:
         self.id = int(guild_id)
         self.name = "Test Guild"
         self._members = {}
+        self.roles = []
 
     def add_member(self, user_id: str, roles: list[str] = None):
         mock_member = MagicMock()
@@ -211,6 +212,7 @@ def handler(mock_bot, database):
 
 class MockRole:
     def __init__(self, name: str):
+        self.id = abs(hash(name)) % 1000000 or 1
         self.name = name
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ class MockThread(discord.Thread):
         self.reactions_added = []
         self.reactions_cleared = False
         self.messages_sent = []
+        self.message_objects = {}
 
     @property
     def id(self):
@@ -76,8 +77,24 @@ class MockThread(discord.Thread):
         self.messages_sent.append(msg)
         mock_msg = MagicMock()
         mock_msg.id = len(self.messages_sent)
+        mock_msg.content = content
         mock_msg.delete = AsyncMock()
+        mock_msg.edit = AsyncMock(
+            side_effect=lambda **edit_kwargs: setattr(
+                mock_msg, "content", edit_kwargs.get("content", mock_msg.content)
+            )
+        )
+        mock_msg.add_reaction = AsyncMock()
+        mock_msg.remove_reaction = AsyncMock()
+        self.message_objects[mock_msg.id] = mock_msg
         return mock_msg
+
+    async def fetch_message(self, message_id: int):
+        return self.message_objects[message_id]
+
+    def register_message(self, message):
+        self.message_objects[message.id] = message
+        return message
 
 
 class MockGuild:

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1150,7 +1150,7 @@ class TestFixturePanelFlows:
         await view.load_fixture_options()
         view._refresh_items()
 
-        assert _has_button(view, "Review Pending") is False
+        assert _has_button(view, "Review Late") is False
 
     @pytest.mark.asyncio
     async def test_unified_panel_shows_review_pending_button_when_pending_partials_exist(
@@ -1181,8 +1181,9 @@ class TestFixturePanelFlows:
         )
         await view.load_fixture_options()
 
-        assert _has_button(view, "Review Pending") is True
-        assert _get_button(view, "Review Pending").row == 4
+        assert _has_button(view, "Review Late") is True
+        assert _get_button(view, "Review Late").row == 4
+        assert _get_button(view, "Review Late").style == discord.ButtonStyle.primary
 
     @pytest.mark.asyncio
     async def test_unified_panel_review_pending_button_jumps_to_pending_submission(
@@ -1213,14 +1214,16 @@ class TestFixturePanelFlows:
         )
         await view.load_fixture_options()
 
-        review_button = _get_button(view, "Review Pending")
+        review_button = _get_button(view, "Review Late")
         await review_button.callback(mock_interaction_admin)
 
         assert view.selection.fixture_label == "Week 56 [OPEN]"
         assert view.selection.user_id == "111"
-        assert _has_button(view, "Approve Partial") is True
-        assert _get_button(view, "Approve Partial").row == 4
-        assert _get_button(view, "Reject Partial").row == 4
+        assert _has_button(view, "Approve Late") is True
+        assert _get_button(view, "Approve Late").row == 4
+        assert _get_button(view, "Approve Late").style == discord.ButtonStyle.success
+        assert _get_button(view, "Reject Late").row == 4
+        assert _get_button(view, "Reject Late").style == discord.ButtonStyle.danger
 
     @pytest.mark.asyncio
     async def test_unified_panel_review_pending_button_cycles_pending_submissions(
@@ -1264,7 +1267,7 @@ class TestFixturePanelFlows:
         await view.load_fixture_options()
         view._refresh_items()
 
-        review_button = _get_button(view, "Review Pending")
+        review_button = _get_button(view, "Review Late")
         await review_button.callback(mock_interaction_admin)
         first_selection = (view.selection.fixture_id, view.selection.user_id)
 
@@ -2030,8 +2033,8 @@ class TestResultsPanelFlows:
         view.user_select._values = ["111"]
         await view.user_select.callback(mock_interaction_admin)
 
-        assert _has_button(view, "Approve Partial") is True
-        assert _has_button(view, "Reject Partial") is True
+        assert _has_button(view, "Approve Late") is True
+        assert _has_button(view, "Reject Late") is True
         assert _has_button(view, "Replace Prediction") is False
 
     @pytest.mark.asyncio
@@ -2069,7 +2072,7 @@ class TestResultsPanelFlows:
         view.user_select._values = ["111"]
         await view.user_select.callback(mock_interaction_admin)
 
-        approve_button = _get_button(view, "Approve Partial")
+        approve_button = _get_button(view, "Approve Late")
         await approve_button.callback(mock_interaction_admin)
 
         prediction = await admin_cog.db.get_prediction(fixture_id, "111")
@@ -2113,7 +2116,7 @@ class TestResultsPanelFlows:
         view.user_select._values = ["111"]
         await view.user_select.callback(mock_interaction_admin)
 
-        reject_button = _get_button(view, "Reject Partial")
+        reject_button = _get_button(view, "Reject Late")
         await reject_button.callback(mock_interaction_admin)
 
         assert await admin_cog.db.get_prediction(fixture_id, "111") is None
@@ -2163,7 +2166,7 @@ class TestResultsPanelFlows:
         view.user_select._values = ["111"]
         await view.user_select.callback(mock_interaction_admin)
 
-        approve_button = _get_button(view, "Approve Partial")
+        approve_button = _get_button(view, "Approve Late")
         await approve_button.callback(mock_interaction_admin)
 
         standings = await admin_cog.db.get_standings()
@@ -2213,7 +2216,7 @@ class TestResultsPanelFlows:
         view.user_select._values = ["111"]
         await view.user_select.callback(mock_interaction_admin)
 
-        reject_button = _get_button(view, "Reject Partial")
+        reject_button = _get_button(view, "Reject Late")
         await reject_button.callback(mock_interaction_admin)
 
         standings = await admin_cog.db.get_standings()

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1180,7 +1180,6 @@ class TestFixturePanelFlows:
             bot=admin_cog.bot,
         )
         await view.load_fixture_options()
-        view._refresh_items()
 
         assert _has_button(view, "Review Pending") is True
 
@@ -1212,7 +1211,6 @@ class TestFixturePanelFlows:
             bot=admin_cog.bot,
         )
         await view.load_fixture_options()
-        view._refresh_items()
 
         review_button = _get_button(view, "Review Pending")
         await review_button.callback(mock_interaction_admin)

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -2177,6 +2177,60 @@ class TestResultsPanelFlows:
         assert "approved by an admin" in public_message.content
 
     @pytest.mark.asyncio
+    async def test_unified_panel_reject_partial_prediction_edits_public_bot_post(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            72, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.update_fixture_announcement(
+            fixture_id,
+            message_id="789012",
+            channel_id="123456",
+        )
+        thread = MockThread(thread_id="789012", guild=mock_interaction_admin.guild)
+        public_message = await thread.send(
+            "**Prediction from <@111> · Week 72**\n\n2. Team C - Team D **1-1**\n3. Team E - Team F **0-2**\n\n⏳ Late prediction awaiting admin review."
+        )
+        admin_cog.bot.get_channel.side_effect = lambda channel_id: (
+            thread if channel_id == 789012 else None
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+            public_message_id=str(public_message.id),
+            public_message_kind="bot_post",
+        )
+        target_user = MockUser("111", "User One")
+        admin_cog.bot.get_user.return_value = target_user
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        reject_button = _get_button(view, "Reject Late")
+        await reject_button.callback(mock_interaction_admin)
+
+        assert "rejected by an admin" in public_message.content
+
+    @pytest.mark.asyncio
     async def test_unified_panel_reject_partial_prediction_updates_thread_reaction(
         self,
         admin_cog,
@@ -2235,6 +2289,116 @@ class TestResultsPanelFlows:
 
         assert ("⏳", admin_cog.bot.user.id) in user_message.reactions_removed
         assert "❌" in user_message.reactions_added
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_approve_partial_prediction_updates_thread_reaction(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            73, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.update_fixture_announcement(
+            fixture_id,
+            message_id="789012",
+            channel_id="123456",
+        )
+        thread = MockThread(thread_id="789012", guild=mock_interaction_admin.guild)
+        user_message = MockMessage(
+            content="Team C - Team D 1-1\nTeam E - Team F 0-2",
+            message_id="555555",
+            author=MockUser("111", "User One"),
+            channel=thread,
+            guild=mock_interaction_admin.guild,
+        )
+        thread.register_message(user_message)
+        admin_cog.bot.get_channel.side_effect = lambda channel_id: (
+            thread if channel_id == 789012 else None
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+            public_message_id=str(user_message.id),
+            public_message_kind="thread_message",
+        )
+        target_user = MockUser("111", "User One")
+        admin_cog.bot.get_user.return_value = target_user
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        approve_button = _get_button(view, "Approve Late")
+        await approve_button.callback(mock_interaction_admin)
+
+        assert ("⏳", admin_cog.bot.user.id) in user_message.reactions_removed
+        assert "✅" in user_message.reactions_added
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_approve_partial_prediction_ignores_bad_fixture_thread_id(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            74, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.update_fixture_announcement(
+            fixture_id,
+            message_id="not-a-thread-id",
+            channel_id="123456",
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+            public_message_id="555555",
+            public_message_kind="thread_message",
+        )
+        target_user = MockUser("111", "User One")
+        admin_cog.bot.get_user.return_value = target_user
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        approve_button = _get_button(view, "Approve Late")
+        await approve_button.callback(mock_interaction_admin)
+
+        prediction = await admin_cog.db.get_prediction(fixture_id, "111")
+        assert prediction is not None
+        assert prediction["pending_partial_approval"] is False
+        assert "approved" in target_user.dm_sent[-1].lower()
 
     @pytest.mark.asyncio
     async def test_unified_panel_approve_partial_prediction_recalculates_scores(

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1135,6 +1135,144 @@ class TestFixturePanelFlows:
         assert rows_by_label["Toggle Late Waiver"] == 4
 
     @pytest.mark.asyncio
+    async def test_unified_panel_hides_review_pending_button_without_pending_partials(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+    ):
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view._refresh_items()
+
+        assert _has_button(view, "Review Pending") is False
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_shows_review_pending_button_when_pending_partials_exist(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            55, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view._refresh_items()
+
+        assert _has_button(view, "Review Pending") is True
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_review_pending_button_jumps_to_pending_submission(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            56, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view._refresh_items()
+
+        review_button = _get_button(view, "Review Pending")
+        await review_button.callback(mock_interaction_admin)
+
+        assert view.selection.fixture_label == "Week 56 [OPEN]"
+        assert view.selection.user_id == "111"
+        assert _has_button(view, "Approve Partial") is True
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_review_pending_button_cycles_pending_submissions(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_a = await admin_cog.db.create_fixture(
+            57, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        fixture_b = await admin_cog.db.create_fixture(
+            58, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_a,
+            "111",
+            "User One",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+        await admin_cog.db.save_prediction(
+            fixture_b,
+            "222",
+            "User Two",
+            ["2-1"],
+            True,
+            predicted_game_indexes=[0],
+            pending_partial_approval=True,
+        )
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view._refresh_items()
+
+        review_button = _get_button(view, "Review Pending")
+        await review_button.callback(mock_interaction_admin)
+        first_selection = (view.selection.fixture_id, view.selection.user_id)
+
+        await review_button.callback(mock_interaction_admin)
+        second_selection = (view.selection.fixture_id, view.selection.user_id)
+
+        assert first_selection != second_selection
+
+    @pytest.mark.asyncio
     async def test_unified_panel_create_fixture_button_uses_parent_channel_from_thread(
         self,
         admin_cog,

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1182,6 +1182,7 @@ class TestFixturePanelFlows:
         await view.load_fixture_options()
 
         assert _has_button(view, "Review Pending") is True
+        assert _get_button(view, "Review Pending").row == 4
 
     @pytest.mark.asyncio
     async def test_unified_panel_review_pending_button_jumps_to_pending_submission(
@@ -1218,6 +1219,8 @@ class TestFixturePanelFlows:
         assert view.selection.fixture_label == "Week 56 [OPEN]"
         assert view.selection.user_id == "111"
         assert _has_button(view, "Approve Partial") is True
+        assert _get_button(view, "Approve Partial").row == 4
+        assert _get_button(view, "Reject Partial").row == 4
 
     @pytest.mark.asyncio
     async def test_unified_panel_review_pending_button_cycles_pending_submissions(

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1130,7 +1130,7 @@ class TestFixturePanelFlows:
         assert rows_by_label["Enter Results"] == 3
         assert rows_by_label["Calculate Scores"] == 3
         assert rows_by_label["Correct Results"] == 3
-        assert rows_by_label["Re-post Results"] == 4
+        assert rows_by_label["Re-post Results"] == 3
         assert rows_by_label["Replace Prediction"] == 4
         assert rows_by_label["Toggle Late Waiver"] == 4
 

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import discord
 import pytest
 
-from tests.conftest import MockInteraction, MockUser
+from tests.conftest import MockInteraction, MockMessage, MockThread, MockUser
 from typer_bot.commands.admin_commands import AdminCommands
 from typer_bot.commands.admin_panel import (
     CorrectResultsModal,
@@ -2121,6 +2121,120 @@ class TestResultsPanelFlows:
 
         assert await admin_cog.db.get_prediction(fixture_id, "111") is None
         assert "rejected" in target_user.dm_sent[-1].lower()
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_approve_partial_prediction_edits_public_bot_post(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            70, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.update_fixture_announcement(
+            fixture_id,
+            message_id="789012",
+            channel_id="123456",
+        )
+        thread = MockThread(thread_id="789012", guild=mock_interaction_admin.guild)
+        public_message = await thread.send(
+            "**Prediction from <@111> · Week 70**\n\n2. Team C - Team D **1-1**\n3. Team E - Team F **0-2**\n\n⏳ Late prediction awaiting admin review."
+        )
+        admin_cog.bot.get_channel.side_effect = lambda channel_id: (
+            thread if channel_id == 789012 else None
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+            public_message_id=str(public_message.id),
+            public_message_kind="bot_post",
+        )
+        target_user = MockUser("111", "User One")
+        admin_cog.bot.get_user.return_value = target_user
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        approve_button = _get_button(view, "Approve Late")
+        await approve_button.callback(mock_interaction_admin)
+
+        assert "approved by an admin" in public_message.content
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_reject_partial_prediction_updates_thread_reaction(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            71, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.update_fixture_announcement(
+            fixture_id,
+            message_id="789012",
+            channel_id="123456",
+        )
+        thread = MockThread(thread_id="789012", guild=mock_interaction_admin.guild)
+        user_message = MockMessage(
+            content="Team C - Team D 1-1\nTeam E - Team F 0-2",
+            message_id="555555",
+            author=MockUser("111", "User One"),
+            channel=thread,
+            guild=mock_interaction_admin.guild,
+        )
+        thread.register_message(user_message)
+        admin_cog.bot.get_channel.side_effect = lambda channel_id: (
+            thread if channel_id == 789012 else None
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+            public_message_id=str(user_message.id),
+            public_message_kind="thread_message",
+        )
+        target_user = MockUser("111", "User One")
+        admin_cog.bot.get_user.return_value = target_user
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        reject_button = _get_button(view, "Reject Late")
+        await reject_button.callback(mock_interaction_admin)
+
+        assert ("⏳", admin_cog.bot.user.id) in user_message.reactions_removed
+        assert "❌" in user_message.reactions_added
 
     @pytest.mark.asyncio
     async def test_unified_panel_approve_partial_prediction_recalculates_scores(

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1858,6 +1858,228 @@ class TestResultsPanelFlows:
         assert view.user_select.disabled is True
         assert "Fixture no longer exists" in mock_interaction_admin.response_sent[-1]["content"]
 
+    @pytest.mark.asyncio
+    async def test_unified_panel_shows_partial_approval_buttons_for_pending_prediction(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            50, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        assert _has_button(view, "Approve Partial") is True
+        assert _has_button(view, "Reject Partial") is True
+        assert _has_button(view, "Replace Prediction") is False
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_approve_partial_prediction(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            51, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+        target_user = MockUser("111", "User One")
+        admin_cog.bot.get_user.return_value = target_user
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        approve_button = _get_button(view, "Approve Partial")
+        await approve_button.callback(mock_interaction_admin)
+
+        prediction = await admin_cog.db.get_prediction(fixture_id, "111")
+        assert prediction is not None
+        assert prediction["pending_partial_approval"] is False
+        assert prediction["is_late"] == 0
+        assert "approved" in target_user.dm_sent[-1].lower()
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_reject_partial_prediction(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            52, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+        target_user = MockUser("111", "User One")
+        admin_cog.bot.get_user.return_value = target_user
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        reject_button = _get_button(view, "Reject Partial")
+        await reject_button.callback(mock_interaction_admin)
+
+        assert await admin_cog.db.get_prediction(fixture_id, "111") is None
+        assert "rejected" in target_user.dm_sent[-1].lower()
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_approve_partial_prediction_recalculates_scores(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            53, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["2-1", "1-1", "0-2"])
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "999",
+            "Full User",
+            ["2-1", "1-1", "0-2"],
+            False,
+        )
+        await admin_cog.service.calculate_fixture_scores(fixture_id)
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+        target_user = MockUser("111", "User One")
+        admin_cog.bot.get_user.return_value = target_user
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        approve_button = _get_button(view, "Approve Partial")
+        await approve_button.callback(mock_interaction_admin)
+
+        standings = await admin_cog.db.get_standings()
+        assert {row["user_id"] for row in standings} == {"999", "111"}
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_reject_partial_prediction_recalculates_scores(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            54, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["2-1", "1-1", "0-2"])
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "999",
+            "Full User",
+            ["2-1", "1-1", "0-2"],
+            False,
+        )
+        await admin_cog.service.calculate_fixture_scores(fixture_id)
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+        target_user = MockUser("111", "User One")
+        admin_cog.bot.get_user.return_value = target_user
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+        view.user_select._values = ["111"]
+        await view.user_select.callback(mock_interaction_admin)
+
+        reject_button = _get_button(view, "Reject Partial")
+        await reject_button.callback(mock_interaction_admin)
+
+        standings = await admin_cog.db.get_standings()
+        assert {row["user_id"] for row in standings} == {"999"}
+
 
 class TestAdminPanelModals:
     """Modal submit paths should reject stale permissions."""

--- a/tests/test_admin_service.py
+++ b/tests/test_admin_service.py
@@ -313,3 +313,150 @@ class TestResultCorrection:
             )
 
         assert await database.get_results(fixture_id) == ["1-0", "1-1", "0-0"]
+
+
+class TestPartialPredictionApproval:
+    @pytest.mark.asyncio
+    async def test_pending_partial_predictions_are_excluded_from_scoring(
+        self,
+        database,
+        sample_games,
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            3, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
+        await database.save_prediction(
+            fixture_id,
+            "111",
+            "Full User",
+            ["2-1", "1-1", "0-2"],
+            False,
+        )
+        await database.save_prediction(
+            fixture_id,
+            "222",
+            "Pending User",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+
+        result = await service.calculate_fixture_scores(fixture_id)
+
+        assert [score["user_id"] for score in result.scores] == ["111"]
+
+    @pytest.mark.asyncio
+    async def test_approved_partial_prediction_scores_only_selected_rows(
+        self,
+        database,
+        sample_games,
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            4, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
+        await database.save_prediction(
+            fixture_id,
+            "222",
+            "Partial User",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+
+        _fixture, approved_prediction, recalculation = await service.approve_partial_prediction(
+            fixture_id,
+            "222",
+            "admin-1",
+        )
+
+        assert approved_prediction["pending_partial_approval"] is False
+        assert recalculation is None
+
+        result = await service.calculate_fixture_scores(fixture_id)
+
+        assert result.scores[0]["user_id"] == "222"
+        assert result.scores[0]["points"] == 6
+
+    @pytest.mark.asyncio
+    async def test_approve_partial_prediction_recalculates_scored_fixture(
+        self,
+        database,
+        sample_games,
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            5, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
+        await database.save_prediction(
+            fixture_id,
+            "111",
+            "Full User",
+            ["2-1", "1-1", "0-2"],
+            False,
+        )
+        await service.calculate_fixture_scores(fixture_id)
+        await database.save_prediction(
+            fixture_id,
+            "222",
+            "Pending User",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+
+        _fixture, approved_prediction, recalculation = await service.approve_partial_prediction(
+            fixture_id,
+            "222",
+            "admin-1",
+        )
+
+        assert approved_prediction["pending_partial_approval"] is False
+        assert recalculation is not None
+        standings = await database.get_standings()
+        assert {row["user_id"] for row in standings} == {"111", "222"}
+
+    @pytest.mark.asyncio
+    async def test_reject_partial_prediction_recalculates_scored_fixture(
+        self,
+        database,
+        sample_games,
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            6, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
+        await database.save_prediction(
+            fixture_id,
+            "111",
+            "Full User",
+            ["2-1", "1-1", "0-2"],
+            False,
+        )
+        await service.calculate_fixture_scores(fixture_id)
+        await database.save_prediction(
+            fixture_id,
+            "222",
+            "Pending User",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+
+        _fixture, prediction, recalculation = await service.reject_partial_prediction(
+            fixture_id,
+            "222",
+        )
+
+        assert prediction["pending_partial_approval"] is True
+        assert recalculation is not None
+        assert await database.get_prediction(fixture_id, "222") is None

--- a/tests/test_prediction_parser.py
+++ b/tests/test_prediction_parser.py
@@ -162,6 +162,18 @@ class TestParsePredictionLines:
         assert game_indexes == [2]
         assert errors == []
 
+    def test_partial_mapping_preserves_team_names_starting_with_number(self):
+        games = ["1. FC Koln - Bayern", "Team C - Team D"]
+        predictions, game_indexes, errors = parse_prediction_lines(
+            "1. FC Koln - Bayern 2:1",
+            games,
+            allow_partial=True,
+        )
+
+        assert predictions == ["2-1"]
+        assert game_indexes == [0]
+        assert errors == []
+
     def test_mixed_separators_in_lines(self):
         """Lines with mixed separators."""
         input_text = "Team A 2-1\nTeam B 1:0\nTeam C 2-2"

--- a/tests/test_prediction_parser.py
+++ b/tests/test_prediction_parser.py
@@ -5,6 +5,7 @@ from typer_bot.utils.prediction_parser import (
     format_predictions_preview,
     format_standings,
     parse_line_predictions,
+    parse_prediction_lines,
     parse_predictions,
 )
 
@@ -118,6 +119,48 @@ class TestParseLinePredictions:
         predictions, errors = parse_line_predictions(input_text, games)
         assert predictions == ["2-1", "1-0"]
         assert not errors
+
+
+class TestParsePredictionLines:
+    def test_partial_mapping_by_game_name(self):
+        games = ["Team A - Team B", "Team C - Team D", "Team E - Team F"]
+        input_text = "Team C - Team D 1-1\nTeam E - Team F 0-2"
+
+        predictions, game_indexes, errors = parse_prediction_lines(
+            input_text, games, allow_partial=True
+        )
+
+        assert predictions == ["1-1", "0-2"]
+        assert game_indexes == [1, 2]
+        assert errors == []
+
+    def test_full_prediction_falls_back_to_positional_matching(self):
+        games = ["Team A - Team B", "Team C - Team D"]
+        predictions, game_indexes, errors = parse_prediction_lines(
+            "2-1\n1-0", games, allow_partial=False
+        )
+
+        assert predictions == ["2-1", "1-0"]
+        assert game_indexes == [0, 1]
+        assert errors == []
+
+    def test_partial_requires_game_names(self):
+        games = ["Team A - Team B", "Team C - Team D"]
+        predictions, game_indexes, errors = parse_prediction_lines("2-1", games, allow_partial=True)
+
+        assert predictions == []
+        assert game_indexes == []
+        assert "Could not match that line" in errors[0]
+
+    def test_partial_cancelled_games_map_by_name(self):
+        games = ["Team A - Team B", "Team C - Team D", "Team E - Team F"]
+        predictions, game_indexes, errors = parse_prediction_lines(
+            "Team E - Team F x", games, allow_partial=True
+        )
+
+        assert predictions == ["x"]
+        assert game_indexes == [2]
+        assert errors == []
 
     def test_mixed_separators_in_lines(self):
         """Lines with mixed separators."""

--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -154,6 +154,10 @@ class TestOnMessage:
         await database.update_fixture_announcement(
             fixture_id, message_id="789012", channel_id="123456"
         )
+        admin_role = MagicMock()
+        admin_role.name = "typer-admin"
+        admin_role.id = 4242
+        mock_message.guild.roles = [admin_role]
         mock_message.content = "Team C - Team D 1-1\nTeam E - Team F 0-2"
         mock_message.channel.id = 789012
 
@@ -166,6 +170,7 @@ class TestOnMessage:
         assert predictions[0]["predicted_game_indexes"] == [1, 2]
         assert "awaiting admin approval" in mock_message.author.dm_sent[-1]
         assert "awaiting admin approval" in mock_message.channel.messages_sent[-1]["content"]
+        assert "<@&4242>" in mock_message.channel.messages_sent[-1]["content"]
 
     @pytest.mark.asyncio
     async def test_rejects_thread_resubmission_without_overwriting_prediction(

--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -144,6 +144,7 @@ class TestOnMessage:
         assert predictions[0]["predicted_game_indexes"] == [1, 2]
         assert predictions[0]["pending_partial_approval"] is False
         assert "Partial prediction saved" in mock_message.author.dm_sent[-1]
+        assert "fill the rest" in mock_message.author.dm_sent[-1]
 
     @pytest.mark.asyncio
     async def test_marks_late_partial_thread_prediction_pending(
@@ -168,8 +169,9 @@ class TestOnMessage:
         predictions = await handler.db.get_all_predictions(fixture_id, include_pending=True)
         assert predictions[0]["pending_partial_approval"] is True
         assert predictions[0]["predicted_game_indexes"] == [1, 2]
-        assert "awaiting admin approval" in mock_message.author.dm_sent[-1]
-        assert "awaiting admin approval" in mock_message.channel.messages_sent[-1]["content"]
+        assert "awaiting admin review" in mock_message.author.dm_sent[-1]
+        assert "awaiting admin review" in mock_message.channel.messages_sent[-1]["content"]
+        assert "missing games" in mock_message.channel.messages_sent[-1]["content"]
         assert "<@&4242>" in mock_message.channel.messages_sent[-1]["content"]
 
     @pytest.mark.asyncio

--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -169,6 +169,8 @@ class TestOnMessage:
         predictions = await handler.db.get_all_predictions(fixture_id, include_pending=True)
         assert predictions[0]["pending_partial_approval"] is True
         assert predictions[0]["predicted_game_indexes"] == [1, 2]
+        assert predictions[0]["public_message_id"] == str(mock_message.id)
+        assert predictions[0]["public_message_kind"] == "thread_message"
         assert "awaiting admin review" in mock_message.author.dm_sent[-1]
         assert "awaiting admin review" in mock_message.channel.messages_sent[-1]["content"]
         assert "missing games" in mock_message.channel.messages_sent[-1]["content"]

--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -128,6 +128,46 @@ class TestOnMessage:
         assert "Late prediction" in mock_message.author.dm_sent[0]
 
     @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_thread")
+    async def test_accepts_pre_deadline_partial_thread_prediction(
+        self, handler, fixture_with_thread, mock_message
+    ):
+        mock_message.content = "Team C - Team D 1-1\nTeam E - Team F 0-2"
+        mock_message.channel.id = 789012
+
+        result = await handler.on_message(mock_message)
+
+        assert result is True
+        predictions = await handler.db.get_all_predictions(
+            fixture_with_thread["id"], include_pending=True
+        )
+        assert predictions[0]["predicted_game_indexes"] == [1, 2]
+        assert predictions[0]["pending_partial_approval"] is False
+        assert "Partial prediction saved" in mock_message.author.dm_sent[-1]
+
+    @pytest.mark.asyncio
+    async def test_marks_late_partial_thread_prediction_pending(
+        self, handler, database, mock_message, sample_games
+    ):
+        deadline = datetime.now(UTC) - timedelta(hours=1)
+        fixture_id = await database.create_fixture(1, sample_games, deadline)
+        await database.update_fixture_announcement(
+            fixture_id, message_id="789012", channel_id="123456"
+        )
+        mock_message.content = "Team C - Team D 1-1\nTeam E - Team F 0-2"
+        mock_message.channel.id = 789012
+
+        result = await handler.on_message(mock_message)
+
+        assert result is True
+        assert "⏳" in mock_message.reactions_added
+        predictions = await handler.db.get_all_predictions(fixture_id, include_pending=True)
+        assert predictions[0]["pending_partial_approval"] is True
+        assert predictions[0]["predicted_game_indexes"] == [1, 2]
+        assert "awaiting admin approval" in mock_message.author.dm_sent[-1]
+        assert "awaiting admin approval" in mock_message.channel.messages_sent[-1]["content"]
+
+    @pytest.mark.asyncio
     async def test_rejects_thread_resubmission_without_overwriting_prediction(
         self,
         handler,

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from tests.conftest import MockInteraction, MockThread, MockUser
+from tests.conftest import MockInteraction, MockRole, MockThread, MockUser
 from typer_bot.commands.user_commands import (
     ContinuePredictView,
     FixtureSelectView,
@@ -260,6 +260,8 @@ class TestPredictCommand:
         self, user_commands, mock_interaction, database
     ):
         await _attach_prediction_threads(user_commands, database, [1], mock_interaction.guild)
+        admin_role = MockRole("typer-admin")
+        mock_interaction.guild.roles = [admin_role]
         fixture = await database.get_fixture_by_id(1)
         assert fixture is not None
         fixture["deadline"] = datetime.now(UTC) - timedelta(minutes=1)
@@ -277,6 +279,8 @@ class TestPredictCommand:
         assert prediction["predicted_game_indexes"] == [1, 2]
         assert "Pending admin approval" in mock_interaction.response_sent[-1]["content"]
         assert "0 points" not in mock_interaction.response_sent[-1]["content"]
+        thread = user_commands.bot.get_channel(700001)
+        assert f"<@&{admin_role.id}>" in thread.messages_sent[-1]["content"]
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("fixture_with_dm")

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -252,7 +252,8 @@ class TestPredictCommand:
         assert prediction["predictions"] == ["1-1", "0-2"]
         assert prediction["predicted_game_indexes"] == [1, 2]
         assert prediction["pending_partial_approval"] is False
-        assert "Partial prediction" in mock_interaction.response_sent[-1]["content"]
+        assert "Partial prediction saved" in mock_interaction.response_sent[-1]["content"]
+        assert "fill the rest" in mock_interaction.response_sent[-1]["content"]
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("fixture_with_dm")
@@ -277,7 +278,9 @@ class TestPredictCommand:
         assert prediction is not None
         assert prediction["pending_partial_approval"] is True
         assert prediction["predicted_game_indexes"] == [1, 2]
-        assert "Pending admin approval" in mock_interaction.response_sent[-1]["content"]
+        assert (
+            "Late prediction awaiting admin review" in mock_interaction.response_sent[-1]["content"]
+        )
         assert "0 points" not in mock_interaction.response_sent[-1]["content"]
         thread = user_commands.bot.get_channel(700001)
         assert f"<@&{admin_role.id}>" in thread.messages_sent[-1]["content"]
@@ -302,7 +305,7 @@ class TestPredictCommand:
         content = mock_interaction.response_sent[-1]["content"]
         assert "2. Team C - Team D **1-1**" in content
         assert "3. Team E - Team F **0-2**" in content
-        assert "Pending admin approval" in content
+        assert "Late prediction awaiting admin review" in content
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("fixture_with_dm")

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -394,6 +394,24 @@ class TestPredictCommand:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("fixture_with_dm")
+    async def test_predict_modal_rejects_empty_partial_parse_result(
+        self, user_commands, mock_interaction, database
+    ):
+        await _attach_prediction_threads(user_commands, database, [1], mock_interaction.guild)
+        await user_commands.predict.callback(user_commands, mock_interaction)
+
+        modal = mock_interaction.modal_sent["modal"]
+        modal.predictions_input._value = ","
+        await modal.on_submit(mock_interaction)
+
+        assert (
+            "Please enter at least one prediction before submitting."
+            in mock_interaction.response_sent[-1]["content"]
+        )
+        assert await database.get_prediction(1, str(mock_interaction.user.id)) is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_dm")
     async def test_continue_predict_button_opens_next_modal(
         self, user_commands, mock_interaction, database, sample_games
     ):

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -278,6 +278,8 @@ class TestPredictCommand:
         assert prediction is not None
         assert prediction["pending_partial_approval"] is True
         assert prediction["predicted_game_indexes"] == [1, 2]
+        assert prediction["public_message_id"] == "1"
+        assert prediction["public_message_kind"] == "bot_post"
         assert (
             "Late prediction awaiting admin review" in mock_interaction.response_sent[-1]["content"]
         )

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -237,6 +237,71 @@ class TestPredictCommand:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("fixture_with_dm")
+    async def test_predict_modal_accepts_pre_deadline_partial_prediction(
+        self, user_commands, mock_interaction, database
+    ):
+        await _attach_prediction_threads(user_commands, database, [1], mock_interaction.guild)
+        await user_commands.predict.callback(user_commands, mock_interaction)
+
+        modal = mock_interaction.modal_sent["modal"]
+        modal.predictions_input._value = "Team C - Team D 1-1\nTeam E - Team F 0-2"
+        await modal.on_submit(mock_interaction)
+
+        prediction = await database.get_prediction(1, str(mock_interaction.user.id))
+        assert prediction is not None
+        assert prediction["predictions"] == ["1-1", "0-2"]
+        assert prediction["predicted_game_indexes"] == [1, 2]
+        assert prediction["pending_partial_approval"] is False
+        assert "Partial prediction" in mock_interaction.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_dm")
+    async def test_predict_modal_marks_late_partial_as_pending(
+        self, user_commands, mock_interaction, database
+    ):
+        await _attach_prediction_threads(user_commands, database, [1], mock_interaction.guild)
+        fixture = await database.get_fixture_by_id(1)
+        assert fixture is not None
+        fixture["deadline"] = datetime.now(UTC) - timedelta(minutes=1)
+        user_commands.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        user_commands.db.get_fixture_by_id = AsyncMock(return_value=fixture)
+
+        await user_commands.predict.callback(user_commands, mock_interaction)
+        modal = mock_interaction.modal_sent["modal"]
+        modal.predictions_input._value = "Team C - Team D 1-1\nTeam E - Team F 0-2"
+        await modal.on_submit(mock_interaction)
+
+        prediction = await database.get_prediction(1, str(mock_interaction.user.id))
+        assert prediction is not None
+        assert prediction["pending_partial_approval"] is True
+        assert prediction["predicted_game_indexes"] == [1, 2]
+        assert "Pending admin approval" in mock_interaction.response_sent[-1]["content"]
+        assert "0 points" not in mock_interaction.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_dm")
+    async def test_my_predictions_shows_sparse_pending_prediction(
+        self, user_commands, mock_interaction, database
+    ):
+        await database.save_prediction(
+            1,
+            str(mock_interaction.user.id),
+            mock_interaction.user.name,
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+
+        await user_commands.my_predictions.callback(user_commands, mock_interaction)
+
+        content = mock_interaction.response_sent[-1]["content"]
+        assert "2. Team C - Team D **1-1**" in content
+        assert "3. Team E - Team F **0-2**" in content
+        assert "Pending admin approval" in content
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_dm")
     async def test_predict_modal_reports_closed_fixture_during_submit(
         self, user_commands, mock_interaction, monkeypatch
     ):

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -289,6 +289,36 @@ class TestPredictCommand:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("fixture_with_dm")
+    async def test_predict_modal_replaces_previous_pending_bot_post(
+        self, user_commands, mock_interaction, database
+    ):
+        await _attach_prediction_threads(user_commands, database, [1], mock_interaction.guild)
+        fixture = await database.get_fixture_by_id(1)
+        assert fixture is not None
+        fixture["deadline"] = datetime.now(UTC) - timedelta(minutes=1)
+        user_commands.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        user_commands.db.get_fixture_by_id = AsyncMock(return_value=fixture)
+
+        await user_commands.predict.callback(user_commands, mock_interaction)
+        first_modal = mock_interaction.modal_sent["modal"]
+        first_modal.predictions_input._value = "Team C - Team D 1-1\nTeam E - Team F 0-2"
+        await first_modal.on_submit(mock_interaction)
+
+        thread = user_commands.bot.get_channel(700001)
+        first_public_message = thread.message_objects[1]
+
+        await user_commands.predict.callback(user_commands, mock_interaction)
+        second_modal = mock_interaction.modal_sent["modal"]
+        second_modal.predictions_input._value = "Team A - Team B 2-0\nTeam C - Team D 1-1"
+        await second_modal.on_submit(mock_interaction)
+
+        prediction = await database.get_prediction(1, str(mock_interaction.user.id))
+        assert prediction is not None
+        assert prediction["public_message_id"] == "2"
+        first_public_message.delete.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_dm")
     async def test_my_predictions_shows_sparse_pending_prediction(
         self, user_commands, mock_interaction, database
     ):

--- a/typer_bot/commands/admin_panel/base.py
+++ b/typer_bot/commands/admin_panel/base.py
@@ -206,7 +206,13 @@ async def _get_fixture_thread(
     if not message_id:
         return None
 
-    thread = bot.get_channel(int(message_id))
+    try:
+        thread_id = int(message_id)
+    except (TypeError, ValueError):
+        logger.warning("Could not parse fixture thread id %s for public review update", message_id)
+        return None
+
+    thread = bot.get_channel(thread_id)
     if isinstance(thread, discord.Thread):
         return thread
 
@@ -215,7 +221,7 @@ async def _get_fixture_thread(
         return None
 
     try:
-        fetched = await fetch_channel(int(message_id))
+        fetched = await fetch_channel(thread_id)
     except discord.HTTPException:
         logger.warning("Could not fetch fixture thread %s for public review update", message_id)
         return None
@@ -231,6 +237,7 @@ def _review_status_line(*, approved: bool) -> str:
 
 
 def _render_public_review_content(content: str, *, approved: bool) -> str:
+    """Replace any pending/reviewed footer in a public bot post, including older variants."""
     lines = content.splitlines()
     status_prefixes = (
         "⏳ Late prediction awaiting admin review.",

--- a/typer_bot/commands/admin_panel/base.py
+++ b/typer_bot/commands/admin_panel/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -192,6 +193,113 @@ async def _notify_user_dm(
         await user.send(message)
     except discord.HTTPException:
         logger.warning("Could not DM user %s for %s notification", user_id, context)
+
+
+async def _get_fixture_thread(
+    bot: discord.Client | None,
+    fixture: dict,
+) -> discord.Thread | None:
+    if bot is None:
+        return None
+
+    message_id = fixture.get("message_id")
+    if not message_id:
+        return None
+
+    thread = bot.get_channel(int(message_id))
+    if isinstance(thread, discord.Thread):
+        return thread
+
+    fetch_channel = getattr(bot, "fetch_channel", None)
+    if fetch_channel is None:
+        return None
+
+    try:
+        fetched = await fetch_channel(int(message_id))
+    except discord.HTTPException:
+        logger.warning("Could not fetch fixture thread %s for public review update", message_id)
+        return None
+    return fetched if isinstance(fetched, discord.Thread) else None
+
+
+def _review_status_line(*, approved: bool) -> str:
+    return (
+        "✅ Late prediction approved by an admin."
+        if approved
+        else "❌ Late prediction rejected by an admin."
+    )
+
+
+def _render_public_review_content(content: str, *, approved: bool) -> str:
+    lines = content.splitlines()
+    status_prefixes = (
+        "⏳ Late prediction awaiting admin review.",
+        "⏳ Late partial pending admin approval.",
+        "✅ Late prediction approved by an admin.",
+        "❌ Late prediction rejected by an admin.",
+    )
+    for index in range(len(lines) - 1, -1, -1):
+        if lines[index].startswith(status_prefixes):
+            lines[index] = _review_status_line(approved=approved)
+            return "\n".join(lines)
+
+    return f"{content}\n\n{_review_status_line(approved=approved)}"
+
+
+async def _update_public_review_marker(
+    bot: discord.Client | None,
+    fixture: dict,
+    prediction: dict,
+    *,
+    approved: bool,
+) -> None:
+    """Best-effort public marker update for reviewed late predictions."""
+    public_message_id = prediction.get("public_message_id")
+    public_message_kind = prediction.get("public_message_kind")
+    if public_message_id is None or public_message_kind is None:
+        return
+
+    thread = await _get_fixture_thread(bot, fixture)
+    if thread is None:
+        return
+
+    try:
+        message = await thread.fetch_message(int(public_message_id))
+    except (ValueError, discord.HTTPException, AttributeError):
+        logger.warning(
+            "Could not fetch public review marker %s for fixture %s",
+            public_message_id,
+            fixture.get("id"),
+        )
+        return
+
+    if public_message_kind == "bot_post":
+        content = getattr(message, "content", None)
+        if not isinstance(content, str):
+            return
+        try:
+            await message.edit(content=_render_public_review_content(content, approved=approved))
+        except discord.HTTPException:
+            logger.warning(
+                "Could not edit public review post %s for fixture %s",
+                public_message_id,
+                fixture.get("id"),
+            )
+        return
+
+    if public_message_kind != "thread_message" or bot is None or bot.user is None:
+        return
+
+    with suppress(discord.HTTPException, AttributeError):
+        await message.remove_reaction("⏳", bot.user)
+    try:
+        await message.add_reaction("✅" if approved else "❌")
+    except discord.HTTPException:
+        logger.warning(
+            "Could not update public review reaction on message %s for fixture %s",
+            public_message_id,
+            fixture.get("id"),
+        )
 
 
 class FixtureSelect(discord.ui.Select):

--- a/typer_bot/commands/admin_panel/base.py
+++ b/typer_bot/commands/admin_panel/base.py
@@ -96,7 +96,7 @@ def _render_panel_content(lines: list[str]) -> str:
 
 def _prediction_status_text(prediction: dict) -> str:
     if prediction.get("pending_partial_approval"):
-        return "pending partial"
+        return "late, pending review"
     if not prediction["is_late"]:
         return "on time"
     if prediction["late_penalty_waived"]:

--- a/typer_bot/commands/admin_panel/base.py
+++ b/typer_bot/commands/admin_panel/base.py
@@ -52,6 +52,19 @@ def _build_detail_lines(games: list[str], values: list[str]) -> list[str]:
     ]
 
 
+def _build_indexed_detail_lines(
+    game_indexes: list[int],
+    games: list[str],
+    values: list[str],
+) -> list[str]:
+    """Format detail lines while preserving original fixture row numbers."""
+    return [
+        _format_prediction_line(game_index + 1, games[game_index], value)
+        for game_index, value in zip(game_indexes, values, strict=False)
+        if 0 <= game_index < len(games)
+    ]
+
+
 def _render_panel_content(lines: list[str]) -> str:
     """Join panel lines under Discord's message limit.
 
@@ -82,6 +95,8 @@ def _render_panel_content(lines: list[str]) -> str:
 
 
 def _prediction_status_text(prediction: dict) -> str:
+    if prediction.get("pending_partial_approval"):
+        return "pending partial"
     if not prediction["is_late"]:
         return "on time"
     if prediction["late_penalty_waived"]:
@@ -262,6 +277,10 @@ class FixtureSelect(discord.ui.Select):
         load_user_options = getattr(self.parent_view, "load_user_options", None)
         if callable(load_user_options):
             await load_user_options()
+
+        set_selected_prediction = getattr(self.parent_view, "set_selected_prediction", None)
+        if callable(set_selected_prediction):
+            await set_selected_prediction()
 
         self.sync_selected_option()
 

--- a/typer_bot/commands/admin_panel/modals.py
+++ b/typer_bot/commands/admin_panel/modals.py
@@ -12,6 +12,7 @@ from typer_bot.utils import APP_TZ, format_for_discord, is_admin, now, parse_lin
 
 from .base import (
     _build_detail_lines,
+    _build_indexed_detail_lines,
     _format_prediction_line,
     _notify_user_dm,
     _prediction_status_text,
@@ -387,10 +388,9 @@ class ReplacePredictionModal(discord.ui.Modal):
             style=discord.TextStyle.paragraph,
             placeholder="One line per match, e.g. Team A - Team B 2:1",
             default="\n".join(
-                _format_prediction_line(index, game, result)
-                for index, (game, result) in enumerate(
-                    zip(fixture["games"], prediction["predictions"], strict=False),
-                    1,
+                _format_prediction_line(index + 1, fixture["games"][index], result)
+                for index, result in zip(
+                    prediction["predicted_game_indexes"], prediction["predictions"], strict=False
                 )
             ),
             required=True,
@@ -448,8 +448,10 @@ class ReplacePredictionModal(discord.ui.Modal):
         self.parent_view.selection.user_label = (
             f"{updated_prediction['user_name']} ({_prediction_status_text(updated_prediction)})"
         )
-        self.parent_view.selection.detail_lines = _build_detail_lines(
-            fixture["games"], updated_prediction["predictions"]
+        self.parent_view.selection.detail_lines = _build_indexed_detail_lines(
+            updated_prediction["predicted_game_indexes"],
+            fixture["games"],
+            updated_prediction["predictions"],
         )
 
         await self.parent_view.load_user_options()

--- a/typer_bot/commands/admin_panel/predictions.py
+++ b/typer_bot/commands/admin_panel/predictions.py
@@ -15,6 +15,7 @@ from .base import (
     OwnerRestrictedView,
     PanelSelectionState,
     _build_detail_lines,
+    _build_indexed_detail_lines,
     _notify_user_dm,
     _prediction_status_text,
     _render_panel_content,
@@ -66,7 +67,9 @@ class PredictionsPanelView(OwnerRestrictedView):
             self.user_select.update_options([])
             return
 
-        predictions = await self.db.get_all_predictions(self.selection.fixture_id)
+        predictions = await self.db.get_all_predictions(
+            self.selection.fixture_id, include_pending=True
+        )
         self.has_user_overflow = len(predictions) > MAX_SELECT_OPTIONS
         self.user_select.update_options(predictions)
 
@@ -181,10 +184,16 @@ class PredictionUserSelect(discord.ui.Select):
             self.parent_view.selection.user_label = (
                 f"{prediction['user_name']} ({_prediction_status_text(prediction)})"
             )
-            self.parent_view.selection.detail_lines = _build_detail_lines(
-                fixture["games"], prediction["predictions"]
+            self.parent_view.selection.detail_lines = _build_indexed_detail_lines(
+                prediction["predicted_game_indexes"],
+                fixture["games"],
+                prediction["predictions"],
             )
             self.parent_view.selection.status_message = ""
+
+        set_selected_prediction = getattr(self.parent_view, "set_selected_prediction", None)
+        if callable(set_selected_prediction):
+            await set_selected_prediction()
 
         self.sync_selected_option()
 

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -16,6 +16,8 @@ from .base import (
     OwnerRestrictedView,
     PanelSelectionState,
     _build_detail_lines,
+    _build_indexed_detail_lines,
+    _notify_user_dm,
     _render_panel_content,
 )
 from .fixtures import FixturesDeleteButton
@@ -25,8 +27,122 @@ from .predictions import (
     ReplacePredictionButton,
     ToggleWaiverButton,
     ViewPredictionsButton,
+    _prediction_status_text,
 )
 from .results import CorrectResultsButton
+
+
+class ApprovePartialButton(discord.ui.Button):
+    def __init__(self, parent_view: UnifiedAdminPanelView):
+        self.parent_view = parent_view
+        super().__init__(label="Approve Partial", style=discord.ButtonStyle.success, row=4)
+
+    async def callback(self, interaction: discord.Interaction):
+        fixture_id = self.parent_view.selection.fixture_id
+        user_id = self.parent_view.selection.user_id
+        if fixture_id is None or user_id is None:
+            await interaction.response.send_message(
+                "Select both fixture and user first.", ephemeral=True
+            )
+            return
+        try:
+            (
+                fixture,
+                prediction,
+                recalculation,
+            ) = await self.parent_view.service.approve_partial_prediction(
+                fixture_id,
+                user_id,
+                str(interaction.user.id),
+            )
+        except ValueError as exc:
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
+
+        self.parent_view.selection.user_label = (
+            f"{prediction['user_name']} ({_prediction_status_text(prediction)})"
+        )
+        self.parent_view.selection.detail_lines = _build_indexed_detail_lines(
+            prediction["predicted_game_indexes"],
+            fixture["games"],
+            prediction["predictions"],
+        )
+        self.parent_view.selection.status_message = f"Approved partial prediction for {prediction['user_name']} in week {fixture['week_number']}."
+        if recalculation is not None:
+            self.parent_view.selection.status_message += " Scores were recalculated."
+
+        await self.parent_view.load_user_options()
+        self.parent_view.current_prediction = prediction
+        self.parent_view._refresh_items()
+        await interaction.response.edit_message(
+            content=self.parent_view.render_content(), view=self.parent_view
+        )
+
+        notification = (
+            f"Your partial prediction for Week {fixture['week_number']} was approved by an admin."
+        )
+        if recalculation is not None:
+            notification += " Scores were recalculated."
+        await _notify_user_dm(
+            self.parent_view.bot,
+            prediction["user_id"],
+            notification,
+            context="partial approval",
+        )
+
+
+class RejectPartialButton(discord.ui.Button):
+    def __init__(self, parent_view: UnifiedAdminPanelView):
+        self.parent_view = parent_view
+        super().__init__(label="Reject Partial", style=discord.ButtonStyle.danger, row=4)
+
+    async def callback(self, interaction: discord.Interaction):
+        fixture_id = self.parent_view.selection.fixture_id
+        user_id = self.parent_view.selection.user_id
+        if fixture_id is None or user_id is None:
+            await interaction.response.send_message(
+                "Select both fixture and user first.", ephemeral=True
+            )
+            return
+        try:
+            (
+                fixture,
+                prediction,
+                recalculation,
+            ) = await self.parent_view.service.reject_partial_prediction(
+                fixture_id,
+                user_id,
+            )
+        except ValueError as exc:
+            await interaction.response.send_message(str(exc), ephemeral=True)
+            return
+
+        self.parent_view.selection.user_id = None
+        self.parent_view.selection.user_label = ""
+        self.parent_view.selection.detail_lines = []
+        self.parent_view.selection.status_message = f"Rejected partial prediction for {prediction['user_name']} in week {fixture['week_number']}."
+        if recalculation is not None:
+            self.parent_view.selection.status_message += " Scores were recalculated."
+
+        await self.parent_view.load_user_options()
+        self.parent_view.current_prediction = None
+        self.parent_view._refresh_items()
+        await interaction.response.edit_message(
+            content=self.parent_view.render_content(), view=self.parent_view
+        )
+
+        notification = (
+            f"Your partial prediction for Week {fixture['week_number']} was rejected by an admin."
+        )
+        if recalculation is not None:
+            notification += " Scores were recalculated."
+        await _notify_user_dm(
+            self.parent_view.bot,
+            prediction["user_id"],
+            notification,
+            context="partial rejection",
+        )
+
 
 if TYPE_CHECKING:
     from typer_bot.commands.admin_commands import AdminCommands
@@ -300,6 +416,7 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
         self.admin_commands = admin_commands
         self.selection = PanelSelectionState()
         self.has_user_overflow = False
+        self.current_prediction: dict | None = None
         self.fixture_select = FixtureSelect(self)
         self.user_select = PredictionUserSelect(self)
         self.user_select.update_options([])
@@ -316,20 +433,24 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
         self.add_item(CalculateScoresButton(self))
         self.add_item(CorrectResultsButton(self, disabled=self.selection.fixture_id is None, row=3))
         self.add_item(PostResultsButton(self))
-        self.add_item(
-            ReplacePredictionButton(
-                self,
-                disabled=self.selection.fixture_id is None or self.selection.user_id is None,
-                row=4,
+        if self.current_prediction and self.current_prediction.get("pending_partial_approval"):
+            self.add_item(ApprovePartialButton(self))
+            self.add_item(RejectPartialButton(self))
+        else:
+            self.add_item(
+                ReplacePredictionButton(
+                    self,
+                    disabled=self.selection.fixture_id is None or self.selection.user_id is None,
+                    row=4,
+                )
             )
-        )
-        self.add_item(
-            ToggleWaiverButton(
-                self,
-                disabled=self.selection.fixture_id is None or self.selection.user_id is None,
-                row=4,
+            self.add_item(
+                ToggleWaiverButton(
+                    self,
+                    disabled=self.selection.fixture_id is None or self.selection.user_id is None,
+                    row=4,
+                )
             )
-        )
         if self.has_user_overflow:
             self.add_item(
                 ViewPredictionsButton(self, disabled=self.selection.fixture_id is None, row=4)
@@ -345,9 +466,19 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
             self.user_select.update_options([])
             return
 
-        predictions = await self.db.get_all_predictions(self.selection.fixture_id)
+        predictions = await self.db.get_all_predictions(
+            self.selection.fixture_id, include_pending=True
+        )
         self.has_user_overflow = len(predictions) > MAX_SELECT_OPTIONS
         self.user_select.update_options(predictions)
+
+    async def set_selected_prediction(self) -> None:
+        self.current_prediction = None
+        if self.selection.fixture_id is None or self.selection.user_id is None:
+            return
+        self.current_prediction = await self.db.get_prediction(
+            self.selection.fixture_id, self.selection.user_id
+        )
 
     async def populate_fixture_details(self, fixture: dict | None) -> None:
         self.selection.detail_lines = []

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -19,6 +19,7 @@ from .base import (
     _build_indexed_detail_lines,
     _notify_user_dm,
     _render_panel_content,
+    _update_public_review_marker,
 )
 from .fixtures import FixturesDeleteButton
 from .modals import CreateFixtureModal, EnterResultsModal
@@ -77,6 +78,12 @@ class ApprovePartialButton(discord.ui.Button):
         await interaction.response.edit_message(
             content=self.parent_view.render_content(), view=self.parent_view
         )
+        await _update_public_review_marker(
+            self.parent_view.bot,
+            fixture,
+            prediction,
+            approved=True,
+        )
 
         notification = (
             f"Your late prediction for Week {fixture['week_number']} was approved by an admin."
@@ -129,6 +136,12 @@ class RejectPartialButton(discord.ui.Button):
         self.parent_view._refresh_items()
         await interaction.response.edit_message(
             content=self.parent_view.render_content(), view=self.parent_view
+        )
+        await _update_public_review_marker(
+            self.parent_view.bot,
+            fixture,
+            prediction,
+            approved=False,
         )
 
         notification = (

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -147,7 +147,7 @@ class RejectPartialButton(discord.ui.Button):
 class ReviewPendingPartialsButton(discord.ui.Button):
     def __init__(self, parent_view: UnifiedAdminPanelView):
         self.parent_view = parent_view
-        super().__init__(label="Review Pending", style=discord.ButtonStyle.danger, row=2)
+        super().__init__(label="Review Pending", style=discord.ButtonStyle.danger, row=4)
 
     async def callback(self, interaction: discord.Interaction):
         pending_predictions = await self.parent_view.db.get_pending_partial_predictions()

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -422,7 +422,7 @@ class PostResultsConfirmView(discord.ui.View):
 class PostResultsButton(discord.ui.Button):
     def __init__(self, parent_view: UnifiedAdminPanelView):
         self.parent_view = parent_view
-        super().__init__(label="Re-post Results", style=discord.ButtonStyle.secondary, row=4)
+        super().__init__(label="Re-post Results", style=discord.ButtonStyle.secondary, row=3)
 
     async def callback(self, interaction: discord.Interaction):
         fixture_data = await self.parent_view.db.get_last_fixture_scores()

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -144,6 +144,58 @@ class RejectPartialButton(discord.ui.Button):
         )
 
 
+class ReviewPendingPartialsButton(discord.ui.Button):
+    def __init__(self, parent_view: UnifiedAdminPanelView):
+        self.parent_view = parent_view
+        super().__init__(label="Review Pending", style=discord.ButtonStyle.danger, row=2)
+
+    async def callback(self, interaction: discord.Interaction):
+        pending_predictions = await self.parent_view.db.get_pending_partial_predictions()
+        if not pending_predictions:
+            await interaction.response.send_message(
+                "There are no pending partial predictions right now.", ephemeral=True
+            )
+            return
+
+        current_key = (self.parent_view.selection.fixture_id, self.parent_view.selection.user_id)
+        next_prediction = pending_predictions[0]
+        for index, pending in enumerate(pending_predictions):
+            if (pending["fixture_id"], pending["user_id"]) == current_key:
+                next_prediction = pending_predictions[(index + 1) % len(pending_predictions)]
+                break
+
+        fixture = await self.parent_view.db.get_fixture_by_id(next_prediction["fixture_id"])
+        if fixture is None:
+            await interaction.response.send_message(
+                "That fixture no longer exists. Try again after refreshing the panel.",
+                ephemeral=True,
+            )
+            return
+
+        self.parent_view.selection.fixture_id = fixture["id"]
+        self.parent_view.selection.fixture_label = (
+            f"Week {fixture['week_number']} [{fixture['status'].upper()}]"
+        )
+        self.parent_view.selection.user_id = next_prediction["user_id"]
+        self.parent_view.selection.user_label = (
+            f"{next_prediction['user_name']} ({_prediction_status_text(next_prediction)})"
+        )
+        self.parent_view.selection.detail_lines = _build_indexed_detail_lines(
+            next_prediction["predicted_game_indexes"],
+            fixture["games"],
+            next_prediction["predictions"],
+        )
+        self.parent_view.selection.status_message = f"Reviewing pending partial prediction for {next_prediction['user_name']} in week {fixture['week_number']}."
+        await self.parent_view.load_user_options()
+        await self.parent_view.set_selected_prediction()
+        self.parent_view.fixture_select.sync_selected_option()
+        self.parent_view._refresh_items()
+        await interaction.response.edit_message(
+            content=self.parent_view.render_content(),
+            view=self.parent_view,
+        )
+
+
 if TYPE_CHECKING:
     from typer_bot.commands.admin_commands import AdminCommands
 
@@ -416,6 +468,7 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
         self.admin_commands = admin_commands
         self.selection = PanelSelectionState()
         self.has_user_overflow = False
+        self.has_pending_partials = False
         self.current_prediction: dict | None = None
         self.fixture_select = FixtureSelect(self)
         self.user_select = PredictionUserSelect(self)
@@ -429,6 +482,8 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
         self.add_item(CreateFixtureButton(self))
         self.add_item(FixturesDeleteButton(self, disabled=self.selection.fixture_id is None, row=2))
         self.add_item(JumpToWeekButton(self))
+        if self.has_pending_partials:
+            self.add_item(ReviewPendingPartialsButton(self))
         self.add_item(EnterResultsButton(self))
         self.add_item(CalculateScoresButton(self))
         self.add_item(CorrectResultsButton(self, disabled=self.selection.fixture_id is None, row=3))
@@ -459,6 +514,7 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
     async def load_fixture_options(self) -> None:
         fixtures = await self.db.get_recent_fixtures(MAX_SELECT_OPTIONS)
         self.fixture_select.update_options(fixtures)
+        self.has_pending_partials = bool(await self.db.get_pending_partial_predictions())
 
     async def load_user_options(self) -> None:
         if self.selection.fixture_id is None:

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -35,7 +35,7 @@ from .results import CorrectResultsButton
 class ApprovePartialButton(discord.ui.Button):
     def __init__(self, parent_view: UnifiedAdminPanelView):
         self.parent_view = parent_view
-        super().__init__(label="Approve Partial", style=discord.ButtonStyle.success, row=4)
+        super().__init__(label="Approve Late", style=discord.ButtonStyle.success, row=4)
 
     async def callback(self, interaction: discord.Interaction):
         fixture_id = self.parent_view.selection.fixture_id
@@ -67,7 +67,7 @@ class ApprovePartialButton(discord.ui.Button):
             fixture["games"],
             prediction["predictions"],
         )
-        self.parent_view.selection.status_message = f"Approved partial prediction for {prediction['user_name']} in week {fixture['week_number']}."
+        self.parent_view.selection.status_message = f"Approved late prediction for {prediction['user_name']} in week {fixture['week_number']}."
         if recalculation is not None:
             self.parent_view.selection.status_message += " Scores were recalculated."
 
@@ -79,7 +79,7 @@ class ApprovePartialButton(discord.ui.Button):
         )
 
         notification = (
-            f"Your partial prediction for Week {fixture['week_number']} was approved by an admin."
+            f"Your late prediction for Week {fixture['week_number']} was approved by an admin."
         )
         if recalculation is not None:
             notification += " Scores were recalculated."
@@ -94,7 +94,7 @@ class ApprovePartialButton(discord.ui.Button):
 class RejectPartialButton(discord.ui.Button):
     def __init__(self, parent_view: UnifiedAdminPanelView):
         self.parent_view = parent_view
-        super().__init__(label="Reject Partial", style=discord.ButtonStyle.danger, row=4)
+        super().__init__(label="Reject Late", style=discord.ButtonStyle.danger, row=4)
 
     async def callback(self, interaction: discord.Interaction):
         fixture_id = self.parent_view.selection.fixture_id
@@ -120,7 +120,7 @@ class RejectPartialButton(discord.ui.Button):
         self.parent_view.selection.user_id = None
         self.parent_view.selection.user_label = ""
         self.parent_view.selection.detail_lines = []
-        self.parent_view.selection.status_message = f"Rejected partial prediction for {prediction['user_name']} in week {fixture['week_number']}."
+        self.parent_view.selection.status_message = f"Rejected late prediction for {prediction['user_name']} in week {fixture['week_number']}."
         if recalculation is not None:
             self.parent_view.selection.status_message += " Scores were recalculated."
 
@@ -132,7 +132,7 @@ class RejectPartialButton(discord.ui.Button):
         )
 
         notification = (
-            f"Your partial prediction for Week {fixture['week_number']} was rejected by an admin."
+            f"Your late prediction for Week {fixture['week_number']} was rejected by an admin."
         )
         if recalculation is not None:
             notification += " Scores were recalculated."
@@ -147,13 +147,13 @@ class RejectPartialButton(discord.ui.Button):
 class ReviewPendingPartialsButton(discord.ui.Button):
     def __init__(self, parent_view: UnifiedAdminPanelView):
         self.parent_view = parent_view
-        super().__init__(label="Review Pending", style=discord.ButtonStyle.danger, row=4)
+        super().__init__(label="Review Late", style=discord.ButtonStyle.primary, row=4)
 
     async def callback(self, interaction: discord.Interaction):
         pending_predictions = await self.parent_view.db.get_pending_partial_predictions()
         if not pending_predictions:
             await interaction.response.send_message(
-                "There are no pending partial predictions right now.", ephemeral=True
+                "There are no late predictions awaiting review right now.", ephemeral=True
             )
             return
 
@@ -185,7 +185,7 @@ class ReviewPendingPartialsButton(discord.ui.Button):
             fixture["games"],
             next_prediction["predictions"],
         )
-        self.parent_view.selection.status_message = f"Reviewing pending partial prediction for {next_prediction['user_name']} in week {fixture['week_number']}."
+        self.parent_view.selection.status_message = f"Reviewing late prediction for {next_prediction['user_name']} in week {fixture['week_number']}."
         await self.parent_view.load_user_options()
         await self.parent_view.set_selected_prediction()
         self.parent_view.fixture_select.sync_selected_option()
@@ -558,7 +558,7 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
             if self.selection.detail_lines:
                 lines.extend(["", *self.selection.detail_lines])
             else:
-                guidance = "Top row: fixture management. Middle row: results workflow. Bottom row: prediction and user actions. Use Jump To Week when the older open week you want is not in the quick list."
+                guidance = "Top row: fixture management. Middle row: results workflow. Bottom row: prediction and late-review actions. Use Jump To Week when the older open week you want is not in the quick list."
                 lines.extend(["", guidance])
 
             if self.has_user_overflow:
@@ -570,7 +570,7 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
                 )
         else:
             lines.append(
-                "Use the top row for fixture management, the middle row for results, and the bottom row for prediction-level actions."
+                "Use the top row for fixture management, the middle row for results, and the bottom row for prediction and late-review actions."
             )
             if self.selection.status_message:
                 lines.extend(["", self.selection.status_message])

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -515,6 +515,7 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
         fixtures = await self.db.get_recent_fixtures(MAX_SELECT_OPTIONS)
         self.fixture_select.update_options(fixtures)
         self.has_pending_partials = bool(await self.db.get_pending_partial_predictions())
+        self._refresh_items()
 
     async def load_user_options(self) -> None:
         if self.selection.fixture_id is None:

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -45,20 +45,21 @@ def _format_thread_prediction_message(
     pending_partial_approval: bool,
 ) -> str:
     heading = "Updated prediction" if is_update else "Prediction"
-    if pending_partial_approval:
-        heading = f"{heading} (awaiting admin approval)"
-    content = [f"**{heading} from <@{user_id}> for Week {fixture['week_number']}**", ""]
+    content = [f"**{heading} from <@{user_id}> · Week {fixture['week_number']}**", ""]
     for game_index, prediction in zip(predicted_game_indexes, predictions, strict=False):
         game = fixture["games"][game_index]
         content.append(f"{game_index + 1}. {game} **{prediction}**")
-    if len(predicted_game_indexes) < len(fixture["games"]):
-        content.append("")
-        content.append("Partial prediction.")
-    if is_late:
-        content.append("")
-        content.append("⚠️ Late prediction.")
+
+    status: str | None = None
     if pending_partial_approval:
-        content.append("Pending admin approval.")
+        status = "⏳ Late partial pending admin approval."
+    elif is_late:
+        status = "⚠️ Late prediction."
+    elif len(predicted_game_indexes) < len(fixture["games"]):
+        status = "Partial prediction."
+
+    if status:
+        content.extend(["", status])
     return "\n".join(content)
 
 

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -382,6 +382,8 @@ class PredictModal(discord.ui.Modal):
                 is_late,
                 predicted_game_indexes=predicted_game_indexes,
                 pending_partial_approval=pending_partial_approval,
+                public_message_id=str(public_message.id) if pending_partial_approval else None,
+                public_message_kind="bot_post" if pending_partial_approval else None,
             )
         except Exception:
             logger.exception(

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -16,7 +16,7 @@ from typer_bot.utils import (
     format_standings,
     is_admin,
     now,
-    parse_line_predictions,
+    parse_prediction_lines,
 )
 
 SELECT_PAGE_SIZE = 25
@@ -35,15 +35,30 @@ def _remaining_open_fixtures(
 
 
 def _format_thread_prediction_message(
-    fixture: dict, user_id: int, predictions: list[str], *, is_update: bool, is_late: bool
+    fixture: dict,
+    user_id: int,
+    predictions: list[str],
+    predicted_game_indexes: list[int],
+    *,
+    is_update: bool,
+    is_late: bool,
+    pending_partial_approval: bool,
 ) -> str:
     heading = "Updated prediction" if is_update else "Prediction"
+    if pending_partial_approval:
+        heading = f"{heading} (awaiting admin approval)"
     content = [f"**{heading} from <@{user_id}> for Week {fixture['week_number']}**", ""]
-    for index, (game, prediction) in enumerate(zip(fixture["games"], predictions, strict=False), 1):
-        content.append(f"{index}. {game} **{prediction}**")
+    for game_index, prediction in zip(predicted_game_indexes, predictions, strict=False):
+        game = fixture["games"][game_index]
+        content.append(f"{game_index + 1}. {game} **{prediction}**")
+    if len(predicted_game_indexes) < len(fixture["games"]):
+        content.append("")
+        content.append("Partial prediction.")
     if is_late:
         content.append("")
         content.append("⚠️ Late prediction.")
+    if pending_partial_approval:
+        content.append("Pending admin approval.")
     return "\n".join(content)
 
 
@@ -281,9 +296,11 @@ class PredictModal(discord.ui.Modal):
         self.completed_fixture_ids = completed_fixture_ids or set()
         default_value = (
             "\n".join(
-                f"{game} {prediction}"
-                for game, prediction in zip(
-                    fixture["games"], existing_prediction["predictions"], strict=False
+                f"{fixture['games'][game_index]} {prediction}"
+                for game_index, prediction in zip(
+                    existing_prediction["predicted_game_indexes"],
+                    existing_prediction["predictions"],
+                    strict=False,
                 )
             )
             if existing_prediction
@@ -308,7 +325,11 @@ class PredictModal(discord.ui.Modal):
             )
             return
 
-        predictions, errors = parse_line_predictions(self.predictions_input.value, fixture["games"])
+        predictions, predicted_game_indexes, errors = parse_prediction_lines(
+            self.predictions_input.value,
+            fixture["games"],
+            allow_partial=True,
+        )
         if errors:
             await interaction.response.send_message("\n".join(errors), ephemeral=True)
             return
@@ -323,6 +344,8 @@ class PredictModal(discord.ui.Modal):
 
         is_late = now() > fixture["deadline"]
         existing_prediction = await self.db.get_prediction(fixture["id"], str(interaction.user.id))
+        is_partial = len(predicted_game_indexes) < len(fixture["games"])
+        pending_partial_approval = is_late and is_partial
         public_message = None
         try:
             public_message = await thread.send(
@@ -330,8 +353,10 @@ class PredictModal(discord.ui.Modal):
                     fixture,
                     interaction.user.id,
                     predictions,
+                    predicted_game_indexes,
                     is_update=existing_prediction is not None,
                     is_late=is_late,
+                    pending_partial_approval=pending_partial_approval,
                 )
             )
         except discord.HTTPException:
@@ -348,6 +373,8 @@ class PredictModal(discord.ui.Modal):
                 self.user_name,
                 predictions,
                 is_late,
+                predicted_game_indexes=predicted_game_indexes,
+                pending_partial_approval=pending_partial_approval,
             )
         except Exception:
             logger.exception(
@@ -376,12 +403,19 @@ class PredictModal(discord.ui.Modal):
             )
             return
 
-        content = format_predictions_preview(fixture["games"], predictions)
+        preview_games = [fixture["games"][index] for index in predicted_game_indexes]
+        content = format_predictions_preview(preview_games, predictions)
         deadline_str = format_for_discord(fixture["deadline"], "F")
         relative_str = format_for_discord(fixture["deadline"], "R")
         content += f"\n\n**Posted publicly in the fixture thread.**\n**Deadline:** {deadline_str} ({relative_str})"
-        if is_late:
+        if pending_partial_approval:
+            content += "\n\n⏳ **Pending admin approval:** your predicted games will only count if an admin approves this late partial submission."
+        elif is_late:
             content += "\n\n⚠️ **Late prediction!** You will receive 0 points for this round."
+        elif is_partial:
+            content += (
+                "\n\nℹ️ **Partial prediction:** any missing games will count as no prediction."
+            )
 
         completed_fixture_ids = set(self.completed_fixture_ids)
         completed_fixture_ids.add(fixture["id"])
@@ -504,34 +538,42 @@ class UserCommands(commands.Cog):
 • `/standings` - See overall leaderboard
 • `/mypredictions` - Check your submitted predictions for open fixtures
 
-**How to Predict (Two Methods):**
+**How to Predict:**
 
-**Method 1: Thread Predictions (NEW)**
-1. Look for the fixture announcement thread (created when admin posts fixtures)
-2. Reply in the thread with your predictions:
+**Reply in the fixture thread**
+1. Open the fixture thread
+2. Reply with your predictions:
    ```
    Team A - Team B 2:0
    Team C - Team D 1:1
    ...
    ```
-3. Bot will react ✅ when saved
+3. Bot reacts ✅ when saved
+4. Late partial submissions react ⏳ and wait for admin approval
 
-**Method 2: /predict Modal**
+**Or use `/predict`**
 1. Type `/predict` in the channel
 2. If multiple fixtures are open, choose the week from the picker
 3. Enter your predictions in the modal
-4. Submit, and the bot posts them publicly in the fixture thread
+4. Submit to post them in the fixture thread
 5. Use the buttons to continue to other open fixtures
+
+**Partial predictions:**
+- You can leave some games out
+- Each partial line must name the game it applies to
+- Missing games count as no prediction
+- Late partials wait for admin approval before they count
 
 **Scoring:**
 • Exact score: 3 points
 • Correct result (win/loss/draw): 1 point
 • Wrong: 0 points
-• Late predictions: 0 points (submit before deadline!)
+• Late full predictions: 0 points
+• Late partial predictions: pending admin approval
 
 **Input formats:** Use `2:0`, `2-0`, or `2 : 0`
 
-**To change a prediction:** Use `/predict` again. The bot will post your updated prediction publicly in the fixture thread."""
+**To change a prediction:** Use `/predict` again. The bot will post an updated prediction in the fixture thread."""
 
         admin_help = """\n\n## 🔧 Admin Commands
 
@@ -551,6 +593,7 @@ class UserCommands(commands.Cog):
 - re-post the latest completed results with optional mentions
 - replace predictions
 - toggle late waivers
+- approve or reject pending late partial predictions
 - inspect overflow prediction lists when a fixture has more than 25 users
 
 **Custom Deadline Format:**
@@ -558,7 +601,7 @@ class UserCommands(commands.Cog):
 • `15.02.2024 18:00`
 • `15/02/2024 18:00`
 
-Use the commands above directly in Discord."""
+Use these directly in Discord."""
 
         await interaction.response.send_message(user_help, ephemeral=True)
 
@@ -633,13 +676,15 @@ Use the commands above directly in Discord."""
                 return
 
             lines = ["**Your Predictions:**\n"]
-            for i, (game, pred) in enumerate(
-                zip(fixture["games"], prediction["predictions"], strict=False), 1
+            for game_index, pred in zip(
+                prediction["predicted_game_indexes"], prediction["predictions"], strict=False
             ):
-                lines.append(f"{i}. {game} **{pred}**")
+                lines.append(f"{game_index + 1}. {fixture['games'][game_index]} **{pred}**")
 
             late_status = "✅ On time"
-            if prediction["is_late"]:
+            if prediction["pending_partial_approval"]:
+                late_status = "⏳ Pending admin approval"
+            elif prediction["is_late"]:
                 late_status = "⚠️ **LATE**"
                 if prediction["late_penalty_waived"]:
                     late_status += " (waiver active)"
@@ -676,13 +721,15 @@ Use the commands above directly in Discord."""
                 continue
 
             has_any_prediction = True
-            for i, (game, pred) in enumerate(
-                zip(fixture["games"], prediction["predictions"], strict=False), 1
+            for game_index, pred in zip(
+                prediction["predicted_game_indexes"], prediction["predictions"], strict=False
             ):
-                lines.append(f"{i}. {game} **{pred}**")
+                lines.append(f"{game_index + 1}. {fixture['games'][game_index]} **{pred}**")
 
             late_status = "✅ On time"
-            if prediction["is_late"]:
+            if prediction["pending_partial_approval"]:
+                late_status = "⏳ Pending admin approval"
+            elif prediction["is_late"]:
                 late_status = "⚠️ **LATE**"
                 if prediction["late_penalty_waived"]:
                     late_status += " (waiver active)"

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -55,13 +55,13 @@ def _format_thread_prediction_message(
     status: str | None = None
     if pending_partial_approval:
         admin_role_mention = get_admin_role_mention(guild)
-        status = "⏳ Late partial pending admin approval."
+        status = "⏳ Late prediction awaiting admin review."
         if admin_role_mention:
             status += f" {admin_role_mention}"
     elif is_late:
         status = "⚠️ Late prediction."
     elif len(predicted_game_indexes) < len(fixture["games"]):
-        status = "Partial prediction."
+        status = "Partial prediction. Add the missing games before the deadline if you can."
 
     if status:
         content.extend(["", status])
@@ -416,12 +416,16 @@ class PredictModal(discord.ui.Modal):
         relative_str = format_for_discord(fixture["deadline"], "R")
         content += f"\n\n**Posted publicly in the fixture thread.**\n**Deadline:** {deadline_str} ({relative_str})"
         if pending_partial_approval:
-            content += "\n\n⏳ **Pending admin approval:** your predicted games will only count if an admin approves this late partial submission."
+            content += (
+                "\n\n⏳ **Late prediction awaiting admin review:** your predicted games will only count "
+                "if an admin approves this late submission with missing games."
+            )
         elif is_late:
             content += "\n\n⚠️ **Late prediction!** You will receive 0 points for this round."
         elif is_partial:
             content += (
-                "\n\nℹ️ **Partial prediction:** any missing games will count as no prediction."
+                "\n\nℹ️ **Partial prediction saved:** any missing games will count as no prediction. "
+                "If the deadline has not passed yet, use `/predict` again to fill the rest."
             )
 
         completed_fixture_ids = set(self.completed_fixture_ids)
@@ -556,7 +560,7 @@ class UserCommands(commands.Cog):
    ...
    ```
 3. Bot reacts ✅ when saved
-4. Late partial submissions react ⏳ and wait for admin approval
+4. Late submissions with missing games react ⏳ and wait for admin review
 
 **Or use `/predict`**
 1. Type `/predict` in the channel
@@ -566,17 +570,17 @@ class UserCommands(commands.Cog):
 5. Use the buttons to continue to other open fixtures
 
 **Partial predictions:**
-- You can leave some games out
+- You can leave some games out, but before the deadline you should still try to fill the whole fixture
 - Each partial line must name the game it applies to
 - Missing games count as no prediction
-- Late partials wait for admin approval before they count
+- Late submissions with missing games wait for admin review before they count
 
 **Scoring:**
 • Exact score: 3 points
 • Correct result (win/loss/draw): 1 point
 • Wrong: 0 points
 • Late full predictions: 0 points
-• Late partial predictions: pending admin approval
+• Late predictions with missing games: pending admin review
 
 **Input formats:** Use `2:0`, `2-0`, or `2 : 0`
 
@@ -600,7 +604,7 @@ class UserCommands(commands.Cog):
 - re-post the latest completed results with optional mentions
 - replace predictions
 - toggle late waivers
-- approve or reject pending late partial predictions
+- review, approve, or reject late predictions submitted with missing games
 - inspect overflow prediction lists when a fixture has more than 25 users
 
 **Custom Deadline Format:**
@@ -690,7 +694,7 @@ Use these directly in Discord."""
 
             late_status = "✅ On time"
             if prediction["pending_partial_approval"]:
-                late_status = "⏳ Pending admin approval"
+                late_status = "⏳ Late prediction awaiting admin review"
             elif prediction["is_late"]:
                 late_status = "⚠️ **LATE**"
                 if prediction["late_penalty_waived"]:
@@ -735,7 +739,7 @@ Use these directly in Discord."""
 
             late_status = "✅ On time"
             if prediction["pending_partial_approval"]:
-                late_status = "⏳ Pending admin approval"
+                late_status = "⏳ Late prediction awaiting admin review"
             elif prediction["is_late"]:
                 late_status = "⚠️ **LATE**"
                 if prediction["late_penalty_waived"]:

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -73,7 +73,12 @@ async def _get_prediction_thread(bot: commands.Bot, fixture: dict) -> discord.Th
     if not message_id:
         return None
 
-    thread = bot.get_channel(int(message_id))
+    try:
+        thread_id = int(message_id)
+    except (TypeError, ValueError):
+        return None
+
+    thread = bot.get_channel(thread_id)
     if isinstance(thread, discord.Thread):
         return thread
 
@@ -82,10 +87,40 @@ async def _get_prediction_thread(bot: commands.Bot, fixture: dict) -> discord.Th
         return None
 
     try:
-        fetched = await fetch_channel(int(message_id))
+        fetched = await fetch_channel(thread_id)
     except discord.HTTPException:
         return None
     return fetched if isinstance(fetched, discord.Thread) else None
+
+
+async def _delete_previous_pending_bot_post(
+    thread: discord.Thread,
+    existing_prediction: dict | None,
+    *,
+    replacement_message_id: int,
+) -> None:
+    """Delete the older pending bot post so only the latest late submission stays public."""
+    if existing_prediction is None or not existing_prediction.get("pending_partial_approval"):
+        return
+
+    if existing_prediction.get("public_message_kind") != "bot_post":
+        return
+
+    previous_message_id = existing_prediction.get("public_message_id")
+    if previous_message_id is None:
+        return
+
+    try:
+        previous_message_id_int = int(previous_message_id)
+    except (TypeError, ValueError):
+        return
+
+    if previous_message_id_int == replacement_message_id:
+        return
+
+    with suppress(discord.HTTPException, AttributeError):
+        previous_message = await thread.fetch_message(previous_message_id_int)
+        await previous_message.delete()
 
 
 def _page_slice(items: list[dict], page: int, page_size: int) -> list[dict]:
@@ -412,6 +447,13 @@ class PredictModal(discord.ui.Modal):
             )
             return
 
+        if public_message is not None:
+            await _delete_previous_pending_bot_post(
+                thread,
+                existing_prediction,
+                replacement_message_id=public_message.id,
+            )
+
         preview_games = [fixture["games"][index] for index in predicted_game_indexes]
         content = format_predictions_preview(preview_games, predictions)
         deadline_str = format_for_discord(fixture["deadline"], "F")
@@ -576,6 +618,8 @@ class UserCommands(commands.Cog):
 - Each partial line must name the game it applies to
 - Missing games count as no prediction
 - Late submissions with missing games wait for admin review before they count
+- Approval counts the submitted lines normally; rejection discards that late submission
+- Public status stays visible in the fixture thread after review
 
 **Scoring:**
 • Exact score: 3 points
@@ -607,6 +651,7 @@ class UserCommands(commands.Cog):
 - replace predictions
 - toggle late waivers
 - review, approve, or reject late predictions submitted with missing games
+- `Review Late` appears when pending items exist, and approve/reject can recalculate scored fixtures
 - inspect overflow prediction lists when a fixture has more than 25 users
 
 **Custom Deadline Format:**

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -374,6 +374,11 @@ class PredictModal(discord.ui.Modal):
         if errors:
             await interaction.response.send_message("\n".join(errors), ephemeral=True)
             return
+        if not predictions:
+            await interaction.response.send_message(
+                "Please enter at least one prediction before submitting.", ephemeral=True
+            )
+            return
 
         thread = await _get_prediction_thread(self.bot, fixture)
         if thread is None:

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -14,6 +14,7 @@ from typer_bot.utils import (
     format_for_discord,
     format_predictions_preview,
     format_standings,
+    get_admin_role_mention,
     is_admin,
     now,
     parse_prediction_lines,
@@ -36,6 +37,7 @@ def _remaining_open_fixtures(
 
 def _format_thread_prediction_message(
     fixture: dict,
+    guild: discord.Guild | None,
     user_id: int,
     predictions: list[str],
     predicted_game_indexes: list[int],
@@ -52,7 +54,10 @@ def _format_thread_prediction_message(
 
     status: str | None = None
     if pending_partial_approval:
+        admin_role_mention = get_admin_role_mention(guild)
         status = "⏳ Late partial pending admin approval."
+        if admin_role_mention:
+            status += f" {admin_role_mention}"
     elif is_late:
         status = "⚠️ Late prediction."
     elif len(predicted_game_indexes) < len(fixture["games"]):
@@ -352,6 +357,7 @@ class PredictModal(discord.ui.Modal):
             public_message = await thread.send(
                 _format_thread_prediction_message(
                     fixture,
+                    interaction.guild,
                     interaction.user.id,
                     predictions,
                     predicted_game_indexes,

--- a/typer_bot/database/connection.py
+++ b/typer_bot/database/connection.py
@@ -94,6 +94,16 @@ async def _migrate_prediction_columns(db: aiosqlite.Connection) -> None:
         logger.info("Adding admin_edited_by column to predictions table")
         await db.execute("ALTER TABLE predictions ADD COLUMN admin_edited_by TEXT")
 
+    if "predicted_game_indexes" not in columns:
+        logger.info("Adding predicted_game_indexes column to predictions table")
+        await db.execute("ALTER TABLE predictions ADD COLUMN predicted_game_indexes TEXT")
+
+    if "pending_partial_approval" not in columns:
+        logger.info("Adding pending_partial_approval column to predictions table")
+        await db.execute(
+            "ALTER TABLE predictions ADD COLUMN pending_partial_approval BOOLEAN DEFAULT FALSE"
+        )
+
 
 class Database:
     """Composition root for SQLite setup and the bot's stable data facade.
@@ -151,6 +161,8 @@ class Database:
                     late_penalty_waived BOOLEAN DEFAULT FALSE,
                     admin_edited_at DATETIME,
                     admin_edited_by TEXT,
+                    predicted_game_indexes TEXT,
+                    pending_partial_approval BOOLEAN DEFAULT FALSE,
                     FOREIGN KEY (fixture_id) REFERENCES fixtures(id),
                     UNIQUE(fixture_id, user_id)
                 )
@@ -237,23 +249,69 @@ class Database:
     async def update_fixture_announcement(self, fixture_id, message_id, channel_id):
         return await self._fixtures.update_fixture_announcement(fixture_id, message_id, channel_id)
 
-    async def save_prediction(self, fixture_id, user_id, user_name, predictions, is_late=False):
+    async def save_prediction(
+        self,
+        fixture_id,
+        user_id,
+        user_name,
+        predictions,
+        is_late=False,
+        *,
+        predicted_game_indexes=None,
+        pending_partial_approval=False,
+    ):
         return await self._predictions.save_prediction(
-            fixture_id, user_id, user_name, predictions, is_late
+            fixture_id,
+            user_id,
+            user_name,
+            predictions,
+            is_late,
+            predicted_game_indexes=predicted_game_indexes,
+            pending_partial_approval=pending_partial_approval,
         )
 
-    async def try_save_prediction(self, fixture_id, user_id, user_name, predictions, is_late=False):
+    async def try_save_prediction(
+        self,
+        fixture_id,
+        user_id,
+        user_name,
+        predictions,
+        is_late=False,
+        *,
+        predicted_game_indexes=None,
+        pending_partial_approval=False,
+    ):
         """Insert once for thread submissions with atomic duplicate and open checks."""
         return await self._predictions.try_save_prediction(
-            fixture_id, user_id, user_name, predictions, is_late
+            fixture_id,
+            user_id,
+            user_name,
+            predictions,
+            is_late,
+            predicted_game_indexes=predicted_game_indexes,
+            pending_partial_approval=pending_partial_approval,
         )
 
     async def save_prediction_guarded(
-        self, fixture_id, user_id, user_name, predictions, is_late=False
+        self,
+        fixture_id,
+        user_id,
+        user_name,
+        predictions,
+        is_late=False,
+        *,
+        predicted_game_indexes=None,
+        pending_partial_approval=False,
     ):
         """Upsert a prediction only while the fixture is still open."""
         return await self._predictions.save_prediction_guarded(
-            fixture_id, user_id, user_name, predictions, is_late
+            fixture_id,
+            user_id,
+            user_name,
+            predictions,
+            is_late,
+            predicted_game_indexes=predicted_game_indexes,
+            pending_partial_approval=pending_partial_approval,
         )
 
     async def get_prediction(self, fixture_id, user_id):
@@ -281,8 +339,18 @@ class Database:
     async def delete_prediction(self, fixture_id, user_id):
         return await self._predictions.delete_prediction(fixture_id, user_id)
 
-    async def get_all_predictions(self, fixture_id):
-        return await self._predictions.get_all_predictions(fixture_id)
+    async def get_all_predictions(self, fixture_id, include_pending=False):
+        return await self._predictions.get_all_predictions(
+            fixture_id, include_pending=include_pending
+        )
+
+    async def approve_partial_prediction(self, fixture_id, user_id, admin_user_id):
+        return await self._predictions.approve_partial_prediction_with_recalc(
+            fixture_id, user_id, admin_user_id
+        )
+
+    async def reject_partial_prediction(self, fixture_id, user_id):
+        return await self._predictions.reject_partial_prediction_with_recalc(fixture_id, user_id)
 
     async def save_results(self, fixture_id, results):
         return await self._results.save_results(fixture_id, results)

--- a/typer_bot/database/connection.py
+++ b/typer_bot/database/connection.py
@@ -344,6 +344,9 @@ class Database:
             fixture_id, include_pending=include_pending
         )
 
+    async def get_pending_partial_predictions(self):
+        return await self._predictions.get_pending_partial_predictions()
+
     async def approve_partial_prediction(self, fixture_id, user_id, admin_user_id):
         return await self._predictions.approve_partial_prediction_with_recalc(
             fixture_id, user_id, admin_user_id

--- a/typer_bot/database/connection.py
+++ b/typer_bot/database/connection.py
@@ -104,6 +104,14 @@ async def _migrate_prediction_columns(db: aiosqlite.Connection) -> None:
             "ALTER TABLE predictions ADD COLUMN pending_partial_approval BOOLEAN DEFAULT FALSE"
         )
 
+    if "public_message_id" not in columns:
+        logger.info("Adding public_message_id column to predictions table")
+        await db.execute("ALTER TABLE predictions ADD COLUMN public_message_id TEXT")
+
+    if "public_message_kind" not in columns:
+        logger.info("Adding public_message_kind column to predictions table")
+        await db.execute("ALTER TABLE predictions ADD COLUMN public_message_kind TEXT")
+
 
 class Database:
     """Composition root for SQLite setup and the bot's stable data facade.
@@ -163,6 +171,8 @@ class Database:
                     admin_edited_by TEXT,
                     predicted_game_indexes TEXT,
                     pending_partial_approval BOOLEAN DEFAULT FALSE,
+                    public_message_id TEXT,
+                    public_message_kind TEXT,
                     FOREIGN KEY (fixture_id) REFERENCES fixtures(id),
                     UNIQUE(fixture_id, user_id)
                 )
@@ -259,6 +269,8 @@ class Database:
         *,
         predicted_game_indexes=None,
         pending_partial_approval=False,
+        public_message_id=None,
+        public_message_kind=None,
     ):
         return await self._predictions.save_prediction(
             fixture_id,
@@ -268,6 +280,8 @@ class Database:
             is_late,
             predicted_game_indexes=predicted_game_indexes,
             pending_partial_approval=pending_partial_approval,
+            public_message_id=public_message_id,
+            public_message_kind=public_message_kind,
         )
 
     async def try_save_prediction(
@@ -280,6 +294,8 @@ class Database:
         *,
         predicted_game_indexes=None,
         pending_partial_approval=False,
+        public_message_id=None,
+        public_message_kind=None,
     ):
         """Insert once for thread submissions with atomic duplicate and open checks."""
         return await self._predictions.try_save_prediction(
@@ -290,6 +306,8 @@ class Database:
             is_late,
             predicted_game_indexes=predicted_game_indexes,
             pending_partial_approval=pending_partial_approval,
+            public_message_id=public_message_id,
+            public_message_kind=public_message_kind,
         )
 
     async def save_prediction_guarded(
@@ -302,6 +320,8 @@ class Database:
         *,
         predicted_game_indexes=None,
         pending_partial_approval=False,
+        public_message_id=None,
+        public_message_kind=None,
     ):
         """Upsert a prediction only while the fixture is still open."""
         return await self._predictions.save_prediction_guarded(
@@ -312,6 +332,8 @@ class Database:
             is_late,
             predicted_game_indexes=predicted_game_indexes,
             pending_partial_approval=pending_partial_approval,
+            public_message_id=public_message_id,
+            public_message_kind=public_message_kind,
         )
 
     async def get_prediction(self, fixture_id, user_id):

--- a/typer_bot/database/predictions.py
+++ b/typer_bot/database/predictions.py
@@ -458,6 +458,12 @@ class PredictionRepository:
         user_id: str,
         admin_user_id: str,
     ) -> bool:
+        """Approve a pending partial prediction and recalculate if needed.
+
+        Approval clears `pending_partial_approval`, resets `is_late`, and marks
+        the row as admin-edited. If the fixture already has scores, standings are
+        recalculated in the same transaction.
+        """
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute("BEGIN IMMEDIATE")
             try:
@@ -491,6 +497,11 @@ class PredictionRepository:
         fixture_id: int,
         user_id: str,
     ) -> bool:
+        """Reject and delete a pending partial prediction.
+
+        If the fixture already has scores, standings are recalculated in the same
+        transaction after the pending row is removed.
+        """
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute("BEGIN IMMEDIATE")
             try:
@@ -514,7 +525,11 @@ class PredictionRepository:
     async def get_all_predictions(
         self, fixture_id: int, *, include_pending: bool = False
     ) -> list[dict]:
-        """Get all predictions for a fixture."""
+        """Get fixture predictions, excluding pending partials by default.
+
+        Scoring paths rely on the default behavior so pending partial approvals do
+        not count until an admin explicitly approves them.
+        """
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(

--- a/typer_bot/database/predictions.py
+++ b/typer_bot/database/predictions.py
@@ -13,6 +13,18 @@ from .scores import _fixture_has_scores_in_connection, _recalculate_scores_in_co
 logger = logging.getLogger(__name__)
 
 
+def _serialize_game_indexes(game_indexes: list[int] | None, prediction_count: int) -> str | None:
+    if game_indexes is None:
+        game_indexes = list(range(prediction_count))
+    return ",".join(str(index) for index in game_indexes)
+
+
+def _deserialize_game_indexes(raw: str | None, prediction_count: int) -> list[int]:
+    if not raw:
+        return list(range(prediction_count))
+    return [int(part) for part in raw.split(",") if part != ""]
+
+
 class SaveResult(StrEnum):
     """Result of an atomic prediction save attempt."""
 
@@ -34,22 +46,43 @@ class PredictionRepository:
         user_name: str,
         predictions: list[str],
         is_late: bool = False,
+        *,
+        predicted_game_indexes: list[int] | None = None,
+        pending_partial_approval: bool = False,
     ) -> None:
         """Save or update a user's predictions."""
         start_time = time.perf_counter()
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
-                """INSERT INTO predictions (fixture_id, user_id, user_name, predictions, is_late)
-                   VALUES (?, ?, ?, ?, ?)
+                """INSERT INTO predictions (
+                       fixture_id,
+                       user_id,
+                       user_name,
+                       predictions,
+                       is_late,
+                       predicted_game_indexes,
+                       pending_partial_approval
+                   )
+                   VALUES (?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(fixture_id, user_id)
-                    DO UPDATE SET predictions = excluded.predictions,
-                                  user_name = excluded.user_name,
-                                  is_late = excluded.is_late,
-                                  late_penalty_waived = FALSE,
-                                  admin_edited_at = NULL,
-                                  admin_edited_by = NULL,
-                                  submitted_at = CURRENT_TIMESTAMP""",
-                (fixture_id, user_id, user_name, "\n".join(predictions), is_late),
+                     DO UPDATE SET predictions = excluded.predictions,
+                                   user_name = excluded.user_name,
+                                   is_late = excluded.is_late,
+                                   predicted_game_indexes = excluded.predicted_game_indexes,
+                                   pending_partial_approval = excluded.pending_partial_approval,
+                                   late_penalty_waived = FALSE,
+                                   admin_edited_at = NULL,
+                                   admin_edited_by = NULL,
+                                   submitted_at = CURRENT_TIMESTAMP""",
+                (
+                    fixture_id,
+                    user_id,
+                    user_name,
+                    "\n".join(predictions),
+                    is_late,
+                    _serialize_game_indexes(predicted_game_indexes, len(predictions)),
+                    pending_partial_approval,
+                ),
             )
             await db.commit()
 
@@ -73,6 +106,9 @@ class PredictionRepository:
         user_name: str,
         predictions: list[str],
         is_late: bool = False,
+        *,
+        predicted_game_indexes: list[int] | None = None,
+        pending_partial_approval: bool = False,
     ) -> SaveResult:
         """Insert a prediction atomically with first-write-wins and fixture-open guards.
 
@@ -111,9 +147,25 @@ class PredictionRepository:
                         return SaveResult.DUPLICATE
 
                 await db.execute(
-                    """INSERT INTO predictions (fixture_id, user_id, user_name, predictions, is_late)
-                       VALUES (?, ?, ?, ?, ?)""",
-                    (fixture_id, user_id, user_name, "\n".join(predictions), is_late),
+                    """INSERT INTO predictions (
+                           fixture_id,
+                           user_id,
+                           user_name,
+                           predictions,
+                           is_late,
+                           predicted_game_indexes,
+                           pending_partial_approval
+                       )
+                       VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        fixture_id,
+                        user_id,
+                        user_name,
+                        "\n".join(predictions),
+                        is_late,
+                        _serialize_game_indexes(predicted_game_indexes, len(predictions)),
+                        pending_partial_approval,
+                    ),
                 )
                 await db.commit()
             except Exception:
@@ -140,6 +192,9 @@ class PredictionRepository:
         user_name: str,
         predictions: list[str],
         is_late: bool = False,
+        *,
+        predicted_game_indexes: list[int] | None = None,
+        pending_partial_approval: bool = False,
     ) -> SaveResult:
         """Upsert a prediction, but only when the fixture is still open.
 
@@ -171,17 +226,35 @@ class PredictionRepository:
                         return SaveResult.FIXTURE_CLOSED
 
                 await db.execute(
-                    """INSERT INTO predictions (fixture_id, user_id, user_name, predictions, is_late)
-                       VALUES (?, ?, ?, ?, ?)
+                    """INSERT INTO predictions (
+                           fixture_id,
+                           user_id,
+                           user_name,
+                           predictions,
+                           is_late,
+                           predicted_game_indexes,
+                           pending_partial_approval
+                       )
+                       VALUES (?, ?, ?, ?, ?, ?, ?)
                        ON CONFLICT(fixture_id, user_id)
                         DO UPDATE SET predictions = excluded.predictions,
                                       user_name = excluded.user_name,
                                       is_late = excluded.is_late,
+                                      predicted_game_indexes = excluded.predicted_game_indexes,
+                                      pending_partial_approval = excluded.pending_partial_approval,
                                       late_penalty_waived = FALSE,
                                       admin_edited_at = NULL,
                                       admin_edited_by = NULL,
                                       submitted_at = CURRENT_TIMESTAMP""",
-                    (fixture_id, user_id, user_name, "\n".join(predictions), is_late),
+                    (
+                        fixture_id,
+                        user_id,
+                        user_name,
+                        "\n".join(predictions),
+                        is_late,
+                        _serialize_game_indexes(predicted_game_indexes, len(predictions)),
+                        pending_partial_approval,
+                    ),
                 )
                 await db.commit()
             except Exception:
@@ -218,6 +291,11 @@ class PredictionRepository:
                         "submitted_at": parse_iso(row["submitted_at"]),
                         "is_late": row["is_late"],
                         "late_penalty_waived": row["late_penalty_waived"],
+                        "predicted_game_indexes": _deserialize_game_indexes(
+                            row["predicted_game_indexes"],
+                            len(row["predictions"].split("\n")),
+                        ),
+                        "pending_partial_approval": bool(row["pending_partial_approval"]),
                         "admin_edited_at": parse_iso(row["admin_edited_at"])
                         if row["admin_edited_at"]
                         else None,
@@ -262,11 +340,19 @@ class PredictionRepository:
                     """
                     UPDATE predictions
                     SET predictions = ?,
+                        predicted_game_indexes = ?,
+                        pending_partial_approval = FALSE,
                         admin_edited_at = CURRENT_TIMESTAMP,
                         admin_edited_by = ?
                     WHERE fixture_id = ? AND user_id = ?
                     """,
-                    ("\n".join(predictions), admin_user_id, fixture_id, user_id),
+                    (
+                        "\n".join(predictions),
+                        _serialize_game_indexes(None, len(predictions)),
+                        admin_user_id,
+                        fixture_id,
+                        user_id,
+                    ),
                 )
                 if cursor.rowcount <= 0:
                     await db.rollback()
@@ -352,12 +438,92 @@ class PredictionRepository:
             await db.commit()
             return cursor.rowcount > 0
 
-    async def get_all_predictions(self, fixture_id: int) -> list[dict]:
+    async def set_partial_approval_pending(
+        self,
+        fixture_id: int,
+        user_id: str,
+        pending: bool,
+    ) -> bool:
+        async with aiosqlite.connect(self.db_path) as db:
+            cursor = await db.execute(
+                "UPDATE predictions SET pending_partial_approval = ?, is_late = ? WHERE fixture_id = ? AND user_id = ?",
+                (pending, pending, fixture_id, user_id),
+            )
+            await db.commit()
+            return cursor.rowcount > 0
+
+    async def approve_partial_prediction_with_recalc(
+        self,
+        fixture_id: int,
+        user_id: str,
+        admin_user_id: str,
+    ) -> bool:
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = await db.execute(
+                    """
+                    UPDATE predictions
+                    SET pending_partial_approval = FALSE,
+                        is_late = FALSE,
+                        late_penalty_waived = FALSE,
+                        admin_edited_at = CURRENT_TIMESTAMP,
+                        admin_edited_by = ?
+                    WHERE fixture_id = ? AND user_id = ? AND pending_partial_approval = TRUE
+                    """,
+                    (admin_user_id, fixture_id, user_id),
+                )
+                if cursor.rowcount <= 0:
+                    await db.rollback()
+                    return False
+
+                if await _fixture_has_scores_in_connection(db, fixture_id):
+                    await _recalculate_scores_in_connection(db, fixture_id)
+
+                await db.commit()
+                return True
+            except Exception:
+                await db.rollback()
+                raise
+
+    async def reject_partial_prediction_with_recalc(
+        self,
+        fixture_id: int,
+        user_id: str,
+    ) -> bool:
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = await db.execute(
+                    "DELETE FROM predictions WHERE fixture_id = ? AND user_id = ? AND pending_partial_approval = TRUE",
+                    (fixture_id, user_id),
+                )
+                if cursor.rowcount <= 0:
+                    await db.rollback()
+                    return False
+
+                if await _fixture_has_scores_in_connection(db, fixture_id):
+                    await _recalculate_scores_in_connection(db, fixture_id)
+
+                await db.commit()
+                return True
+            except Exception:
+                await db.rollback()
+                raise
+
+    async def get_all_predictions(
+        self, fixture_id: int, *, include_pending: bool = False
+    ) -> list[dict]:
         """Get all predictions for a fixture."""
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
-                "SELECT * FROM predictions WHERE fixture_id = ?", (fixture_id,)
+                (
+                    "SELECT * FROM predictions WHERE fixture_id = ?"
+                    if include_pending
+                    else "SELECT * FROM predictions WHERE fixture_id = ? AND pending_partial_approval = FALSE"
+                ),
+                (fixture_id,),
             ) as cursor:
                 rows = await cursor.fetchall()
                 return [
@@ -365,9 +531,14 @@ class PredictionRepository:
                         "user_id": row["user_id"],
                         "user_name": row["user_name"],
                         "predictions": row["predictions"].split("\n"),
+                        "predicted_game_indexes": _deserialize_game_indexes(
+                            row["predicted_game_indexes"],
+                            len(row["predictions"].split("\n")),
+                        ),
                         "submitted_at": parse_iso(row["submitted_at"]),
                         "is_late": row["is_late"],
                         "late_penalty_waived": row["late_penalty_waived"],
+                        "pending_partial_approval": bool(row["pending_partial_approval"]),
                         "admin_edited_at": parse_iso(row["admin_edited_at"])
                         if row["admin_edited_at"]
                         else None,

--- a/typer_bot/database/predictions.py
+++ b/typer_bot/database/predictions.py
@@ -39,6 +39,29 @@ class PredictionRepository:
     def __init__(self, db_path: str) -> None:
         self.db_path = db_path
 
+    @staticmethod
+    def _prediction_row_to_dict(row: aiosqlite.Row) -> dict:
+        prediction_values = row["predictions"].split("\n")
+        return {
+            "user_id": row["user_id"],
+            "user_name": row["user_name"],
+            "predictions": prediction_values,
+            "submitted_at": parse_iso(row["submitted_at"]),
+            "is_late": row["is_late"],
+            "late_penalty_waived": row["late_penalty_waived"],
+            "predicted_game_indexes": _deserialize_game_indexes(
+                row["predicted_game_indexes"],
+                len(prediction_values),
+            ),
+            "pending_partial_approval": bool(row["pending_partial_approval"]),
+            "admin_edited_at": parse_iso(row["admin_edited_at"])
+            if row["admin_edited_at"]
+            else None,
+            "admin_edited_by": row["admin_edited_by"],
+            "public_message_id": row["public_message_id"],
+            "public_message_kind": row["public_message_kind"],
+        }
+
     async def save_prediction(
         self,
         fixture_id: int,
@@ -49,6 +72,8 @@ class PredictionRepository:
         *,
         predicted_game_indexes: list[int] | None = None,
         pending_partial_approval: bool = False,
+        public_message_id: str | None = None,
+        public_message_kind: str | None = None,
     ) -> None:
         """Save or update a user's predictions."""
         start_time = time.perf_counter()
@@ -61,18 +86,22 @@ class PredictionRepository:
                        predictions,
                        is_late,
                        predicted_game_indexes,
-                       pending_partial_approval
+                       pending_partial_approval,
+                       public_message_id,
+                       public_message_kind
                    )
-                   VALUES (?, ?, ?, ?, ?, ?, ?)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(fixture_id, user_id)
                      DO UPDATE SET predictions = excluded.predictions,
-                                   user_name = excluded.user_name,
-                                   is_late = excluded.is_late,
-                                   predicted_game_indexes = excluded.predicted_game_indexes,
-                                   pending_partial_approval = excluded.pending_partial_approval,
-                                   late_penalty_waived = FALSE,
-                                   admin_edited_at = NULL,
-                                   admin_edited_by = NULL,
+                                    user_name = excluded.user_name,
+                                    is_late = excluded.is_late,
+                                    predicted_game_indexes = excluded.predicted_game_indexes,
+                                    pending_partial_approval = excluded.pending_partial_approval,
+                                    public_message_id = excluded.public_message_id,
+                                    public_message_kind = excluded.public_message_kind,
+                                    late_penalty_waived = FALSE,
+                                    admin_edited_at = NULL,
+                                    admin_edited_by = NULL,
                                    submitted_at = CURRENT_TIMESTAMP""",
                 (
                     fixture_id,
@@ -82,6 +111,8 @@ class PredictionRepository:
                     is_late,
                     _serialize_game_indexes(predicted_game_indexes, len(predictions)),
                     pending_partial_approval,
+                    public_message_id,
+                    public_message_kind,
                 ),
             )
             await db.commit()
@@ -109,6 +140,8 @@ class PredictionRepository:
         *,
         predicted_game_indexes: list[int] | None = None,
         pending_partial_approval: bool = False,
+        public_message_id: str | None = None,
+        public_message_kind: str | None = None,
     ) -> SaveResult:
         """Insert a prediction atomically with first-write-wins and fixture-open guards.
 
@@ -154,9 +187,11 @@ class PredictionRepository:
                            predictions,
                            is_late,
                            predicted_game_indexes,
-                           pending_partial_approval
+                           pending_partial_approval,
+                           public_message_id,
+                           public_message_kind
                        )
-                       VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         fixture_id,
                         user_id,
@@ -165,6 +200,8 @@ class PredictionRepository:
                         is_late,
                         _serialize_game_indexes(predicted_game_indexes, len(predictions)),
                         pending_partial_approval,
+                        public_message_id,
+                        public_message_kind,
                     ),
                 )
                 await db.commit()
@@ -195,6 +232,8 @@ class PredictionRepository:
         *,
         predicted_game_indexes: list[int] | None = None,
         pending_partial_approval: bool = False,
+        public_message_id: str | None = None,
+        public_message_kind: str | None = None,
     ) -> SaveResult:
         """Upsert a prediction, but only when the fixture is still open.
 
@@ -233,15 +272,19 @@ class PredictionRepository:
                            predictions,
                            is_late,
                            predicted_game_indexes,
-                           pending_partial_approval
+                           pending_partial_approval,
+                           public_message_id,
+                           public_message_kind
                        )
-                       VALUES (?, ?, ?, ?, ?, ?, ?)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                        ON CONFLICT(fixture_id, user_id)
                         DO UPDATE SET predictions = excluded.predictions,
                                       user_name = excluded.user_name,
                                       is_late = excluded.is_late,
                                       predicted_game_indexes = excluded.predicted_game_indexes,
                                       pending_partial_approval = excluded.pending_partial_approval,
+                                      public_message_id = excluded.public_message_id,
+                                      public_message_kind = excluded.public_message_kind,
                                       late_penalty_waived = FALSE,
                                       admin_edited_at = NULL,
                                       admin_edited_by = NULL,
@@ -254,6 +297,8 @@ class PredictionRepository:
                         is_late,
                         _serialize_game_indexes(predicted_game_indexes, len(predictions)),
                         pending_partial_approval,
+                        public_message_id,
+                        public_message_kind,
                     ),
                 )
                 await db.commit()
@@ -284,23 +329,7 @@ class PredictionRepository:
             ) as cursor:
                 row = await cursor.fetchone()
                 if row:
-                    return {
-                        "user_id": row["user_id"],
-                        "user_name": row["user_name"],
-                        "predictions": row["predictions"].split("\n"),
-                        "submitted_at": parse_iso(row["submitted_at"]),
-                        "is_late": row["is_late"],
-                        "late_penalty_waived": row["late_penalty_waived"],
-                        "predicted_game_indexes": _deserialize_game_indexes(
-                            row["predicted_game_indexes"],
-                            len(row["predictions"].split("\n")),
-                        ),
-                        "pending_partial_approval": bool(row["pending_partial_approval"]),
-                        "admin_edited_at": parse_iso(row["admin_edited_at"])
-                        if row["admin_edited_at"]
-                        else None,
-                        "admin_edited_by": row["admin_edited_by"],
-                    }
+                    return self._prediction_row_to_dict(row)
                 return None
 
     async def admin_update_prediction(
@@ -541,26 +570,7 @@ class PredictionRepository:
                 (fixture_id,),
             ) as cursor:
                 rows = await cursor.fetchall()
-                return [
-                    {
-                        "user_id": row["user_id"],
-                        "user_name": row["user_name"],
-                        "predictions": row["predictions"].split("\n"),
-                        "predicted_game_indexes": _deserialize_game_indexes(
-                            row["predicted_game_indexes"],
-                            len(row["predictions"].split("\n")),
-                        ),
-                        "submitted_at": parse_iso(row["submitted_at"]),
-                        "is_late": row["is_late"],
-                        "late_penalty_waived": row["late_penalty_waived"],
-                        "pending_partial_approval": bool(row["pending_partial_approval"]),
-                        "admin_edited_at": parse_iso(row["admin_edited_at"])
-                        if row["admin_edited_at"]
-                        else None,
-                        "admin_edited_by": row["admin_edited_by"],
-                    }
-                    for row in rows
-                ]
+                return [self._prediction_row_to_dict(row) for row in rows]
 
     async def get_pending_partial_predictions(self) -> list[dict]:
         """List all pending partial predictions with fixture metadata."""
@@ -577,6 +587,8 @@ class PredictionRepository:
                     p.is_late,
                     p.late_penalty_waived,
                     p.pending_partial_approval,
+                    p.public_message_id,
+                    p.public_message_kind,
                     f.week_number,
                     f.games,
                     f.status
@@ -600,6 +612,8 @@ class PredictionRepository:
                         "is_late": row["is_late"],
                         "late_penalty_waived": row["late_penalty_waived"],
                         "pending_partial_approval": bool(row["pending_partial_approval"]),
+                        "public_message_id": row["public_message_id"],
+                        "public_message_kind": row["public_message_kind"],
                         "week_number": row["week_number"],
                         "games": row["games"].split("\n"),
                         "status": row["status"],

--- a/typer_bot/database/predictions.py
+++ b/typer_bot/database/predictions.py
@@ -561,3 +561,48 @@ class PredictionRepository:
                     }
                     for row in rows
                 ]
+
+    async def get_pending_partial_predictions(self) -> list[dict]:
+        """List all pending partial predictions with fixture metadata."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                """
+                SELECT
+                    p.fixture_id,
+                    p.user_id,
+                    p.user_name,
+                    p.predictions,
+                    p.predicted_game_indexes,
+                    p.is_late,
+                    p.late_penalty_waived,
+                    p.pending_partial_approval,
+                    f.week_number,
+                    f.games,
+                    f.status
+                FROM predictions p
+                JOIN fixtures f ON f.id = p.fixture_id
+                WHERE p.pending_partial_approval = TRUE
+                ORDER BY f.week_number ASC, p.user_name COLLATE NOCASE ASC
+                """
+            ) as cursor:
+                rows = await cursor.fetchall()
+                return [
+                    {
+                        "fixture_id": row["fixture_id"],
+                        "user_id": row["user_id"],
+                        "user_name": row["user_name"],
+                        "predictions": row["predictions"].split("\n"),
+                        "predicted_game_indexes": _deserialize_game_indexes(
+                            row["predicted_game_indexes"],
+                            len(row["predictions"].split("\n")),
+                        ),
+                        "is_late": row["is_late"],
+                        "late_penalty_waived": row["late_penalty_waived"],
+                        "pending_partial_approval": bool(row["pending_partial_approval"]),
+                        "week_number": row["week_number"],
+                        "games": row["games"].split("\n"),
+                        "status": row["status"],
+                    }
+                    for row in rows
+                ]

--- a/typer_bot/database/scores.py
+++ b/typer_bot/database/scores.py
@@ -4,7 +4,7 @@ import logging
 
 import aiosqlite
 
-from typer_bot.utils import calculate_points
+from typer_bot.utils import align_predictions_to_fixture, calculate_points
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,8 @@ async def _recalculate_scores_in_connection(db: aiosqlite.Connection, fixture_id
             raise ValueError("No results entered for this fixture")
 
         async with db.execute(
-            "SELECT * FROM predictions WHERE fixture_id = ?", (fixture_id,)
+            "SELECT * FROM predictions WHERE fixture_id = ? AND pending_partial_approval = FALSE",
+            (fixture_id,),
         ) as cursor:
             prediction_rows = await cursor.fetchall()
         if not prediction_rows:
@@ -43,8 +44,20 @@ async def _recalculate_scores_in_connection(db: aiosqlite.Connection, fixture_id
         results = results_row["results"].split("\n")
         scores = []
         for prediction_row in prediction_rows:
+            raw_predictions = prediction_row["predictions"].split("\n")
+            raw_indexes = prediction_row["predicted_game_indexes"]
+            predicted_game_indexes = (
+                [int(part) for part in raw_indexes.split(",") if part != ""]
+                if raw_indexes
+                else list(range(len(raw_predictions)))
+            )
+            aligned_predictions = align_predictions_to_fixture(
+                raw_predictions,
+                predicted_game_indexes,
+                len(results),
+            )
             score_data = calculate_points(
-                prediction_row["predictions"].split("\n"),
+                aligned_predictions,
                 results,
                 bool(prediction_row["is_late"]),
                 bool(prediction_row["late_penalty_waived"]),

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -1,13 +1,14 @@
 """Handler for thread-based predictions."""
 
 import logging
+import re
 from contextlib import suppress
 from datetime import datetime, timedelta
 
 import discord
 
 from typer_bot.database import Database, SaveResult
-from typer_bot.utils import now, parse_line_predictions
+from typer_bot.utils import now, parse_prediction_lines
 from typer_bot.utils.logger import LogContextManager, log_event
 
 logger = logging.getLogger(__name__)
@@ -109,12 +110,20 @@ class ThreadPredictionHandler:
                 )
                 return True
 
-            predictions, errors = parse_line_predictions(message.content, fixture["games"])
-
-            # Threads also contain chatter; only treat messages with score lines as submissions.
-            if len(predictions) == 0:
-                logger.debug(f"Ignoring message with no valid scores from {message.author.id}")
+            if not any(
+                re.search(r"\d+\s*[-:]\s*\d+\s*$", line.strip())
+                for line in message.content.splitlines()
+            ):
+                logger.debug(
+                    f"Ignoring message with no score-like content from {message.author.id}"
+                )
                 return False
+
+            predictions, predicted_game_indexes, errors = parse_prediction_lines(
+                message.content,
+                fixture["games"],
+                allow_partial=True,
+            )
 
             if errors:
                 error_msg = "\n".join(errors)
@@ -137,8 +146,15 @@ class ThreadPredictionHandler:
                 )
                 return True
 
+            # Threads also contain chatter; only treat messages with score lines as submissions.
+            if len(predictions) == 0:
+                logger.debug(f"Ignoring message with no valid scores from {message.author.id}")
+                return False
+
             current_time = now()
             is_late = current_time > fixture["deadline"]
+            is_partial = len(predicted_game_indexes) < len(fixture["games"])
+            pending_partial_approval = is_late and is_partial
 
         try:
             result = await self.db.try_save_prediction(
@@ -147,6 +163,8 @@ class ThreadPredictionHandler:
                 message.author.display_name,
                 predictions,
                 is_late,
+                predicted_game_indexes=predicted_game_indexes,
+                pending_partial_approval=pending_partial_approval,
             )
 
             if result == SaveResult.FIXTURE_CLOSED:
@@ -184,7 +202,7 @@ class ThreadPredictionHandler:
                 return True
 
             try:
-                await message.add_reaction("✅")
+                await message.add_reaction("⏳" if pending_partial_approval else "✅")
             except discord.Forbidden:
                 logger.warning(
                     f"Could not add reaction to thread prediction from {message.author.id}. "
@@ -212,9 +230,22 @@ class ThreadPredictionHandler:
 
             if is_late:
                 with suppress(discord.Forbidden):
+                    if pending_partial_approval:
+                        await message.author.send(
+                            "⏳ **Late partial prediction received.** It was saved and is now awaiting admin approval."
+                        )
+                        await message.channel.send(
+                            f"⏳ Partial prediction from <@{message.author.id}> is awaiting admin approval."
+                        )
+                    else:
+                        await message.author.send(
+                            "⚠️ **Late prediction!** Your prediction was saved but you will receive "
+                            "0 points for this round since the deadline has passed."
+                        )
+            elif is_partial:
+                with suppress(discord.Forbidden):
                     await message.author.send(
-                        "⚠️ **Late prediction!** Your prediction was saved but you will receive "
-                        "0 points for this round since the deadline has passed."
+                        "ℹ️ **Partial prediction saved.** Any missing games will count as no prediction."
                     )
 
             return True

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 import discord
 
 from typer_bot.database import Database, SaveResult
-from typer_bot.utils import now, parse_prediction_lines
+from typer_bot.utils import get_admin_role_mention, now, parse_prediction_lines
 from typer_bot.utils.logger import LogContextManager, log_event
 
 logger = logging.getLogger(__name__)
@@ -231,11 +231,14 @@ class ThreadPredictionHandler:
             if is_late:
                 with suppress(discord.Forbidden):
                     if pending_partial_approval:
+                        admin_role_mention = get_admin_role_mention(message.guild)
                         await message.author.send(
                             "⏳ **Late partial prediction received.** It was saved and is now awaiting admin approval."
                         )
                         await message.channel.send(
-                            f"⏳ Partial prediction from <@{message.author.id}> is awaiting admin approval."
+                            f"⏳ Partial prediction from <@{message.author.id}> is awaiting admin approval. {admin_role_mention}"
+                            if admin_role_mention
+                            else f"⏳ Partial prediction from <@{message.author.id}> is awaiting admin approval."
                         )
                     else:
                         await message.author.send(

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -233,12 +233,12 @@ class ThreadPredictionHandler:
                     if pending_partial_approval:
                         admin_role_mention = get_admin_role_mention(message.guild)
                         await message.author.send(
-                            "⏳ **Late partial prediction received.** It was saved and is now awaiting admin approval."
+                            "⏳ **Late prediction received.** It was saved and is now awaiting admin review because it arrived late with missing games."
                         )
                         await message.channel.send(
-                            f"⏳ Partial prediction from <@{message.author.id}> is awaiting admin approval. {admin_role_mention}"
+                            f"⏳ Late prediction from <@{message.author.id}> with missing games is awaiting admin review. {admin_role_mention}"
                             if admin_role_mention
-                            else f"⏳ Partial prediction from <@{message.author.id}> is awaiting admin approval."
+                            else f"⏳ Late prediction from <@{message.author.id}> with missing games is awaiting admin review."
                         )
                     else:
                         await message.author.send(
@@ -248,7 +248,7 @@ class ThreadPredictionHandler:
             elif is_partial:
                 with suppress(discord.Forbidden):
                     await message.author.send(
-                        "ℹ️ **Partial prediction saved.** Any missing games will count as no prediction."
+                        "ℹ️ **Partial prediction saved.** Any missing games will count as no prediction. If the deadline has not passed yet, use `/predict` again to fill the rest."
                     )
 
             return True

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -165,6 +165,8 @@ class ThreadPredictionHandler:
                 is_late,
                 predicted_game_indexes=predicted_game_indexes,
                 pending_partial_approval=pending_partial_approval,
+                public_message_id=str(message.id) if pending_partial_approval else None,
+                public_message_kind="thread_message" if pending_partial_approval else None,
             )
 
             if result == SaveResult.FIXTURE_CLOSED:

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -111,7 +111,7 @@ class ThreadPredictionHandler:
                 return True
 
             if not any(
-                re.search(r"\d+\s*[-:]\s*\d+\s*$", line.strip())
+                re.search(r"(\d+\s*[-:]\s*\d+|[xX])\s*$", line.strip())
                 for line in message.content.splitlines()
             ):
                 logger.debug(

--- a/typer_bot/services/admin_service.py
+++ b/typer_bot/services/admin_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from typer_bot.database import Database
-from typer_bot.utils import calculate_points, parse_line_predictions
+from typer_bot.utils import align_predictions_to_fixture, calculate_points, parse_line_predictions
 
 
 @dataclass(slots=True)
@@ -67,8 +67,13 @@ class AdminService:
 
         scores = []
         for prediction in predictions:
-            score_data = calculate_points(
+            aligned_predictions = align_predictions_to_fixture(
                 prediction["predictions"],
+                prediction["predicted_game_indexes"],
+                len(results),
+            )
+            score_data = calculate_points(
+                aligned_predictions,
                 results,
                 prediction["is_late"],
                 prediction["late_penalty_waived"],
@@ -107,12 +112,61 @@ class AdminService:
         if fixture is None:
             raise ValueError("Fixture not found")
 
-        predictions = await self.db.get_all_predictions(fixture_id)
+        predictions = await self.db.get_all_predictions(fixture_id, include_pending=True)
         if not predictions:
             raise ValueError("No predictions saved for this fixture")
 
         predictions.sort(key=lambda prediction: prediction["user_name"].lower())
         return fixture, predictions
+
+    async def approve_partial_prediction(
+        self,
+        fixture_id: int,
+        user_id: str,
+        admin_user_id: str,
+    ) -> tuple[dict, dict, FixtureScoreResult | None]:
+        fixture = await self.db.get_fixture_by_id(fixture_id)
+        if fixture is None:
+            raise ValueError("Fixture not found")
+
+        prediction = await self.db.get_prediction(fixture_id, user_id)
+        if prediction is None or not prediction["pending_partial_approval"]:
+            raise ValueError("No pending partial prediction for that user")
+
+        approved = await self.db.approve_partial_prediction(fixture_id, user_id, admin_user_id)
+        if not approved:
+            raise ValueError("Partial approval failed")
+
+        refreshed_prediction = await self.db.get_prediction(fixture_id, user_id)
+        if refreshed_prediction is None:
+            raise ValueError("Prediction disappeared after approval")
+
+        recalculation = None
+        if await self.db.fixture_has_scores(fixture_id):
+            recalculation = await self._build_score_result(fixture_id)
+        return fixture, refreshed_prediction, recalculation
+
+    async def reject_partial_prediction(
+        self,
+        fixture_id: int,
+        user_id: str,
+    ) -> tuple[dict, dict, FixtureScoreResult | None]:
+        fixture = await self.db.get_fixture_by_id(fixture_id)
+        if fixture is None:
+            raise ValueError("Fixture not found")
+
+        prediction = await self.db.get_prediction(fixture_id, user_id)
+        if prediction is None or not prediction["pending_partial_approval"]:
+            raise ValueError("No pending partial prediction for that user")
+
+        rejected = await self.db.reject_partial_prediction(fixture_id, user_id)
+        if not rejected:
+            raise ValueError("Partial rejection failed")
+
+        recalculation = None
+        if await self.db.fixture_has_scores(fixture_id):
+            recalculation = await self._build_score_result(fixture_id)
+        return fixture, prediction, recalculation
 
     async def replace_prediction(
         self,

--- a/typer_bot/services/admin_service.py
+++ b/typer_bot/services/admin_service.py
@@ -131,7 +131,7 @@ class AdminService:
 
         prediction = await self.db.get_prediction(fixture_id, user_id)
         if prediction is None or not prediction["pending_partial_approval"]:
-            raise ValueError("No pending partial prediction for that user")
+            raise ValueError("No late prediction awaiting review for that user")
 
         approved = await self.db.approve_partial_prediction(fixture_id, user_id, admin_user_id)
         if not approved:
@@ -157,7 +157,7 @@ class AdminService:
 
         prediction = await self.db.get_prediction(fixture_id, user_id)
         if prediction is None or not prediction["pending_partial_approval"]:
-            raise ValueError("No pending partial prediction for that user")
+            raise ValueError("No late prediction awaiting review for that user")
 
         rejected = await self.db.reject_partial_prediction(fixture_id, user_id)
         if not rejected:

--- a/typer_bot/utils/__init__.py
+++ b/typer_bot/utils/__init__.py
@@ -7,9 +7,10 @@ from .prediction_parser import (
     format_predictions_preview,
     format_standings,
     parse_line_predictions,
+    parse_prediction_lines,
     parse_predictions,
 )
-from .scoring import calculate_points
+from .scoring import align_predictions_to_fixture, calculate_points
 from .timezone import APP_TZ, format_for_discord, now, parse_deadline, parse_iso
 
 __all__ = [
@@ -17,10 +18,12 @@ __all__ = [
     "is_admin",
     "is_admin_member",
     "parse_predictions",
+    "parse_prediction_lines",
     "parse_line_predictions",
     "format_fixture_results",
     "format_predictions_preview",
     "format_standings",
+    "align_predictions_to_fixture",
     "calculate_points",
     "now",
     "parse_deadline",

--- a/typer_bot/utils/__init__.py
+++ b/typer_bot/utils/__init__.py
@@ -1,6 +1,6 @@
 """Utility functions and helpers."""
 
-from .permissions import is_admin, is_admin_member
+from .permissions import get_admin_role_mention, is_admin, is_admin_member
 from .prediction_parser import (
     ascii_username,
     format_fixture_results,
@@ -15,6 +15,7 @@ from .timezone import APP_TZ, format_for_discord, now, parse_deadline, parse_iso
 
 __all__ = [
     "ascii_username",
+    "get_admin_role_mention",
     "is_admin",
     "is_admin_member",
     "parse_predictions",

--- a/typer_bot/utils/permissions.py
+++ b/typer_bot/utils/permissions.py
@@ -28,3 +28,17 @@ def is_admin(interaction: discord.Interaction) -> bool:
 def is_admin_member(member: discord.Member | None) -> bool:
     """Check if a guild member currently has an admin role."""
     return _has_admin_role(member) if member else False
+
+
+def get_admin_role_mention(guild: discord.Guild | None) -> str | None:
+    """Return the preferred admin role mention for a guild, if available."""
+    if guild is None or not hasattr(guild, "roles"):
+        return None
+
+    preferred_names = ["typer-admin", "admin"]
+    lowered = {name: name.lower() for name in preferred_names}
+    for preferred_name in preferred_names:
+        for role in guild.roles:
+            if role.name.lower() == lowered[preferred_name]:
+                return f"<@&{role.id}>"
+    return None

--- a/typer_bot/utils/prediction_parser.py
+++ b/typer_bot/utils/prediction_parser.py
@@ -6,6 +6,87 @@ import re
 logger = logging.getLogger(__name__)
 
 
+def _strip_line_prefix(line: str) -> str:
+    return re.sub(r"^\s*\d+\.\s*", "", line).strip()
+
+
+def parse_prediction_lines(
+    input_text: str,
+    games: list[str],
+    *,
+    allow_partial: bool = False,
+) -> tuple[list[str], list[int], list[str]]:
+    """Parse prediction lines and map them to specific fixture rows.
+
+    Each non-empty line must end with a score like ``2:0`` or ``2-1``. When the
+    fixture label at the start of the line matches one of the provided games, the
+    prediction is mapped to that exact game row. Full submissions can still fall
+    back to positional matching for backward compatibility.
+    """
+    normalized = input_text.replace(",", "\n")
+    lines = [line.strip() for line in normalized.split("\n") if line.strip()]
+
+    predictions: list[str] = []
+    game_indexes: list[int] = []
+    errors: list[str] = []
+
+    for line_number, raw_line in enumerate(lines, 1):
+        stripped = _strip_line_prefix(raw_line)
+        is_cancelled = bool(re.search(r"[xX]\s*$", stripped))
+        cancelled_match = re.search(r"[xX]\s*$", stripped)
+        match = re.search(r"(\d+)\s*[-:]\s*(\d+)\s*$", stripped)
+        if not match and not is_cancelled:
+            errors.append(
+                f"Line {line_number}: Could not find score (expected format: '2:0' or '2-1')"
+            )
+            continue
+
+        if is_cancelled:
+            score = "x"
+            game_text = stripped[: cancelled_match.start()].strip() if cancelled_match else ""
+        else:
+            assert match is not None
+            home_score = match.group(1)
+            away_score = match.group(2)
+            score = f"{home_score}-{away_score}"
+            game_text = stripped[: match.start()].strip()
+
+        game_index: int | None = None
+        if game_text:
+            for index, game in enumerate(games):
+                if game_text == game:
+                    game_index = index
+                    break
+
+        if game_index is None:
+            if len(lines) == len(games):
+                game_index = line_number - 1
+            else:
+                errors.append(
+                    f"Line {line_number}: Could not match that line to a fixture row. Include the fixture name, e.g. '{games[0]} 2:0'."
+                )
+                continue
+
+        if game_index in game_indexes:
+            errors.append(f"Line {line_number}: That fixture row was entered more than once.")
+            continue
+
+        predictions.append(score)
+        game_indexes.append(game_index)
+
+    if errors:
+        return [], [], errors
+
+    ordered = sorted(zip(game_indexes, predictions, strict=True), key=lambda item: item[0])
+    ordered_indexes = [index for index, _ in ordered]
+    ordered_predictions = [prediction for _, prediction in ordered]
+
+    if not allow_partial and len(ordered_predictions) != len(games):
+        return [], [], [f"Expected {len(games)} predictions, found {len(ordered_predictions)}"]
+
+    return ordered_predictions, ordered_indexes, []
+
+
 def parse_predictions(input_text: str, expected_count: int = 9) -> tuple[list[str], list[str]]:
     """Parse predictions from user input.
 

--- a/typer_bot/utils/prediction_parser.py
+++ b/typer_bot/utils/prediction_parser.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 def _strip_line_prefix(line: str) -> str:
-    return re.sub(r"^\s*\d+\.\s*", "", line).strip()
+    return line.strip()
 
 
 def parse_prediction_lines(

--- a/typer_bot/utils/scoring.py
+++ b/typer_bot/utils/scoring.py
@@ -1,9 +1,24 @@
 """Scoring calculation utilities."""
 
+from collections.abc import Sequence
+
+
+def align_predictions_to_fixture(
+    predictions: list[str],
+    predicted_game_indexes: list[int],
+    fixture_length: int,
+) -> list[str | None]:
+    """Expand sparse predictions to fixture length with missing rows as ``None``."""
+    aligned: list[str | None] = [None] * fixture_length
+    for game_index, prediction in zip(predicted_game_indexes, predictions, strict=False):
+        if 0 <= game_index < fixture_length:
+            aligned[game_index] = prediction
+    return aligned
+
 
 def calculate_points(
-    predictions: list[str],
-    actual_results: list[str],
+    predictions: Sequence[str | None],
+    actual_results: Sequence[str],
     is_late: bool = False,
     late_penalty_waived: bool = False,
 ) -> dict:


### PR DESCRIPTION
## Summary
- allow sparse predictions with explicit game-row mapping so users can submit only some fixture rows
- treat late submissions with missing games as pending admin review in both `/predict` and thread workflows, while pre-deadline partials still save normally with a nudge to complete the fixture
- add unified-panel review/approve/reject actions, keep pending late submissions out of scoring until reviewed, and keep the public thread status in sync after approval or rejection

Closes #160

## Notes
- Sparse predictions are stored with `predicted_game_indexes` so omitted middle games work cleanly.
- Missing games count as no prediction when a submission is approved or saved before the deadline.
- Late submissions with missing games do not score until an admin reviews them.
- Public status remains visible in the fixture thread: `/predict` posts are edited after review, and thread replies switch from `⏳` to `✅` or `❌`.

## Testing
- `uv run pytest --tb=short`
- `uv run ruff check typer_bot/commands/user_commands.py typer_bot/handlers/thread_prediction_handler.py typer_bot/commands/admin_panel typer_bot/database typer_bot/services typer_bot/utils tests/test_prediction_parser.py tests/test_user_commands.py tests/test_thread_prediction_handler.py tests/test_admin_panel.py tests/test_admin_service.py tests/test_scoring.py`
- `uv run ty check typer_bot`