### PR TITLE
refactor: deduplicate backup SQL validation logic

### DIFF
--- a/scripts/restore_db.py
+++ b/scripts/restore_db.py
@@ -8,51 +8,14 @@ already present, it is copied to a timestamped backup file first.
 
 import argparse
 import os
-import re
 import shutil
 import sqlite3
 import sys
 from datetime import datetime
 from pathlib import Path
 
+from typer_bot.utils.backup_sql import validate_backup_sql
 from typer_bot.utils.config import DB_PATH
-
-
-def validate_backup_sql(sql_content: str) -> bool:
-    """Reject obviously unsafe SQL before attempting a restore.
-
-    This is a best-effort blacklist, not a real SQL parser. Real restore safety
-    comes from loading the SQL into a temporary database and replacing the live
-    DB only if that restore completes successfully.
-    """
-    normalized = re.sub(r"--.*?$", "", sql_content, flags=re.MULTILINE)
-    normalized = re.sub(r"/\*.*?\*/", "", normalized, flags=re.DOTALL)
-    normalized = re.sub(r"^\s*$", "", normalized, flags=re.MULTILINE)
-    normalized = normalized.upper()
-
-    dangerous = [
-        "DROP",
-        "DELETE",
-        "UPDATE",
-        "ALTER",
-        "TRUNCATE",
-        "REPLACE",
-        "ATTACH",
-        "DETACH",
-        "PRAGMA",
-    ]
-
-    for keyword in dangerous:
-        if re.search(rf"\b{keyword}\b", normalized):
-            return False
-
-    lines = normalized.split("\n")
-    for line in lines:
-        line = line.strip()
-        if line.startswith("CREATE") and ("TABLE" not in line or "IF NOT EXISTS" not in line):
-            return False
-
-    return True
 
 
 def main():
@@ -71,7 +34,7 @@ def main():
     sql_content = backup_path.read_text(encoding="utf-8")
     if not validate_backup_sql(sql_content):
         print("Error: Backup file contains unsafe SQL")
-        print("Only CREATE TABLE IF NOT EXISTS and INSERT statements are allowed")
+        print("Only SQLite dump statements emitted by the bot backup flow are allowed")
         sys.exit(1)
 
     print("\nWarning: This will REPLACE the current database!")

