### PR TITLE
fix: tighten v1.1 prediction retry handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ You are working on `TyperBot`, a Discord bot for football prediction leagues.
   - `DB_PATH`: Full database path (default: `{DATA_DIR}/typer.db`)
   - `BACKUP_DIR`: Backup storage (default: `{DATA_DIR}/backups`)
 - **Modal Workflow:** Complex inputs (fixture creation, results entry, `/predict`) use Discord modals instead of DM sessions.
-- **Thread Predictions:** Users can post predictions in public threads under fixture announcements (NEW - see handlers/thread_prediction_handler.py).
+- **Thread Predictions:** Users can post predictions in public threads under fixture announcements.
 - **Rate Limiting:** Thread predictions are rate-limited to 1 per second per user. Cooldown entries auto-expire after 1 hour.
 - **Async:** All database ops must be async (`aiosqlite`).
 - **Parsing:** Use `utils.prediction_parser.parse_line_predictions` for all score parsing. Do NOT write ad-hoc regex.
@@ -65,7 +65,6 @@ scores (
 ## 4. Codebase Map
 - `typer_bot/bot.py`: Entry point and setup hook.
 - `typer_bot/commands/user_commands.py`: Public slash commands, including modal-driven `/predict` flow.
-- `typer_bot/commands/admin_commands.py`: `/admin` command surface and orchestration for admin workflows.
 - `typer_bot/commands/admin_panel/`: Admin panel UI views, selects, and modals split out of `admin_commands.py`.
 - `typer_bot/handlers/thread_prediction_handler.py`: Thread-based prediction processing (on_message) plus thread prediction cooldown state.
 - `typer_bot/commands/admin_commands.py`: `/admin` command surface and orchestration for admin workflows, including admin calculation cooldown state.
@@ -151,8 +150,7 @@ prek run ruff            # Run specific hook
 ```
 
 **Type Checking:**
-- Tool: `ty` (Astral's type checker, 10-100x faster than mypy)
-- Current status: **0 errors** (complete)
+- Tool: `ty`
 - Run: `ty check typer_bot`
 
 ## 8. Deployment Environment

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # TyperBot
 
-100% vibecoded, no guarantees given but it seems to work.
-
 Discord bot for weekly football prediction leagues. Admins create fixtures and enter results. Players submit score predictions in fixture threads or through `/predict`, which posts publicly into those threads. The bot stores picks, calculates points, and posts standings.
 
 ## Features
@@ -30,12 +28,14 @@ The panel handles:
 - calculate scores
 - re-post the latest completed results with optional mentions
 - replace predictions
+- review late partial predictions
 - toggle late waivers
 
 Admins need a Discord role named `Admin` or `typer-admin`.
 
 ## Permissions
 - `Send Messages`
+- `Send Messages in Threads`
 - `Read Message History`
 - `Add Reactions`
 - `Create Public Threads`
@@ -94,9 +94,7 @@ Team E - Team F 3:2
 
 This bot runs anywhere you can deploy a persistent container.
 
-The example below uses Coolify.
-
-### Coolify (Nixpacks)
+### Coolify
 
 1. Create a new Coolify worker/background service from this repo.
 2. Use Nixpacks.

--- a/tests/test_admin_service.py
+++ b/tests/test_admin_service.py
@@ -497,6 +497,52 @@ class TestPartialPredictionApproval:
         assert {row["user_id"] for row in standings} == {"111", "222"}
 
     @pytest.mark.asyncio
+    async def test_approve_partial_prediction_rolls_back_if_recalculation_fails(
+        self,
+        database,
+        sample_games,
+        monkeypatch,
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            5, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
+        await database.save_prediction(
+            fixture_id,
+            "111",
+            "Full User",
+            ["2-1", "1-1", "0-2"],
+            False,
+        )
+        await service.calculate_fixture_scores(fixture_id)
+        await database.save_prediction(
+            fixture_id,
+            "222",
+            "Pending User",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+
+        async def raise_recalc_error(*_args, **_kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(
+            predictions_module, "_recalculate_scores_in_connection", raise_recalc_error
+        )
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await service.approve_partial_prediction(fixture_id, "222", "admin-1")
+
+        prediction = await database.get_prediction(fixture_id, "222")
+        assert prediction is not None
+        assert prediction["pending_partial_approval"] is True
+        assert prediction["is_late"] == 1
+        assert prediction["admin_edited_by"] is None
+
+    @pytest.mark.asyncio
     async def test_reject_partial_prediction_recalculates_scored_fixture(
         self,
         database,
@@ -533,3 +579,48 @@ class TestPartialPredictionApproval:
         assert prediction["pending_partial_approval"] is True
         assert recalculation is not None
         assert await database.get_prediction(fixture_id, "222") is None
+
+    @pytest.mark.asyncio
+    async def test_reject_partial_prediction_rolls_back_if_recalculation_fails(
+        self,
+        database,
+        sample_games,
+        monkeypatch,
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            6, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
+        await database.save_prediction(
+            fixture_id,
+            "111",
+            "Full User",
+            ["2-1", "1-1", "0-2"],
+            False,
+        )
+        await service.calculate_fixture_scores(fixture_id)
+        await database.save_prediction(
+            fixture_id,
+            "222",
+            "Pending User",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+
+        async def raise_recalc_error(*_args, **_kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(
+            predictions_module, "_recalculate_scores_in_connection", raise_recalc_error
+        )
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await service.reject_partial_prediction(fixture_id, "222")
+
+        prediction = await database.get_prediction(fixture_id, "222")
+        assert prediction is not None
+        assert prediction["pending_partial_approval"] is True
+        assert prediction["is_late"] == 1

--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -74,6 +74,7 @@ class TestOnMessage:
         assert result is False
         assert len(mock_message.reactions_added) == 0
         assert len(mock_message.author.dm_sent) == 0
+        assert handler.get_thread_prediction_cooldown("123456") is None
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("fixture_with_thread")
@@ -88,6 +89,7 @@ class TestOnMessage:
         assert "❌" in mock_message.reactions_added
         assert len(mock_message.author.dm_sent) == 1
         assert "Invalid predictions" in mock_message.author.dm_sent[0]
+        assert handler.get_thread_prediction_cooldown("123456") is not None
 
     @pytest.mark.asyncio
     async def test_saves_valid_predictions(self, handler, fixture_with_thread, mock_message):
@@ -230,6 +232,74 @@ class TestOnMessage:
         assert predictions[0]["predictions"] == ["2-1", "1-1", "0-2"]
         assert second_message.reactions_added == []
         assert second_message.author.dm_sent == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_thread")
+    async def test_chatty_message_does_not_consume_next_prediction_cooldown(
+        self, handler, mock_message
+    ):
+        mock_message.channel.id = 789012
+        mock_message.content = "Anyone backing an upset here?"
+
+        first = await handler.on_message(mock_message)
+
+        prediction_message = type(mock_message)(
+            content="Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2",
+            message_id="777779",
+            author=mock_message.author,
+            channel=mock_message.channel,
+            guild=mock_message.guild,
+        )
+        prediction_message.channel.id = 789012
+        second = await handler.on_message(prediction_message)
+
+        assert first is False
+        assert second is True
+        assert "✅" in prediction_message.reactions_added
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_thread")
+    async def test_invalid_prediction_consumes_cooldown(self, handler, mock_message):
+        mock_message.channel.id = 789012
+        mock_message.content = "Team A - Team B invalid\nTeam C - Team D 1-1"
+
+        first = await handler.on_message(mock_message)
+
+        retry_message = type(mock_message)(
+            content="Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2",
+            message_id="777780",
+            author=mock_message.author,
+            channel=mock_message.channel,
+            guild=mock_message.guild,
+        )
+        retry_message.channel.id = 789012
+        second = await handler.on_message(retry_message)
+
+        assert first is True
+        assert second is True
+        assert retry_message.reactions_added == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_thread")
+    async def test_oversized_message_consumes_cooldown(self, handler, mock_message):
+        mock_message.channel.id = 789012
+        mock_message.content = "x" * 5001
+
+        first = await handler.on_message(mock_message)
+
+        retry_message = type(mock_message)(
+            content="Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2",
+            message_id="777781",
+            author=mock_message.author,
+            channel=mock_message.channel,
+            guild=mock_message.guild,
+        )
+        retry_message.channel.id = 789012
+        second = await handler.on_message(retry_message)
+
+        assert first is True
+        assert second is True
+        assert retry_message.reactions_added == []
 
     def test_cleanup_expired_state_removes_stale_cooldowns(self, handler):
         handler.record_thread_prediction_attempt("user-1", datetime.now(UTC) - timedelta(hours=2))

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -391,6 +391,105 @@ class TestPredictCommand:
             "Something went wrong while saving your prediction"
             in mock_interaction.response_sent[-1]["content"]
         )
+        thread = user_commands.bot.get_channel(700001)
+        thread.message_objects[1].delete.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_dm")
+    async def test_predict_modal_reports_missing_prediction_thread(
+        self, user_commands, mock_interaction
+    ):
+        await user_commands.predict.callback(user_commands, mock_interaction)
+
+        modal = mock_interaction.modal_sent["modal"]
+        modal.predictions_input._value = (
+            "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+        )
+        await modal.on_submit(mock_interaction)
+
+        assert (
+            "does not have a usable prediction thread"
+            in mock_interaction.response_sent[-1]["content"]
+        )
+        assert await user_commands.db.get_prediction(1, str(mock_interaction.user.id)) is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_dm")
+    async def test_predict_modal_uses_fetch_channel_fallback(
+        self, user_commands, mock_interaction, database
+    ):
+        thread = MockThread(thread_id="700001", name="week-1", guild=mock_interaction.guild)
+        await database.update_fixture_announcement(1, message_id="700001", channel_id="123456")
+        user_commands.bot.get_channel.return_value = None
+        user_commands.bot.fetch_channel = AsyncMock(return_value=thread)
+
+        await user_commands.predict.callback(user_commands, mock_interaction)
+
+        modal = mock_interaction.modal_sent["modal"]
+        modal.predictions_input._value = (
+            "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+        )
+        await modal.on_submit(mock_interaction)
+
+        assert await database.get_prediction(1, str(mock_interaction.user.id)) is not None
+        user_commands.bot.fetch_channel.assert_awaited_once_with(700001)
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_dm")
+    async def test_predict_modal_reports_thread_post_failure(
+        self, user_commands, mock_interaction, database, monkeypatch
+    ):
+        await _attach_prediction_threads(user_commands, database, [1], mock_interaction.guild)
+        thread = user_commands.bot.get_channel(700001)
+
+        import discord
+
+        async def raise_http_exception(*_args, **_kwargs):
+            raise discord.HTTPException(response=AsyncMock(status=500), message="boom")
+
+        monkeypatch.setattr(thread, "send", raise_http_exception)
+
+        await user_commands.predict.callback(user_commands, mock_interaction)
+        modal = mock_interaction.modal_sent["modal"]
+        modal.predictions_input._value = (
+            "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+        )
+        await modal.on_submit(mock_interaction)
+
+        assert (
+            "does not have a usable prediction thread"
+            in mock_interaction.response_sent[-1]["content"]
+        )
+        assert await database.get_prediction(1, str(mock_interaction.user.id)) is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("fixture_with_dm")
+    async def test_predict_modal_deletes_public_post_if_fixture_closes_during_save(
+        self, user_commands, mock_interaction, monkeypatch
+    ):
+        await _attach_prediction_threads(
+            user_commands, user_commands.db, [1], mock_interaction.guild
+        )
+        await user_commands.predict.callback(user_commands, mock_interaction)
+
+        modal = mock_interaction.modal_sent["modal"]
+        modal.predictions_input._value = (
+            "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+        )
+        monkeypatch.setattr(
+            user_commands.db,
+            "save_prediction_guarded",
+            AsyncMock(return_value=SaveResult.FIXTURE_CLOSED),
+        )
+
+        await modal.on_submit(mock_interaction)
+
+        thread = user_commands.bot.get_channel(700001)
+        thread.message_objects[1].delete.assert_awaited_once()
+        assert (
+            "closed before your prediction could be saved"
+            in mock_interaction.response_sent[-1]["content"]
+        )
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("fixture_with_dm")

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -51,8 +51,8 @@ class TyperBot(commands.Bot):
         """Route inbound messages through thread handling or the normal cog pipeline.
 
         Thread predictions run first so public fixture threads behave like a
-        dedicated submission surface. All other messages, including DMs, fall
-        back to the normal command/cog pipeline.
+        dedicated submission surface. All other messages fall back to the normal
+        command/cog pipeline.
         """
         if message.author.bot:
             return

--- a/typer_bot/commands/admin_panel/modals.py
+++ b/typer_bot/commands/admin_panel/modals.py
@@ -152,7 +152,7 @@ class CreateFixtureConfirmView(discord.ui.View):
                 )
                 await thread.send(
                     "💬 **Post your predictions here!**\n"
-                    "Reply with your scores (one per line or comma-separated).\n"
+                    "Reply with one line per match. For partial updates, include the game name on each line.\n"
                     "Predictions are one-shot here. To change one, use `/predict`."
                 )
             except Exception:
@@ -322,7 +322,7 @@ class EnterResultsConfirmView(discord.ui.View):
 
 
 class EnterResultsModal(discord.ui.Modal):
-    """Collect results for an open fixture without starting a DM session.
+    """Collect results for an open fixture in one modal.
 
     Parse failures are returned ephemerally, and nothing is persisted until the
     follow-up confirm view succeeds.

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -313,7 +313,7 @@ class FixtureSelectView(PaginatedFixtureView):
 
 
 class PredictModal(discord.ui.Modal):
-    """Collect predictions for one fixture through a modal instead of DMs.
+    """Collect predictions for one fixture in one modal.
 
     Submitting can overwrite an existing open prediction, late submissions are
     accepted but marked late, and successful saves can chain into a follow-up

--- a/typer_bot/database/connection.py
+++ b/typer_bot/database/connection.py
@@ -216,7 +216,7 @@ class Database:
             await _migrate_prediction_columns(db)
             await _migrate_results_table(db)
 
-            # Legacy DBs create this during migration; fresh installs skip that path.
+            # Keep one results row per fixture on both fresh installs and upgraded DBs.
             await db.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS idx_results_fixture_id_unique ON results(fixture_id)"
             )

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -54,6 +54,13 @@ class ThreadPredictionHandler:
 
         return previous_attempt
 
+    def is_rate_limited(self, user_id: str, current_time: datetime) -> bool:
+        """Return whether a recognized prediction attempt should be rate limited."""
+        last_time = self._thread_prediction_cooldowns.get(user_id)
+        if last_time is None:
+            return False
+        return (current_time - last_time).total_seconds() < PREDICTION_RATE_LIMIT_SECONDS
+
     def get_thread_prediction_cooldown(self, user_id: str) -> datetime | None:
         return self._thread_prediction_cooldowns.get(user_id)
 
@@ -93,15 +100,18 @@ class ThreadPredictionHandler:
             week_number=fixture["week_number"],
             source="thread",
         ):
-            # Update and check the cooldown in one step so rapid reposts cannot race each other.
             current_time = now()
-            last_time = self.record_thread_prediction_attempt(user_id, current_time)
-            if (
-                last_time
-                and (current_time - last_time).total_seconds() < PREDICTION_RATE_LIMIT_SECONDS
-            ):
-                logger.debug(f"Rate limiting prediction from {user_id}")
-                return True
+            has_score_like_content = any(
+                re.search(r"(\d+\s*[-:]\s*\d+|[xX])\s*$", line.strip())
+                for line in message.content.splitlines()
+            )
+
+            if len(message.content) > MAX_MESSAGE_LENGTH or has_score_like_content:
+                if self.is_rate_limited(user_id, current_time):
+                    logger.debug(f"Rate limiting prediction from {user_id}")
+                    return True
+
+                self.record_thread_prediction_attempt(user_id, current_time)
 
             if len(message.content) > MAX_MESSAGE_LENGTH:
                 await self._handle_error(
@@ -110,10 +120,7 @@ class ThreadPredictionHandler:
                 )
                 return True
 
-            if not any(
-                re.search(r"(\d+\s*[-:]\s*\d+|[xX])\s*$", line.strip())
-                for line in message.content.splitlines()
-            ):
+            if not has_score_like_content:
                 logger.debug(
                     f"Ignoring message with no score-like content from {message.author.id}"
                 )
@@ -151,7 +158,6 @@ class ThreadPredictionHandler:
                 logger.debug(f"Ignoring message with no valid scores from {message.author.id}")
                 return False
 
-            current_time = now()
             is_late = current_time > fixture["deadline"]
             is_partial = len(predicted_game_indexes) < len(fixture["games"])
             pending_partial_approval = is_late and is_partial


### PR DESCRIPTION
## Summary
- fix thread prediction cooldown handling so chatter does not block a valid retry, but malformed or oversized prediction attempts still hit the 1-second guard
- add rollback coverage for late partial approval and rejection plus `/predict` failure-path coverage around thread lookup, posting, and save cleanup
- trim README and AGENTS wording to keep the docs focused on the current contract without extra narration

## Testing
- `uv run pytest tests/test_thread_prediction_handler.py tests/test_admin_service.py tests/test_user_commands.py --tb=short`
- `uv run ruff check README.md AGENTS.md typer_bot/handlers/thread_prediction_handler.py tests/test_thread_prediction_handler.py tests/test_admin_service.py tests/test_user_commands.py typer_bot/bot.py typer_bot/commands/admin_panel/modals.py typer_bot/commands/user_commands.py typer_bot/database/connection.py`
- `uv run ty check typer_bot`
