### PR TITLE
perf: stop scanning every text channel during startup fixture verification

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -230,6 +230,125 @@ class TestPermissionCheck:
             mock_logger.info.assert_not_called()
 
 
+class TestFixtureAnnouncementSync:
+    @pytest.fixture
+    def bot_instance(self):
+        with (
+            patch("typer_bot.bot.commands.Bot.__init__", return_value=None),
+            patch.object(TyperBot, "guilds", []),
+        ):
+            bot = TyperBot.__new__(TyperBot)
+            bot.db = MagicMock()
+            bot.get_channel = MagicMock()
+            bot.fetch_channel = AsyncMock()
+            yield bot
+
+    @pytest.mark.asyncio
+    async def test_sync_fixture_thread_uses_stored_channel_id(self, bot_instance):
+        fixture = {"id": 1, "message_id": "789012", "channel_id": "123456"}
+        message = MagicMock()
+        message.thread = MagicMock(id=789012)
+        channel = MagicMock()
+        channel.fetch_message = AsyncMock(return_value=message)
+        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        bot_instance.get_channel.return_value = channel
+
+        await bot_instance._sync_fixture_thread()
+
+        bot_instance.get_channel.assert_called_once_with(123456)
+        channel.fetch_message.assert_awaited_once_with(789012)
+        bot_instance.fetch_channel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sync_fixture_thread_scans_guild_channels_only_without_channel_id(
+        self, bot_instance
+    ):
+        fixture = {"id": 1, "message_id": "789012", "channel_id": None}
+        message = MagicMock()
+        message.thread = MagicMock(id=789012)
+        miss_channel = MagicMock()
+        miss_channel.id = 100
+        miss_channel.fetch_message = AsyncMock(side_effect=discord.NotFound(MagicMock(), "missing"))
+        hit_channel = MagicMock()
+        hit_channel.id = 200
+        hit_channel.fetch_message = AsyncMock(return_value=message)
+        guild = MagicMock()
+        guild.text_channels = [miss_channel, hit_channel]
+        bot_instance.guilds = [guild]
+        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+
+        await bot_instance._sync_fixture_thread()
+
+        bot_instance.get_channel.assert_not_called()
+        bot_instance.fetch_channel.assert_not_called()
+        miss_channel.fetch_message.assert_awaited_once_with(789012)
+        hit_channel.fetch_message.assert_awaited_once_with(789012)
+
+    @pytest.mark.asyncio
+    async def test_sync_fixture_thread_does_not_scan_when_stored_channel_missing(
+        self, bot_instance
+    ):
+        fixture = {"id": 1, "message_id": "789012", "channel_id": "123456"}
+        guild = MagicMock()
+        guild.text_channels = [MagicMock()]
+        bot_instance.guilds = [guild]
+        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        bot_instance.get_channel.return_value = None
+        bot_instance.fetch_channel.side_effect = discord.NotFound(MagicMock(), "missing")
+
+        await bot_instance._sync_fixture_thread()
+
+        guild.text_channels[0].fetch_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sync_fixture_thread_does_not_scan_when_stored_channel_message_missing(
+        self, bot_instance
+    ):
+        fixture = {"id": 1, "message_id": "789012", "channel_id": "123456"}
+        channel = MagicMock()
+        channel.fetch_message = AsyncMock(side_effect=discord.NotFound(MagicMock(), "missing"))
+        guild = MagicMock()
+        guild.text_channels = [MagicMock()]
+        bot_instance.guilds = [guild]
+        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        bot_instance.get_channel.return_value = channel
+
+        await bot_instance._sync_fixture_thread()
+
+        channel.fetch_message.assert_awaited_once_with(789012)
+        guild.text_channels[0].fetch_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sync_fixture_thread_fetches_stored_channel_when_not_cached(self, bot_instance):
+        fixture = {"id": 1, "message_id": "789012", "channel_id": "123456"}
+        message = MagicMock()
+        message.thread = MagicMock(id=789012)
+        channel = MagicMock()
+        channel.fetch_message = AsyncMock(return_value=message)
+        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        bot_instance.get_channel.return_value = None
+        bot_instance.fetch_channel.return_value = channel
+
+        await bot_instance._sync_fixture_thread()
+
+        bot_instance.fetch_channel.assert_awaited_once_with(123456)
+        channel.fetch_message.assert_awaited_once_with(789012)
+
+    @pytest.mark.asyncio
+    async def test_sync_fixture_thread_does_not_scan_with_invalid_stored_ids(self, bot_instance):
+        fixture = {"id": 1, "message_id": "not-a-message", "channel_id": "not-a-channel"}
+        guild = MagicMock()
+        guild.text_channels = [MagicMock()]
+        bot_instance.guilds = [guild]
+        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+
+        await bot_instance._sync_fixture_thread()
+
+        bot_instance.get_channel.assert_not_called()
+        bot_instance.fetch_channel.assert_not_called()
+        guild.text_channels[0].fetch_message.assert_not_called()
+
+
 class TestReminderSystem:
     """Test suite for reminder scheduling."""
 

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -243,9 +243,11 @@ class TyperBot(commands.Bot):
     async def _sync_fixture_thread(self):
         """Verify fixture announcement exists on startup.
 
-        Checks that the open fixture's announcement message is accessible.
-        The stored message_id doubles as the thread_id since Discord
-        public threads inherit their parent message's snowflake ID.
+        Checks that each open fixture's announcement message is accessible.
+        Stored channel/message IDs are used directly when available; the slower
+        guild-wide scan only exists for legacy fixtures missing ``channel_id``.
+        The stored message_id doubles as the thread_id since Discord public
+        threads inherit their parent message's snowflake ID.
         """
         logger.info("Verifying fixture announcement...")
 