--- a/tests/test_restore_db.py
+++ b/tests/test_restore_db.py
@@ -2,11 +2,13 @@
 
 import sqlite3
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from scripts.restore_db import main, validate_backup_sql
+from typer_bot.utils.db_backup import create_backup
 
 VALID_SQL = """\
 CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT);
@@ -29,7 +31,45 @@ class TestValidateBackupSql:
         assert validate_backup_sql("DELETE FROM users;") is False
 
     def test_rejects_bare_create_without_if_not_exists(self):
-        assert validate_backup_sql("CREATE TABLE users (id INTEGER);") is False
+        assert validate_backup_sql("DROP TABLE users;") is False
+
+    def test_accepts_real_sqlite_dump_output(self, tmp_path):
+        db_path = tmp_path / "source.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE sample (id INTEGER PRIMARY KEY AUTOINCREMENT, note TEXT)")
+        conn.execute("CREATE UNIQUE INDEX idx_sample_note ON sample(note)")
+        conn.execute("INSERT INTO sample (note) VALUES ('contains DROP text')")
+        conn.commit()
+        conn.close()
+
+        backup_file = create_backup(str(db_path), str(tmp_path / "backups"))
+        sql_content = Path(backup_file).read_text(encoding="utf-8")
+
+        assert validate_backup_sql(sql_content) is True
+
+    def test_accepts_keywords_inside_string_literals(self):
+        sql_content = (
+            "BEGIN TRANSACTION;\n"
+            "CREATE TABLE sample (id INTEGER PRIMARY KEY AUTOINCREMENT, note TEXT);\n"
+            "INSERT INTO sample VALUES(1, 'DELETE DROP UPDATE ALTER');\n"
+            'DELETE FROM "sqlite_sequence";\n'
+            "INSERT INTO sqlite_sequence VALUES('sample',1);\n"
+            "COMMIT;"
+        )
+
+        assert validate_backup_sql(sql_content) is True
+
+    def test_accepts_comment_tokens_inside_string_literals(self):
+        sql_content = (
+            "BEGIN TRANSACTION;\n"
+            "CREATE TABLE sample (id INTEGER PRIMARY KEY AUTOINCREMENT, note TEXT);\n"
+            "INSERT INTO sample VALUES(1, 'alpha -- beta /* gamma */');\n"
+            'DELETE FROM "sqlite_sequence";\n'
+            "INSERT INTO sqlite_sequence VALUES('sample',1);\n"
+            "COMMIT;"
+        )
+
+        assert validate_backup_sql(sql_content) is True
 
 
 class TestRestoreAtomic:
@@ -151,3 +191,35 @@ class TestRestoreAtomic:
         old_rows = backup_conn.execute("SELECT x FROM old_table").fetchall()
         backup_conn.close()
         assert old_rows == [("before",)]
+
+    def test_restore_accepts_real_created_backup_output(self, tmp_path):
+        source_db = tmp_path / "source.db"
+        conn = sqlite3.connect(source_db)
+        conn.execute("CREATE TABLE sample (id INTEGER PRIMARY KEY AUTOINCREMENT, note TEXT)")
+        conn.execute("CREATE UNIQUE INDEX idx_sample_note ON sample(note)")
+        conn.execute("INSERT INTO sample (note) VALUES (?)", ("alpha -- beta /* gamma */",))
+        conn.commit()
+        conn.close()
+
+        backup_file = create_backup(str(source_db), str(tmp_path / "backups"))
+        restore_target = tmp_path / "typer.db"
+
+        with (
+            patch("scripts.restore_db.DB_PATH", str(restore_target)),
+            patch("builtins.input", return_value="YES"),
+        ):
+            sys.argv = ["restore_db", backup_file]
+            main()
+
+        conn = sqlite3.connect(restore_target)
+        rows = conn.execute("SELECT id, note FROM sample").fetchall()
+        indexes = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='sample'"
+            ).fetchall()
+        }
+        conn.close()
+
+        assert rows == [(1, "alpha -- beta /* gamma */")]
+        assert "idx_sample_note" in indexes

--- a/typer_bot/utils/backup_sql.py
+++ b/typer_bot/utils/backup_sql.py
@@ -1,0 +1,102 @@
+"""Shared SQL validation for backup and restore operations."""
+
+import re
+
+
+def validate_backup_sql(sql_content: str) -> bool:
+    """Reject obviously unsafe SQL before backup restore or validation steps.
+
+    This is a best-effort whitelist for the SQLite dump format we emit, not a
+    real SQL parser. Real restore safety
+    still depends on loading SQL into a temporary database before replacing the
+    live DB.
+    """
+    for statement in _iter_sql_statements(sql_content):
+        if not _is_allowed_backup_statement(statement):
+            return False
+    return True
+
+
+def _is_allowed_backup_statement(statement: str) -> bool:
+    normalized = statement.strip().rstrip(";").strip()
+    if not normalized:
+        return True
+
+    allowed_patterns = (
+        r"BEGIN\s+TRANSACTION",
+        r"COMMIT",
+        r"CREATE\s+TABLE\b.*",
+        r"CREATE\s+(?:UNIQUE\s+)?INDEX\b.*",
+        r"INSERT\s+INTO\b.*",
+        r'DELETE\s+FROM\s+["`\[]?SQLITE_SEQUENCE["`\]]?$',
+    )
+    return any(
+        re.fullmatch(pattern, normalized, flags=re.IGNORECASE | re.DOTALL)
+        for pattern in allowed_patterns
+    )
+
+
+def _iter_sql_statements(sql_content: str) -> list[str]:
+    statements: list[str] = []
+    current: list[str] = []
+    index = 0
+    in_single_quote = False
+    in_double_quote = False
+    in_line_comment = False
+    in_block_comment = False
+
+    while index < len(sql_content):
+        char = sql_content[index]
+        next_char = sql_content[index + 1] if index + 1 < len(sql_content) else ""
+
+        if in_line_comment:
+            if char == "\n":
+                in_line_comment = False
+            index += 1
+            continue
+
+        if in_block_comment:
+            if char == "*" and next_char == "/":
+                in_block_comment = False
+                index += 2
+                continue
+            index += 1
+            continue
+
+        if not in_single_quote and not in_double_quote:
+            if char == "-" and next_char == "-":
+                in_line_comment = True
+                index += 2
+                continue
+            if char == "/" and next_char == "*":
+                in_block_comment = True
+                index += 2
+                continue
+
+        current.append(char)
+
+        if char == "'" and not in_double_quote:
+            if in_single_quote and next_char == "'":
+                current.append(next_char)
+                index += 2
+                continue
+            in_single_quote = not in_single_quote
+        elif char == '"' and not in_single_quote:
+            if in_double_quote and next_char == '"':
+                current.append(next_char)
+                index += 2
+                continue
+            in_double_quote = not in_double_quote
+        elif char == ";" and not in_single_quote and not in_double_quote:
+            statement = "".join(current).strip()
+            if statement:
+                statements.append(statement)
+            current = []
+
+        index += 1
+
+    trailing = "".join(current).strip()
+    if trailing:
+        statements.append(trailing)
+
+    return statements

--- a/typer_bot/utils/db_backup.py
+++ b/typer_bot/utils/db_backup.py
@@ -1,44 +1,11 @@
 """Automatic database backup utilities."""
 
 import logging
-import re
 import sqlite3
 from datetime import datetime
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
-
-
-def validate_backup_sql(sql_content: str) -> bool:
-    """Validate backup SQL - allows CREATE TABLE IF NOT EXISTS and INSERT only."""
-    normalized = re.sub(r"--.*?$", "", sql_content, flags=re.MULTILINE)
-    normalized = re.sub(r"/\*.*?\*/", "", normalized, flags=re.DOTALL)
-    normalized = re.sub(r"^\s*$", "", normalized, flags=re.MULTILINE)
-    normalized = normalized.upper()
-
-    dangerous = [
-        "DROP",
-        "DELETE",
-        "UPDATE",
-        "ALTER",
-        "TRUNCATE",
-        "REPLACE",
-        "ATTACH",
-        "DETACH",
-        "PRAGMA",
-    ]
-
-    for keyword in dangerous:
-        if re.search(rf"\b{keyword}\b", normalized):
-            return False
-
-    lines = normalized.split("\n")
-    for line in lines:
-        line = line.strip()
-        if line.startswith("CREATE") and ("TABLE" not in line or "IF NOT EXISTS" not in line):
-            return False
-
-    return True
 
 
 def create_backup(db_path: str, backup_dir: str) -> str:


### PR DESCRIPTION
## Summary
- move backup SQL validation into one shared utility used by both backup and restore flows
- align the validator with real `sqlite3.iterdump()` output instead of the earlier hand-written subset
- add realistic validation and backup→restore round-trip tests, including string data that contains comment markers or SQL keywords

Closes #184

## Notes
- The validator is now a narrow whitelist for the SQLite dump format the bot actually emits.
- Real restore safety still comes from restoring into a temporary database before replacing the live DB.

## Testing
- `uv run pytest tests/test_restore_db.py --tb=short`
- `uv run ruff check typer_bot/utils/backup_sql.py typer_bot/utils/db_backup.py scripts/restore_db.py tests/test_restore_db.py`
- `uv run ty check typer_bot`
