### PR TITLE
docs: add lightweight deployment and migration notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ The example below uses Coolify because that is the current operator path.
 
 Use a separate token for previews and manual testing. Do not run multiple deployments against the same live token.
 
-Routine host migration is a direct SQLite file copy of `typer.db` into the configured `DATA_DIR`. The `scripts/restore_db.py` helper is for restoring SQL dump backups during recovery, not for the normal host-to-host move.
+### Migration and Data
+
+Routine host migration is a direct copy of the live SQLite file at `DB_PATH` (default: `{DATA_DIR}/typer.db`). The `scripts/restore_db.py` helper is for restoring SQL dump backups during recovery, not for the normal host-to-host move.
 
 If you override `DB_PATH` or `BACKUP_DIR`, keep them on the persistent volume too.
 

--- a/scripts/restore_db.py
+++ b/scripts/restore_db.py
@@ -4,6 +4,9 @@
 The script validates the backup, restores it into a temporary SQLite file, and
 atomically replaces the live DB only after the restore succeeds. If a live DB is
 already present, it is copied to a timestamped backup file first.
+
+Use this for recovery from SQL dump backups. Routine host migration should copy
+the live SQLite database file directly instead of round-tripping through SQL.
 """
 
 import argparse
@@ -21,7 +24,8 @@ from typer_bot.utils.config import DB_PATH
 def main():
     """Restore one backup file after explicit operator confirmation."""
     parser = argparse.ArgumentParser(
-        prog="restore_db", description="Restore database from backup file"
+        prog="restore_db",
+        description="Restore database from SQL dump backup for recovery, not routine migration",
     )
     parser.add_argument("backup_file", help="Path to backup SQL file")
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- add a small `Migration and Data` section so deployment docs clearly distinguish routine host migration from SQL-dump recovery
- clarify that routine migration copies the live SQLite file at `DB_PATH`, not always a hard-coded `typer.db` path
- narrow `scripts/restore_db.py` CLI/help text so it is clearly a recovery tool, not the normal migration path

Closes #158

## Notes
- Most of this issue had already been absorbed into `master` by the earlier deployment framing cleanup.
- This PR just closes the remaining operator-contract gaps.

## Testing
- `uv run pytest tests/test_restore_db.py --tb=short`
- `uv run ruff check scripts/restore_db.py`
- `uv run ty check typer_bot`
