### PR TITLE
refactor: replace string-based admin error routing with typed exceptions

### DIFF
--- a/tests/test_admin_service.py
+++ b/tests/test_admin_service.py
@@ -8,6 +8,12 @@ import pytest
 import typer_bot.database.predictions as predictions_module
 import typer_bot.database.results as results_module
 from typer_bot.services import AdminService
+from typer_bot.services.errors import (
+    FixtureNotFoundError,
+    NoPredictionsSavedError,
+    PredictionDisappearedError,
+    PredictionNotFoundError,
+)
 
 
 class TestLatePenaltyWaiver:
@@ -84,6 +90,73 @@ class TestLatePenaltyWaiver:
         prediction = await database.get_prediction(fixture_id, "late-user")
         assert prediction is not None
         assert prediction["late_penalty_waived"] == 0
+
+
+class TestAdminFlowErrors:
+    @pytest.mark.asyncio
+    async def test_get_fixture_prediction_summary_raises_typed_fixture_not_found(self, database):
+        service = AdminService(database)
+
+        with pytest.raises(FixtureNotFoundError):
+            await service.get_fixture_prediction_summary(999)
+
+    @pytest.mark.asyncio
+    async def test_get_fixture_prediction_summary_raises_typed_no_predictions(
+        self, database, sample_games
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+
+        with pytest.raises(NoPredictionsSavedError):
+            await service.get_fixture_prediction_summary(fixture_id)
+
+    @pytest.mark.asyncio
+    async def test_replace_prediction_raises_typed_prediction_not_found(
+        self, database, sample_games
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+
+        with pytest.raises(PredictionNotFoundError):
+            await service.replace_prediction(
+                fixture_id,
+                "missing-user",
+                "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2",
+                "admin-1",
+            )
+
+    @pytest.mark.asyncio
+    async def test_toggle_waiver_raises_typed_prediction_disappeared(
+        self, database, sample_games, monkeypatch
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            1, sample_games, datetime.now(UTC) - timedelta(hours=2)
+        )
+        await database.save_prediction(
+            fixture_id,
+            "late-user",
+            "Late User",
+            ["2-1", "1-1", "0-2"],
+            True,
+        )
+
+        original_get_prediction = database.get_prediction
+
+        async def disappear_after_toggle(request_fixture_id: int, user_id: str):
+            prediction = await original_get_prediction(request_fixture_id, user_id)
+            if prediction is not None and prediction["late_penalty_waived"]:
+                return None
+            return prediction
+
+        monkeypatch.setattr(database, "get_prediction", disappear_after_toggle)
+
+        with pytest.raises(PredictionDisappearedError, match="waiver update"):
+            await service.toggle_late_penalty_waiver(fixture_id, "late-user")
 
 
 class TestPredictionReplacement:

--- a/typer_bot/commands/admin_panel/modals.py
+++ b/typer_bot/commands/admin_panel/modals.py
@@ -8,6 +8,11 @@ from typing import TYPE_CHECKING
 import discord
 
 from typer_bot.database import Database
+from typer_bot.services import (
+    FixtureNotFoundError,
+    PredictionDisappearedError,
+    PredictionNotFoundError,
+)
 from typer_bot.utils import APP_TZ, format_for_discord, is_admin, now, parse_line_predictions
 
 from .base import (
@@ -416,28 +421,23 @@ class ReplacePredictionModal(discord.ui.Modal):
                 self.predictions_input.value,
                 str(interaction.user.id),
             )
+        except (FixtureNotFoundError, PredictionNotFoundError, PredictionDisappearedError) as exc:
+            self.parent_view.selection.user_id = None
+            self.parent_view.selection.user_label = ""
+            self.parent_view.selection.detail_lines = []
+            self.parent_view.selection.status_message = str(exc)
+            if isinstance(exc, FixtureNotFoundError):
+                self.parent_view.selection.fixture_id = None
+                self.parent_view.selection.fixture_label = ""
+                await self.parent_view.load_fixture_options()
+            await self.parent_view.load_user_options()
+            self.parent_view._refresh_items()
+            await interaction.response.edit_message(
+                content=self.parent_view.render_content(),
+                view=self.parent_view,
+            )
+            return
         except ValueError as exc:
-            if str(exc) in {
-                "Fixture not found",
-                "Prediction not found for that user",
-                "Prediction disappeared after update",
-            }:
-                self.parent_view.selection.user_id = None
-                self.parent_view.selection.user_label = ""
-                self.parent_view.selection.detail_lines = []
-                self.parent_view.selection.status_message = str(exc)
-                if str(exc) == "Fixture not found":
-                    self.parent_view.selection.fixture_id = None
-                    self.parent_view.selection.fixture_label = ""
-                    await self.parent_view.load_fixture_options()
-                await self.parent_view.load_user_options()
-                self.parent_view._refresh_items()
-                await interaction.response.edit_message(
-                    content=self.parent_view.render_content(),
-                    view=self.parent_view,
-                )
-                return
-
             await interaction.response.send_message(str(exc), ephemeral=True)
             return
 
@@ -530,25 +530,24 @@ class CorrectResultsModal(discord.ui.Modal):
                 self.fixture["id"],
                 self.results_input.value,
             )
+        except FixtureNotFoundError as exc:
+            self.parent_view.selection.fixture_id = None
+            self.parent_view.selection.fixture_label = ""
+            self.parent_view.selection.user_id = None
+            self.parent_view.selection.user_label = ""
+            self.parent_view.selection.detail_lines = []
+            self.parent_view.selection.status_message = str(exc)
+            await self.parent_view.load_fixture_options()
+            load_user_options = getattr(self.parent_view, "load_user_options", None)
+            if callable(load_user_options):
+                await load_user_options()
+            self.parent_view._refresh_items()
+            await interaction.response.edit_message(
+                content=self.parent_view.render_content(),
+                view=self.parent_view,
+            )
+            return
         except ValueError as exc:
-            if str(exc) == "Fixture not found":
-                self.parent_view.selection.fixture_id = None
-                self.parent_view.selection.fixture_label = ""
-                self.parent_view.selection.user_id = None
-                self.parent_view.selection.user_label = ""
-                self.parent_view.selection.detail_lines = []
-                self.parent_view.selection.status_message = str(exc)
-                await self.parent_view.load_fixture_options()
-                load_user_options = getattr(self.parent_view, "load_user_options", None)
-                if callable(load_user_options):
-                    await load_user_options()
-                self.parent_view._refresh_items()
-                await interaction.response.edit_message(
-                    content=self.parent_view.render_content(),
-                    view=self.parent_view,
-                )
-                return
-
             await interaction.response.send_message(str(exc), ephemeral=True)
             return
 

--- a/typer_bot/commands/admin_panel/predictions.py
+++ b/typer_bot/commands/admin_panel/predictions.py
@@ -7,7 +7,13 @@ from typing import TYPE_CHECKING
 import discord
 
 from typer_bot.database import Database
-from typer_bot.services import AdminService
+from typer_bot.services import (
+    AdminService,
+    FixtureNotFoundError,
+    NoPredictionsSavedError,
+    PredictionDisappearedError,
+    PredictionNotFoundError,
+)
 
 from .base import (
     MAX_SELECT_OPTIONS,
@@ -288,35 +294,34 @@ class ViewPredictionsButton(discord.ui.Button):
             fixture, predictions = await self.parent_view.service.get_fixture_prediction_summary(
                 fixture_id
             )
+        except FixtureNotFoundError as exc:
+            self.parent_view.selection.fixture_id = None
+            self.parent_view.selection.fixture_label = ""
+            self.parent_view.selection.user_id = None
+            self.parent_view.selection.user_label = ""
+            self.parent_view.selection.detail_lines = []
+            self.parent_view.selection.status_message = str(exc)
+            await self.parent_view.load_fixture_options()
+            await self.parent_view.load_user_options()
+            self.parent_view._refresh_items()
+            await interaction.response.edit_message(
+                content=self.parent_view.render_content(),
+                view=self.parent_view,
+            )
+            return
+        except NoPredictionsSavedError as exc:
+            self.parent_view.selection.user_id = None
+            self.parent_view.selection.user_label = ""
+            self.parent_view.selection.detail_lines = []
+            self.parent_view.selection.status_message = str(exc)
+            await self.parent_view.load_user_options()
+            self.parent_view._refresh_items()
+            await interaction.response.edit_message(
+                content=self.parent_view.render_content(),
+                view=self.parent_view,
+            )
+            return
         except ValueError as exc:
-            if str(exc) == "Fixture not found":
-                self.parent_view.selection.fixture_id = None
-                self.parent_view.selection.fixture_label = ""
-                self.parent_view.selection.user_id = None
-                self.parent_view.selection.user_label = ""
-                self.parent_view.selection.detail_lines = []
-                self.parent_view.selection.status_message = str(exc)
-                await self.parent_view.load_fixture_options()
-                await self.parent_view.load_user_options()
-                self.parent_view._refresh_items()
-                await interaction.response.edit_message(
-                    content=self.parent_view.render_content(),
-                    view=self.parent_view,
-                )
-                return
-            if str(exc) == "No predictions saved for this fixture":
-                self.parent_view.selection.user_id = None
-                self.parent_view.selection.user_label = ""
-                self.parent_view.selection.detail_lines = []
-                self.parent_view.selection.status_message = str(exc)
-                await self.parent_view.load_user_options()
-                self.parent_view._refresh_items()
-                await interaction.response.edit_message(
-                    content=self.parent_view.render_content(),
-                    view=self.parent_view,
-                )
-                return
-
             await interaction.response.send_message(str(exc), ephemeral=True)
             return
 
@@ -395,38 +400,34 @@ class ToggleWaiverButton(discord.ui.Button):
                 fixture_id,
                 user_id,
             )
+        except FixtureNotFoundError as exc:
+            self.parent_view.selection.fixture_id = None
+            self.parent_view.selection.fixture_label = ""
+            self.parent_view.selection.user_id = None
+            self.parent_view.selection.user_label = ""
+            self.parent_view.selection.detail_lines = []
+            self.parent_view.selection.status_message = str(exc)
+            await self.parent_view.load_fixture_options()
+            await self.parent_view.load_user_options()
+            self.parent_view._refresh_items()
+            await interaction.response.edit_message(
+                content=self.parent_view.render_content(),
+                view=self.parent_view,
+            )
+            return
+        except (PredictionNotFoundError, PredictionDisappearedError) as exc:
+            self.parent_view.selection.user_id = None
+            self.parent_view.selection.user_label = ""
+            self.parent_view.selection.detail_lines = []
+            self.parent_view.selection.status_message = str(exc)
+            await self.parent_view.load_user_options()
+            self.parent_view._refresh_items()
+            await interaction.response.edit_message(
+                content=self.parent_view.render_content(),
+                view=self.parent_view,
+            )
+            return
         except ValueError as exc:
-            if str(exc) == "Fixture not found":
-                self.parent_view.selection.fixture_id = None
-                self.parent_view.selection.fixture_label = ""
-                self.parent_view.selection.user_id = None
-                self.parent_view.selection.user_label = ""
-                self.parent_view.selection.detail_lines = []
-                self.parent_view.selection.status_message = str(exc)
-                await self.parent_view.load_fixture_options()
-                await self.parent_view.load_user_options()
-                self.parent_view._refresh_items()
-                await interaction.response.edit_message(
-                    content=self.parent_view.render_content(),
-                    view=self.parent_view,
-                )
-                return
-            if str(exc) in {
-                "Prediction not found for that user",
-                "Prediction disappeared after waiver update",
-            }:
-                self.parent_view.selection.user_id = None
-                self.parent_view.selection.user_label = ""
-                self.parent_view.selection.detail_lines = []
-                self.parent_view.selection.status_message = str(exc)
-                await self.parent_view.load_user_options()
-                self.parent_view._refresh_items()
-                await interaction.response.edit_message(
-                    content=self.parent_view.render_content(),
-                    view=self.parent_view,
-                )
-                return
-
             await interaction.response.send_message(str(exc), ephemeral=True)
             return
 

--- a/typer_bot/services/__init__.py
+++ b/typer_bot/services/__init__.py
@@ -1,5 +1,19 @@
 """Shared service-layer helpers."""
 
 from .admin_service import AdminService
+from .errors import (
+    AdminFlowError,
+    FixtureNotFoundError,
+    NoPredictionsSavedError,
+    PredictionDisappearedError,
+    PredictionNotFoundError,
+)
 
-__all__ = ["AdminService"]
+__all__ = [
+    "AdminFlowError",
+    "AdminService",
+    "FixtureNotFoundError",
+    "NoPredictionsSavedError",
+    "PredictionDisappearedError",
+    "PredictionNotFoundError",
+]

--- a/typer_bot/services/admin_service.py
+++ b/typer_bot/services/admin_service.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from typer_bot.database import Database
+from typer_bot.services.errors import (
+    FixtureNotFoundError,
+    NoPredictionsSavedError,
+    PredictionDisappearedError,
+    PredictionNotFoundError,
+)
 from typer_bot.utils import align_predictions_to_fixture, calculate_points, parse_line_predictions
 
 
@@ -29,7 +35,7 @@ class AdminService:
     async def _build_score_result(self, fixture_id: int) -> FixtureScoreResult:
         fixture = await self.db.get_fixture_by_id(fixture_id)
         if fixture is None:
-            raise ValueError("Fixture not found")
+            raise FixtureNotFoundError
 
         results = await self.db.get_results(fixture_id)
         if not results:
@@ -55,7 +61,7 @@ class AdminService:
         """Recalculate one fixture and refresh standings."""
         fixture = await self.db.get_fixture_by_id(fixture_id)
         if fixture is None:
-            raise ValueError("Fixture not found")
+            raise FixtureNotFoundError
 
         results = await self.db.get_results(fixture_id)
         if not results:
@@ -107,14 +113,19 @@ class AdminService:
         return await self.calculate_fixture_scores(fixture_id)
 
     async def get_fixture_prediction_summary(self, fixture_id: int) -> tuple[dict, list[dict]]:
-        """Return fixture and its predictions for panel display."""
+        """Return fixture and its predictions for panel display.
+
+        Raises:
+            FixtureNotFoundError: Fixture was deleted before the panel action ran.
+            NoPredictionsSavedError: Fixture still exists but has no saved predictions.
+        """
         fixture = await self.db.get_fixture_by_id(fixture_id)
         if fixture is None:
-            raise ValueError("Fixture not found")
+            raise FixtureNotFoundError
 
         predictions = await self.db.get_all_predictions(fixture_id, include_pending=True)
         if not predictions:
-            raise ValueError("No predictions saved for this fixture")
+            raise NoPredictionsSavedError
 
         predictions.sort(key=lambda prediction: prediction["user_name"].lower())
         return fixture, predictions
@@ -127,7 +138,7 @@ class AdminService:
     ) -> tuple[dict, dict, FixtureScoreResult | None]:
         fixture = await self.db.get_fixture_by_id(fixture_id)
         if fixture is None:
-            raise ValueError("Fixture not found")
+            raise FixtureNotFoundError
 
         prediction = await self.db.get_prediction(fixture_id, user_id)
         if prediction is None or not prediction["pending_partial_approval"]:
@@ -153,7 +164,7 @@ class AdminService:
     ) -> tuple[dict, dict, FixtureScoreResult | None]:
         fixture = await self.db.get_fixture_by_id(fixture_id)
         if fixture is None:
-            raise ValueError("Fixture not found")
+            raise FixtureNotFoundError
 
         prediction = await self.db.get_prediction(fixture_id, user_id)
         if prediction is None or not prediction["pending_partial_approval"]:
@@ -175,14 +186,21 @@ class AdminService:
         prediction_lines: str,
         admin_user_id: str,
     ) -> tuple[dict, dict, FixtureScoreResult | None]:
-        """Replace a stored prediction through an explicit admin action."""
+        """Replace a stored prediction through an explicit admin action.
+
+        Raises:
+            FixtureNotFoundError: Fixture was deleted before the admin action ran.
+            PredictionNotFoundError: Selected prediction no longer exists.
+            PredictionDisappearedError: Update succeeded but the refreshed row vanished.
+            ValueError: Validation or write failures that should surface directly to admins.
+        """
         fixture = await self.db.get_fixture_by_id(fixture_id)
         if fixture is None:
-            raise ValueError("Fixture not found")
+            raise FixtureNotFoundError
 
         existing_prediction = await self.db.get_prediction(fixture_id, user_id)
         if existing_prediction is None:
-            raise ValueError("Prediction not found for that user")
+            raise PredictionNotFoundError
 
         predictions, errors = parse_line_predictions(prediction_lines, fixture["games"])
         if errors:
@@ -199,7 +217,7 @@ class AdminService:
 
         refreshed_prediction = await self.db.get_prediction(fixture_id, user_id)
         if refreshed_prediction is None:
-            raise ValueError("Prediction disappeared after update")
+            raise PredictionDisappearedError("update")
 
         recalculation = None
         if await self.db.fixture_has_scores(fixture_id):
@@ -211,14 +229,21 @@ class AdminService:
         fixture_id: int,
         user_id: str,
     ) -> tuple[dict, dict, FixtureScoreResult | None]:
-        """Toggle the waiver flag for a stored late prediction."""
+        """Toggle the waiver flag for a stored late prediction.
+
+        Raises:
+            FixtureNotFoundError: Fixture was deleted before the admin action ran.
+            PredictionNotFoundError: Selected prediction no longer exists.
+            PredictionDisappearedError: Waiver update succeeded but the refreshed row vanished.
+            ValueError: On-time or write-failure cases that should surface directly to admins.
+        """
         fixture = await self.db.get_fixture_by_id(fixture_id)
         if fixture is None:
-            raise ValueError("Fixture not found")
+            raise FixtureNotFoundError
 
         prediction = await self.db.get_prediction(fixture_id, user_id)
         if prediction is None:
-            raise ValueError("Prediction not found for that user")
+            raise PredictionNotFoundError
         if not prediction["is_late"]:
             raise ValueError("That prediction was submitted on time")
 
@@ -228,7 +253,7 @@ class AdminService:
 
         refreshed_prediction = await self.db.get_prediction(fixture_id, user_id)
         if refreshed_prediction is None:
-            raise ValueError("Prediction disappeared after waiver update")
+            raise PredictionDisappearedError("waiver update")
 
         recalculation = None
         if await self.db.fixture_has_scores(fixture_id):
@@ -243,7 +268,7 @@ class AdminService:
         """Replace stored results and recalculate scored fixtures."""
         fixture = await self.db.get_fixture_by_id(fixture_id)
         if fixture is None:
-            raise ValueError("Fixture not found")
+            raise FixtureNotFoundError
 
         results, errors = parse_line_predictions(results_lines, fixture["games"])
         if errors:

--- a/typer_bot/services/errors.py
+++ b/typer_bot/services/errors.py
@@ -1,0 +1,27 @@
+"""Typed service-layer exceptions for recoverable admin flows."""
+
+
+class AdminFlowError(ValueError):
+    """Base class for recoverable admin workflow failures."""
+
+
+class FixtureNotFoundError(AdminFlowError):
+    def __init__(self):
+        super().__init__("Fixture not found")
+
+
+class NoPredictionsSavedError(AdminFlowError):
+    def __init__(self):
+        super().__init__("No predictions saved for this fixture")
+
+
+class PredictionNotFoundError(AdminFlowError):
+    def __init__(self):
+        super().__init__("Prediction not found for that user")
+
+
+class PredictionDisappearedError(AdminFlowError):
+    """Prediction vanished after a successful admin write, usually due to stale state."""
+
+    def __init__(self, action: str):
+        super().__init__(f"Prediction disappeared after {action}")


### PR DESCRIPTION
## Summary
- replace string-matched admin routing errors with typed service-layer exceptions for fixture/prediction stale-state cases
- update admin panel prediction and result flows to catch those typed exceptions while still surfacing validation `ValueError`s directly
- add focused admin-service tests for the new typed exception contracts

Closes #182

## Notes
- The new exceptions still inherit from `ValueError`, so unchanged callers keep working while panel/modal flows stop depending on exact message text for control flow.
- Scope stays narrow to the current recoverable admin routing paths; broader exception cleanup can stay follow-up work.

## Testing
- `uv run pytest tests/test_admin_service.py tests/test_admin_panel.py --tb=short`
- `uv run ruff check typer_bot/services typer_bot/commands/admin_panel tests/test_admin_service.py tests/test_admin_panel.py`
- `uv run ty check typer_bot`
