### PR TITLE
docs: simplify user-facing help and README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ The example below uses Coolify because that is the current operator path.
 
 Use a separate token for previews and manual testing. Do not run multiple deployments against the same live token.
 
-Routine host migration is a direct SQLite file copy of `typer.db` into the configured `DATA_DIR`. The `scripts/restore_db.py` helper is for restoring SQL dump backups during recovery, not for the normal host-to-host move.
+### Migration and Data
+
+Routine host migration is a direct copy of the live SQLite file at `DB_PATH` (default: `{DATA_DIR}/typer.db`). The `scripts/restore_db.py` helper is for restoring SQL dump backups during recovery, not for the normal host-to-host move.
 
 If you override `DB_PATH` or `BACKUP_DIR`, keep them on the persistent volume too.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Discord bot for weekly football prediction leagues. Admins create fixtures and e
 
 ## Features
 - Thread predictions on fixture announcement threads
-- `/predict` modal flow that posts publicly into fixture threads
+- `/predict` posts publicly into fixture threads
 - Flexible score parsing: `2-1`, `2:1`, `2 : 1`
 - Per-fixture deadlines with late-pick handling
 - Standings, saved predictions, and weekly results posting
@@ -22,7 +22,7 @@ Discord bot for weekly football prediction leagues. Admins create fixtures and e
 ### Admin commands
 - `/admin panel` - open the main admin surface
 
-Inside the panel you can:
+Inside the panel:
 - create fixtures
 - delete fixtures
 - jump to older open weeks not shown in the quick list
@@ -47,14 +47,14 @@ Admins need a Discord role named `Admin` or `typer-admin`.
 
 ## Prediction flow
 - Reply in the fixture thread with one line per match.
-- Run `/predict` anywhere in the server to fill a modal, then have the bot post your prediction publicly into the fixture thread.
-- To replace a saved prediction, use `/predict` again; the bot posts a new public `Updated prediction` message in the thread.
-- Partial predictions are allowed, but before the deadline players should still try to fill the whole fixture. Each partial line must name the game it applies to.
+- Or run `/predict` anywhere in the server, choose the week if needed, fill the modal, and let the bot post it in the fixture thread.
+- To replace a saved prediction, use `/predict` again; the bot posts an updated public message in the fixture thread.
+- Partial predictions are allowed. Each partial line must name the game it applies to.
 - Missing games count as no prediction.
 - Late predictions with missing games stay under admin review until an admin approves or rejects them.
-- If approved, the submitted lines count normally and any missing games still count as no prediction.
-- If rejected, that late submission is discarded and does not count.
-- Public review status stays visible in the fixture thread: `/predict` posts are edited after review, and thread replies switch from `⏳` to `✅` or `❌`.
+- Approved late submissions count the submitted lines normally, and missing games still count as no prediction.
+- Rejected late submissions are discarded.
+- Public review status stays visible in the fixture thread.
 
 Example:
 
@@ -73,8 +73,7 @@ Team E - Team F 3:2
 
 ## Operational constraints
 - Match data, predictions, results, and scores are stored in SQLite.
-- Short-lived cooldowns are kept in memory.
-- This includes the thread-post rate limiter and the score-calculation cooldown.
+- Short-lived cooldowns are kept in memory, including the thread-post rate limiter and the score-calculation cooldown.
 - The bot is intentionally single-process for v1. If the process restarts, in-memory cooldowns reset.
 
 ## Configuration
@@ -95,7 +94,7 @@ Team E - Team F 3:2
 
 This bot runs anywhere you can deploy a persistent container. Common options for a project this size are Coolify, Railway, Render, Fly.io, or a small VPS with Docker Compose.
 
-The example below uses Coolify because that is the current operator path.
+The example below uses Coolify.
 
 ### Coolify (Nixpacks)
 