@@ -261,39 +263,133 @@ class TyperBot(commands.Bot):
                     logger.info(f"Fixture {fixture['id']} has no message_id, skipping verification")
                     continue
 
-                found = False
-                for guild in self.guilds:
-                    for channel in guild.text_channels:
-                        try:
-                            message = await channel.fetch_message(int(message_id))
-                            if message.thread:
-                                logger.info(
-                                    f"Fixture {fixture['id']} has thread {message.thread.id}"
-                                )
-                            else:
-                                logger.info(
-                                    f"Fixture {fixture['id']} has no thread (/predict cannot post publicly)"
-                                )
-                            found = True
-                            break
-                        except discord.NotFound:
-                            continue
-                        except discord.Forbidden:
-                            logger.warning(f"No permission to read channel {channel.id}")
-                            continue
-                        except Exception as e:
-                            logger.warning(f"Could not verify fixture in {channel.id}: {e}")
-                            continue
-                    if found:
-                        break
-
-                if not found:
+                message = await self._find_fixture_announcement_message(fixture)
+                if message is None:
                     logger.warning(
                         f"Could not find announcement message {message_id} for fixture {fixture['id']}"
+                    )
+                    continue
+
+                if message.thread:
+                    logger.info(f"Fixture {fixture['id']} has thread {message.thread.id}")
+                else:
+                    logger.info(
+                        f"Fixture {fixture['id']} has no thread (/predict cannot post publicly)"
                     )
 
         except Exception as e:
             logger.exception(f"Error during fixture verification: {e}")
+
+    async def _find_fixture_announcement_message(self, fixture: dict):
+        message_id = fixture.get("message_id")
+        channel_id = fixture.get("channel_id")
+        if not message_id:
+            return None
+
+        if channel_id:
+            message = await self._fetch_fixture_message_from_channel(
+                fixture_id=fixture["id"],
+                channel_id=channel_id,
+                message_id=message_id,
+            )
+            if message is not None:
+                return message
+            return None
+
+        logger.info(
+            "Fixture %s has no channel_id, scanning guild text channels for legacy verification",
+            fixture["id"],
+        )
+        return await self._scan_fixture_message_across_guilds(message_id)
+
+    async def _fetch_fixture_message_from_channel(
+        self,
+        *,
+        fixture_id: int,
+        channel_id: str,
+        message_id: str,
+    ):
+        try:
+            discord_channel_id = int(channel_id)
+            discord_message_id = int(message_id)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Fixture %s has invalid stored announcement reference channel_id=%s message_id=%s",
+                fixture_id,
+                channel_id,
+                message_id,
+            )
+            return None
+
+        channel = self.get_channel(discord_channel_id)
+        if channel is None:
+            fetch_channel = getattr(self, "fetch_channel", None)
+            if fetch_channel is None:
+                logger.warning(
+                    "Could not resolve stored channel %s for fixture %s announcement verification",
+                    channel_id,
+                    fixture_id,
+                )
+                return None
+            try:
+                channel = await fetch_channel(discord_channel_id)
+            except discord.HTTPException:
+                logger.warning(
+                    "Could not fetch stored channel %s for fixture %s announcement verification",
+                    channel_id,
+                    fixture_id,
+                )
+                return None
+
+        fetch_message = getattr(channel, "fetch_message", None)
+        if fetch_message is None:
+            logger.warning(
+                "Stored channel %s for fixture %s does not support message fetch",
+                channel_id,
+                fixture_id,
+            )
+            return None
+
+        try:
+            return await fetch_message(discord_message_id)
+        except discord.NotFound:
+            return None
+        except discord.Forbidden:
+            logger.warning(
+                "No permission to read stored channel %s for fixture %s",
+                channel_id,
+                fixture_id,
+            )
+            return None
+        except Exception as exc:
+            logger.warning(
+                "Could not verify fixture %s announcement in stored channel %s: %s",
+                fixture_id,
+                channel_id,
+                exc,
+            )
+            return None
+
+    async def _scan_fixture_message_across_guilds(self, message_id: str):
+        try:
+            discord_message_id = int(message_id)
+        except (TypeError, ValueError):
+            return None
+
+        for guild in self.guilds:
+            for channel in guild.text_channels:
+                try:
+                    return await channel.fetch_message(discord_message_id)
+                except discord.NotFound:
+                    continue
+                except discord.Forbidden:
+                    logger.warning(f"No permission to read channel {channel.id}")
+                    continue
+                except Exception as exc:
+                    logger.warning(f"Could not verify fixture in {channel.id}: {exc}")
+                    continue
+
+        return None
 
     async def _check_permissions(self):
         """Warn when a guild is missing permissions required for prediction workflows."""


### PR DESCRIPTION
## Summary
- use stored fixture `channel_id` to verify announcement messages directly during startup sync
- keep the full guild/channel scan only for legacy fixtures that do not have `channel_id`
- add focused startup-sync tests for direct lookup, uncached channel fetch, legacy fallback, and fail-closed cases

Closes #183

## Notes
- Fixtures that already store both `message_id` and `channel_id` now avoid the old O(all channels) startup scan.
- If a stored channel/message reference is missing or invalid, startup fails closed instead of broad rescanning.
- Legacy fixtures without `channel_id` still use the slower scan path until they are reposted or updated.

## Testing
- `uv run pytest tests/test_bot.py --tb=short`
- `uv run ruff check typer_bot/bot.py tests/test_bot.py`
- `uv run ty check typer_bot`