@@ -151,7 +150,7 @@ uv run python -m typer_bot.dev.seed_test_data --tester-user-id "your_discord_use
 uv run python -m typer_bot
 ```
 
-The seed command resets that local test database and creates one mixed scenario:
+The seed command resets that local test database and creates:
 - one scored past fixture for standings/history
 - one open fixture with saved predictions
 - one late open fixture with a late prediction
@@ -160,10 +159,10 @@ Outside `./.local/manual-discord-test`, add `--force-reset`.
 
 `--force-reset` deletes the target DB, its `-wal` and `-shm` files, and the configured backup directory before reseeding.
 
-In a PR deployment shell, use the same command against that deployment's `DB_PATH` and `BACKUP_DIR`.
+In a deployment shell, use the same command against that deployment's `DB_PATH` and `BACKUP_DIR`.
 Those paths usually are not `./.local/manual-discord-test`, so add `--force-reset`.
 
-Create a real fixture when you need to test announcement posting, thread creation, reactions, or modal-to-thread prediction posting. The seed data is only there to save setup time.
+Create a real fixture when you need to test announcement posting, thread creation, reactions, or modal-to-thread prediction posting.
 
 ## Development
 
@@ -178,14 +177,14 @@ uv run ty check typer_bot
 ## Backup and Restore
 
 - Automatic: the database is backed up after each successful score calculation. The bot keeps the latest 10 backups in `BACKUP_DIR`.
-- Manual restore: run from the host or container shell where the live database volume is mounted.
+- Manual restore: run from the host or container shell where the live data volume is mounted.
 
 ```bash
 ls /app/data/backups/
 python scripts/restore_db.py /app/data/backups/backup_*.sql
 ```
 
-The restore script asks for confirmation, restores into a temporary SQLite file first, and only replaces the live database after a successful restore.
+The restore script asks for confirmation, restores into a temporary SQLite file first, and only replaces the live database after success.
 
 ## License
 MIT.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 Discord bot for weekly football prediction leagues. Admins create fixtures and enter results. Players submit score predictions in fixture threads or through `/predict`, which posts publicly into those threads. The bot stores picks, calculates points, and posts standings.
 
 ## Features
-- Thread predictions on fixture announcement threads
-- `/predict` posts publicly into fixture threads
-- Flexible score parsing: `2-1`, `2:1`, `2 : 1`
-- Per-fixture deadlines with late-pick handling
-- Standings, saved predictions, and weekly results posting
-- SQLite persistence with automatic backups after successful score calculation
+- Thread predictions
+- `/predict`
+- Flexible score parsing
+- Deadlines and late-pick handling
+- Standings and results
+- SQLite backups
 
 ## Commands
 ### Player commands
@@ -22,7 +22,7 @@ Discord bot for weekly football prediction leagues. Admins create fixtures and e
 ### Admin commands
 - `/admin panel` - open the main admin surface
 
-Inside the panel:
+The panel handles:
 - create fixtures
 - delete fixtures
 - jump to older open weeks not shown in the quick list
@@ -47,7 +47,7 @@ Admins need a Discord role named `Admin` or `typer-admin`.
 
 ## Prediction flow
 - Reply in the fixture thread with one line per match.
-- Or run `/predict` anywhere in the server, choose the week if needed, fill the modal, and let the bot post it in the fixture thread.
+- Or run `/predict` anywhere in the server, choose the week if needed, fill the modal, and let the bot post it publicly in the fixture thread.
 - To replace a saved prediction, use `/predict` again; the bot posts an updated public message in the fixture thread.
 - Partial predictions are allowed. Each partial line must name the game it applies to.
 - Missing games count as no prediction.
@@ -92,7 +92,7 @@ Team E - Team F 3:2
 
 ## Deployment
 
-This bot runs anywhere you can deploy a persistent container. Common options for a project this size are Coolify, Railway, Render, Fly.io, or a small VPS with Docker Compose.
+This bot runs anywhere you can deploy a persistent container.
 
 The example below uses Coolify.
 
@@ -162,7 +162,7 @@ Outside `./.local/manual-discord-test`, add `--force-reset`.
 In a deployment shell, use the same command against that deployment's `DB_PATH` and `BACKUP_DIR`.
 Those paths usually are not `./.local/manual-discord-test`, so add `--force-reset`.
 
-Create a real fixture when you need to test announcement posting, thread creation, reactions, or modal-to-thread prediction posting.
+Create a real fixture when you need to test posting, thread creation, reactions, or modal-to-thread prediction posting.
 
 ## Development
 

--- a/scripts/restore_db.py
+++ b/scripts/restore_db.py
@@ -4,6 +4,9 @@
 The script validates the backup, restores it into a temporary SQLite file, and
 atomically replaces the live DB only after the restore succeeds. If a live DB is
 already present, it is copied to a timestamped backup file first.
+
+Use this for recovery from SQL dump backups. Routine host migration should copy
+the live SQLite database file directly instead of round-tripping through SQL.
 """
 
 import argparse
@@ -21,7 +24,8 @@ from typer_bot.utils.config import DB_PATH
 def main():
     """Restore one backup file after explicit operator confirmation."""
     parser = argparse.ArgumentParser(
-        prog="restore_db", description="Restore database from backup file"
+        prog="restore_db",
+        description="Restore database from SQL dump backup for recovery, not routine migration",
     )
     parser.add_argument("backup_file", help="Path to backup SQL file")
     args = parser.parse_args()

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -633,7 +633,7 @@ Team C - Team D 1:1
 **For Admins:**
 • `/admin panel` - Open the main admin surface
 
-**Inside the panel:**
+**The panel handles:**
 - create fixtures
 - delete fixtures
 - jump to an older open week that is not shown in the quick list

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -593,60 +593,47 @@ class UserCommands(commands.Cog):
         user_help = """## 📖 User Commands
 
 **For Players:**
-• `/predict` - Fill predictions in a modal, then post them publicly to the fixture thread
-• `/fixtures` - View all open fixtures
-• `/standings` - See overall leaderboard
-• `/mypredictions` - Check your submitted predictions for open fixtures
+• `/predict` - Choose the week if needed, fill the modal, and post predictions publicly to the fixture thread
+• `/fixtures` - View open fixtures and deadlines
+• `/standings` - See the leaderboard
+• `/mypredictions` - Check your saved predictions
 
 **How to Predict:**
+• Reply in the fixture thread with one line per match
+• Or use `/predict` anywhere in the server
+• If multiple fixtures are open, `/predict` lets you pick the week first
+• Use `/predict` again to replace a saved prediction with a new public thread post
 
-**Reply in the fixture thread**
-1. Open the fixture thread
-2. Reply with your predictions:
-   ```
-   Team A - Team B 2:0
-   Team C - Team D 1:1
-   ...
-   ```
-3. Bot reacts ✅ when saved
-4. Late submissions with missing games react ⏳ and wait for admin review
-
-**Or use `/predict`**
-1. Type `/predict` in the channel
-2. If multiple fixtures are open, choose the week from the picker
-3. Enter your predictions in the modal
-4. Submit to post them in the fixture thread
-5. Use the buttons to continue to other open fixtures
+Example:
+```
+Team A - Team B 2:0
+Team C - Team D 1:1
+```
 
 **Partial predictions:**
-- You can leave some games out, but before the deadline you should still try to fill the whole fixture
-- Each partial line must name the game it applies to
-- Missing games count as no prediction
-- Late submissions with missing games wait for admin review before they count
-- Approval counts the submitted lines normally; rejection discards that late submission
-- Public status stays visible in the fixture thread after review
+• You can leave some games out
+• Each partial line must name the game it applies to
+• Missing games count as no prediction
+• Late submissions with missing games wait for admin review
+• Approved late submissions count the submitted lines normally, and missing games still count as no prediction
+• Rejected late submissions are discarded
+• Public review status stays visible in the fixture thread
 
 **Scoring:**
 • Exact score: 3 points
 • Correct result (win/loss/draw): 1 point
 • Wrong: 0 points
-• Late full predictions: 0 points
+• Late full predictions: 0 points unless an admin waives the penalty
 • Late predictions with missing games: pending admin review
 
-**Input formats:** Use `2:0`, `2-0`, or `2 : 0`
-
-**To change a prediction:** Use `/predict` again. The bot will post an updated prediction in the fixture thread."""
+**Input formats:** `2:0`, `2-0`, `2 : 0`"""
 
         admin_help = """\n\n## 🔧 Admin Commands
 
 **For Admins:**
 • `/admin panel` - Open the main admin surface
 
-**Admin workflow:**
-- run `/admin panel` once
-- use the panel buttons and selectors for admin actions
-
-**Inside the panel you can:**
+**Inside the panel:**
 - create fixtures
 - delete fixtures
 - jump to an older open week that is not shown in the quick list
@@ -656,7 +643,7 @@ class UserCommands(commands.Cog):
 - replace predictions
 - toggle late waivers
 - review, approve, or reject late predictions submitted with missing games
-- `Review Late` appears when pending items exist, and approve/reject can recalculate scored fixtures
+- approve/reject can recalculate already scored fixtures
 - inspect overflow prediction lists when a fixture has more than 25 users
 
 **Custom Deadline Format:**


### PR DESCRIPTION
## Summary
- simplify README wording so it is shorter and easier to scan without dropping behavior contracts
- simplify `/help` text in `user_commands.py` so it describes the current product state directly instead of walking through procedural detail
- keep the important user/admin contracts explicit: modal + week selection, public replacement posts, late-review outcomes, and admin recalc side effects

Closes #174

## Notes
- This is a copy/polish pass only. No behavior changes.
- The simplification was kept narrow to README and `/help` text.

## Testing
- `uv run pytest tests/test_user_commands.py --tb=short`
- `uv run ruff check typer_bot/commands/user_commands.py`
- `uv run ty check typer_bot`
