### PR TITLE
feat: add fixture guild ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ Routine host migration is a direct copy of the live SQLite file at `DB_PATH` (de
 
 If you override `DB_PATH` or `BACKUP_DIR`, keep them on the persistent volume too.
 
+Before deploying v2.0.0 over an existing v1.x database, back up the live database and assign all existing fixtures to your current Discord guild:
+
+```sql
+ALTER TABLE fixtures ADD COLUMN guild_id TEXT;
+UPDATE fixtures SET guild_id = '<your guild id>' WHERE guild_id IS NULL OR TRIM(guild_id) = '';
+SELECT COUNT(*) FROM fixtures WHERE guild_id IS NULL OR TRIM(guild_id) = '';
+```
+
+The final query must return `0`. TyperBot refuses to start if any fixture has no guild owner.
+
 ## Running locally
 
 Local runs default to `ENVIRONMENT=development`, `DATA_DIR=./data`, and `TZ=UTC`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,7 +207,7 @@ def sample_predictions():
 @pytest.fixture
 async def fixture_with_thread(database, sample_games):
     deadline = datetime.now(UTC) + timedelta(days=1)
-    fixture_id = await database.create_fixture(1, sample_games, deadline)
+    fixture_id = await database.create_fixture("111111", 1, sample_games, deadline)
     await database.update_fixture_announcement(fixture_id, message_id="789012", channel_id="123456")
     fixture = await database.get_fixture_by_id(fixture_id)
     yield fixture
@@ -217,7 +217,7 @@ async def fixture_with_thread(database, sample_games):
 async def fixture_with_dm(database, sample_games):
     """Fixture for DM prediction tests (no thread needed)."""
     deadline = datetime.now(UTC) + timedelta(days=1)
-    fixture_id = await database.create_fixture(1, sample_games, deadline)
+    fixture_id = await database.create_fixture("111111", 1, sample_games, deadline)
     fixture = await database.get_fixture_by_id(fixture_id)
     yield fixture
 
@@ -290,6 +290,7 @@ class MockInteraction:
     ):
         self.user = user or MockUser()
         self.guild = guild
+        self.guild_id = guild.id if guild is not None else None
         self.channel = channel
         self.response_sent = []
         self.followup_sent = []

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -95,7 +95,9 @@ class TestAdminPanelCommand:
         mock_interaction_admin,
         sample_games,
     ):
-        await admin_cog.db.create_fixture(5, sample_games, datetime.now(UTC) + timedelta(days=1))
+        await admin_cog.db.create_fixture(
+            "111111", 5, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
         modal = CreateFixtureModal(
             admin_cog.db, mock_interaction_admin.channel, str(mock_interaction_admin.user.id)
         )
@@ -334,7 +336,9 @@ class TestAdminPanelCommand:
         modal.deadline_input._value = "2026-04-20 18:00"
 
         await modal.on_submit(mock_interaction_admin)
-        await admin_cog.db.create_fixture(1, sample_games, datetime.now(UTC) + timedelta(days=1))
+        await admin_cog.db.create_fixture(
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
 
         confirm_view = mock_interaction_admin.response_sent[-1]["view"]
         confirm_button = next(
@@ -456,7 +460,9 @@ class TestPredictionPanelFlows:
         mock_interaction_admin,
         sample_games,
     ):
-        await admin_cog.db.create_fixture(1, sample_games, datetime.now(UTC) + timedelta(days=1))
+        await admin_cog.db.create_fixture(
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
 
         unified_view = UnifiedAdminPanelView(
             admin_cog.db,
@@ -479,7 +485,7 @@ class TestPredictionPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -528,7 +534,7 @@ class TestPredictionPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            10, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 10, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
 
         view = PredictionsPanelView(
@@ -554,7 +560,7 @@ class TestPredictionPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            17, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 17, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         for index in range(30):
             await admin_cog.db.save_prediction(
@@ -592,7 +598,7 @@ class TestPredictionPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            19, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 19, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         for index in range(26):
             await admin_cog.db.save_prediction(
@@ -625,7 +631,7 @@ class TestPredictionPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            22, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 22, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         for index in range(26):
             await admin_cog.db.save_prediction(
@@ -666,7 +672,7 @@ class TestPredictionPanelFlows:
             for index in range(1, 21)
         ]
         fixture_id = await admin_cog.db.create_fixture(
-            20, games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 20, games, datetime.now(UTC) + timedelta(days=1)
         )
         for index in range(26):
             await admin_cog.db.save_prediction(
@@ -699,7 +705,7 @@ class TestPredictionPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -736,7 +742,7 @@ class TestPredictionPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            34, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 34, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -773,7 +779,7 @@ class TestPredictionPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            35, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 35, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -809,7 +815,7 @@ class TestPredictionPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            40, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 40, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -846,7 +852,7 @@ class TestPredictionPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            13, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 13, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -881,7 +887,7 @@ class TestPredictionPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            11, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 11, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -916,7 +922,7 @@ class TestPredictionPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            2, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 2, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -960,7 +966,7 @@ class TestPredictionPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            18, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 18, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -1003,7 +1009,9 @@ class TestFixturePanelFlows:
         mock_interaction_admin,
         sample_games,
     ):
-        await admin_cog.db.create_fixture(4, sample_games, datetime.now(UTC) + timedelta(days=1))
+        await admin_cog.db.create_fixture(
+            "111111", 4, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
 
         view = UnifiedAdminPanelView(
             admin_cog.db,
@@ -1025,7 +1033,7 @@ class TestFixturePanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            5, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 5, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
 
         view = FixturesPanelView(
@@ -1050,7 +1058,7 @@ class TestFixturePanelFlows:
     ):
         """Deletion confirmation must show game list so admin can verify the right fixture."""
         fixture_id = await admin_cog.db.create_fixture(
-            6, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 6, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
 
         view = UnifiedAdminPanelView(
@@ -1144,7 +1152,7 @@ class TestFixturePanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            55, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 55, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -1175,7 +1183,7 @@ class TestFixturePanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            56, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 56, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -1212,10 +1220,10 @@ class TestFixturePanelFlows:
         sample_games,
     ):
         fixture_a = await admin_cog.db.create_fixture(
-            57, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 57, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         fixture_b = await admin_cog.db.create_fixture(
-            58, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 58, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_a,
@@ -1307,7 +1315,7 @@ class TestFixturePanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            44, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 44, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         view = UnifiedAdminPanelView(
             admin_cog.db,
@@ -1333,7 +1341,7 @@ class TestFixturePanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            46, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 46, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
         view = UnifiedAdminPanelView(
@@ -1360,7 +1368,7 @@ class TestFixturePanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            45, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 45, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["2-1", "1-1", "0-2"])
         await admin_cog.db.save_prediction(
@@ -1405,7 +1413,7 @@ class TestFixturePanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            47, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 47, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         admin_cog.record_calculate_cooldown(
             str(mock_interaction_admin.user.id), current_time=now().timestamp()
@@ -1436,7 +1444,7 @@ class TestFixturePanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            48, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 48, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         admin_cog.service.calculate_fixture_scores = AsyncMock(
             side_effect=ValueError("No results entered")
@@ -1518,7 +1526,7 @@ class TestFixturePanelFlows:
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
         for week in range(1, 28):
-            await admin_cog.db.create_fixture(week, sample_games, deadline)
+            await admin_cog.db.create_fixture("111111", week, sample_games, deadline)
 
         view = UnifiedAdminPanelView(
             admin_cog.db,
@@ -1572,8 +1580,8 @@ class TestFixturePanelFlows:
         sample_games,
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
-        await admin_cog.db.create_fixture(5, sample_games, deadline)
-        await admin_cog.db.create_fixture(5, sample_games, deadline)
+        await admin_cog.db.create_fixture("111111", 5, sample_games, deadline)
+        await admin_cog.db.create_fixture("111111", 5, sample_games, deadline)
 
         view = UnifiedAdminPanelView(
             admin_cog.db,
@@ -1645,7 +1653,7 @@ class TestFixturePanelFlows:
     ):
         """Silent DB failures surface as a visible error instead of timing out the interaction."""
         fixture_id = await admin_cog.db.create_fixture(
-            7, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 7, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
 
         db_mock = AsyncMock(spec=Database)
@@ -1726,7 +1734,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            3, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 3, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
 
@@ -1756,7 +1764,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            4, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 4, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
 
@@ -1784,7 +1792,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            5, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 5, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
 
         view = ResultsPanelView(
@@ -1813,7 +1821,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            14, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 14, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
 
@@ -1840,7 +1848,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            23, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 23, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         view = ResultsPanelView(
             admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
@@ -1864,7 +1872,7 @@ class TestResultsPanelFlows:
             for index in range(1, 101)
         ]
         fixture_id = await admin_cog.db.create_fixture(
-            12, games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 12, games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["1-0"] * len(games))
 
@@ -1887,7 +1895,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            32, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 32, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -1934,7 +1942,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            33, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 33, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -1975,7 +1983,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            50, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 50, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -2012,7 +2020,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            51, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 51, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -2056,7 +2064,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            52, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 52, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -2097,7 +2105,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            70, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 70, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.update_fixture_announcement(
             fixture_id,
@@ -2151,7 +2159,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            72, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 72, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.update_fixture_announcement(
             fixture_id,
@@ -2205,7 +2213,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            71, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 71, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.update_fixture_announcement(
             fixture_id,
@@ -2265,7 +2273,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            73, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 73, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.update_fixture_announcement(
             fixture_id,
@@ -2325,7 +2333,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            74, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 74, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.update_fixture_announcement(
             fixture_id,
@@ -2375,7 +2383,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            53, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 53, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["2-1", "1-1", "0-2"])
         await admin_cog.db.save_prediction(
@@ -2425,7 +2433,7 @@ class TestResultsPanelFlows:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            54, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 54, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["2-1", "1-1", "0-2"])
         await admin_cog.db.save_prediction(
@@ -2483,7 +2491,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            24, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 24, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
         assert fixture is not None
@@ -2502,7 +2510,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            25, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 25, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
         assert fixture is not None
@@ -2522,7 +2530,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            28, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 28, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
         assert fixture is not None
@@ -2544,7 +2552,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            26, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 26, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
         assert fixture is not None
@@ -2573,7 +2581,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            30, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 30, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
         assert fixture is not None
@@ -2601,7 +2609,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            31, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 31, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
         assert fixture is not None
@@ -2641,7 +2649,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            27, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 27, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
         assert fixture is not None
@@ -2668,7 +2676,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            29, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 29, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
         assert fixture is not None
@@ -2700,7 +2708,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -2741,7 +2749,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            9, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 9, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -2774,7 +2782,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            15, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 15, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -2818,7 +2826,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            36, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 36, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -2863,7 +2871,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            37, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 37, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -2909,7 +2917,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            41, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 41, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -2954,7 +2962,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            21, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 21, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_prediction(
             fixture_id,
@@ -2998,7 +3006,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            2, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 2, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
         view = ResultsPanelView(
@@ -3027,7 +3035,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            6, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 6, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
         view = ResultsPanelView(
@@ -3055,7 +3063,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            7, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 7, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
         view = ResultsPanelView(
@@ -3081,7 +3089,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            16, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 16, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
         view = ResultsPanelView(
@@ -3113,7 +3121,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            38, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 38, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
         await admin_cog.db.save_prediction(
@@ -3151,7 +3159,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            39, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 39, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
         await admin_cog.db.save_prediction(
@@ -3186,7 +3194,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            42, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 42, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
         await admin_cog.db.save_prediction(
@@ -3224,7 +3232,7 @@ class TestAdminPanelModals:
         sample_games,
     ):
         fixture_id = await admin_cog.db.create_fixture(
-            43, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 43, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
         await admin_cog.db.save_prediction(

--- a/tests/test_admin_service.py
+++ b/tests/test_admin_service.py
@@ -27,7 +27,7 @@ class TestLatePenaltyWaiver:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            1, sample_games, datetime.now(UTC) - timedelta(hours=2)
+            "111111", 1, sample_games, datetime.now(UTC) - timedelta(hours=2)
         )
 
         await database.save_prediction(
@@ -64,7 +64,7 @@ class TestLatePenaltyWaiver:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            1, sample_games, datetime.now(UTC) - timedelta(hours=2)
+            "111111", 1, sample_games, datetime.now(UTC) - timedelta(hours=2)
         )
 
         await database.save_prediction(
@@ -106,7 +106,7 @@ class TestAdminFlowErrors:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
 
         with pytest.raises(NoPredictionsSavedError):
@@ -118,7 +118,7 @@ class TestAdminFlowErrors:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
 
         with pytest.raises(PredictionNotFoundError):
@@ -135,7 +135,7 @@ class TestAdminFlowErrors:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            1, sample_games, datetime.now(UTC) - timedelta(hours=2)
+            "111111", 1, sample_games, datetime.now(UTC) - timedelta(hours=2)
         )
         await database.save_prediction(
             fixture_id,
@@ -170,7 +170,7 @@ class TestPredictionReplacement:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
 
         await database.save_prediction(
@@ -208,7 +208,7 @@ class TestPredictionReplacement:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
 
         await database.save_prediction(
@@ -249,7 +249,7 @@ class TestPredictionReplacement:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
 
         await database.save_prediction(
@@ -290,10 +290,10 @@ class TestResultCorrection:
     ):
         service = AdminService(database)
         fixture1_id = await database.create_fixture(
-            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         fixture2_id = await database.create_fixture(
-            2, sample_games, datetime.now(UTC) + timedelta(days=2)
+            "111111", 2, sample_games, datetime.now(UTC) + timedelta(days=2)
         )
 
         await database.save_prediction(
@@ -362,7 +362,7 @@ class TestResultCorrection:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await database.save_prediction(
             fixture_id,
@@ -397,7 +397,7 @@ class TestPartialPredictionApproval:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            3, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 3, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
         await database.save_prediction(
@@ -429,7 +429,7 @@ class TestPartialPredictionApproval:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            4, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 4, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
         await database.save_prediction(
@@ -464,7 +464,7 @@ class TestPartialPredictionApproval:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            5, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 5, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
         await database.save_prediction(
@@ -505,7 +505,7 @@ class TestPartialPredictionApproval:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            5, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 5, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
         await database.save_prediction(
@@ -550,7 +550,7 @@ class TestPartialPredictionApproval:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            6, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 6, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
         await database.save_prediction(
@@ -589,7 +589,7 @@ class TestPartialPredictionApproval:
     ):
         service = AdminService(database)
         fixture_id = await database.create_fixture(
-            6, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 6, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
         await database.save_prediction(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -29,7 +29,7 @@ class TestGetMaxWeekNumber:
         db = Database(temp_db_path)
         await db.initialize()
 
-        result = await db.get_max_week_number()
+        result = await db.get_max_week_number("111111")
         assert result == 0
 
     @pytest.mark.asyncio
@@ -38,11 +38,11 @@ class TestGetMaxWeekNumber:
         db = Database(temp_db_path)
         await db.initialize()
 
-        await db.create_fixture(1, ["Team A - Team B"], datetime.now(UTC))
-        await db.create_fixture(3, ["Team C - Team D"], datetime.now(UTC))
-        await db.create_fixture(5, ["Team E - Team F"], datetime.now(UTC))
+        await db.create_fixture("111111", 1, ["Team A - Team B"], datetime.now(UTC))
+        await db.create_fixture("111111", 3, ["Team C - Team D"], datetime.now(UTC))
+        await db.create_fixture("111111", 5, ["Team E - Team F"], datetime.now(UTC))
 
-        result = await db.get_max_week_number()
+        result = await db.get_max_week_number("111111")
         assert result == 5
 
     @pytest.mark.asyncio
@@ -51,7 +51,7 @@ class TestGetMaxWeekNumber:
         db = Database(temp_db_path)
         await db.initialize()
 
-        fixture_id = await db.create_fixture(10, ["Team A - Team B"], datetime.now(UTC))
+        fixture_id = await db.create_fixture("111111", 10, ["Team A - Team B"], datetime.now(UTC))
         await db.save_scores(
             fixture_id,
             [
@@ -65,9 +65,9 @@ class TestGetMaxWeekNumber:
             ],
         )
 
-        await db.create_fixture(5, ["Team C - Team D"], datetime.now(UTC))
+        await db.create_fixture("111111", 5, ["Team C - Team D"], datetime.now(UTC))
 
-        result = await db.get_max_week_number()
+        result = await db.get_max_week_number("111111")
         assert result == 10
 
 
@@ -80,9 +80,15 @@ class TestOpenFixturesQueries:
         db = Database(temp_db_path)
         await db.initialize()
 
-        fixture_week_2 = await db.create_fixture(2, ["Team C - Team D"], datetime.now(UTC))
-        fixture_week_1 = await db.create_fixture(1, ["Team A - Team B"], datetime.now(UTC))
-        fixture_week_3 = await db.create_fixture(3, ["Team E - Team F"], datetime.now(UTC))
+        fixture_week_2 = await db.create_fixture(
+            "111111", 2, ["Team C - Team D"], datetime.now(UTC)
+        )
+        fixture_week_1 = await db.create_fixture(
+            "111111", 1, ["Team A - Team B"], datetime.now(UTC)
+        )
+        fixture_week_3 = await db.create_fixture(
+            "111111", 3, ["Team E - Team F"], datetime.now(UTC)
+        )
 
         # Close week 3 fixture so only weeks 1 and 2 remain open
         await db.save_scores(fixture_week_3, [])
@@ -101,8 +107,12 @@ class TestOpenFixturesQueries:
         db = Database(temp_db_path)
         await db.initialize()
 
-        open_fixture_id = await db.create_fixture(7, ["Team A - Team B"], datetime.now(UTC))
-        closed_fixture_id = await db.create_fixture(8, ["Team C - Team D"], datetime.now(UTC))
+        open_fixture_id = await db.create_fixture(
+            "111111", 7, ["Team A - Team B"], datetime.now(UTC)
+        )
+        closed_fixture_id = await db.create_fixture(
+            "111111", 8, ["Team C - Team D"], datetime.now(UTC)
+        )
         await db.save_scores(closed_fixture_id, [])
 
         open_fixture = await db.get_open_fixture_by_week(7)
@@ -119,10 +129,12 @@ class TestOpenFixturesQueries:
         await db.initialize()
 
         fixture_one_id, week_one = await db.create_next_fixture(
+            "111111",
             ["Team A - Team B"],
             datetime.now(UTC),
         )
         fixture_two_id, week_two = await db.create_next_fixture(
+            "111111",
             ["Team C - Team D"],
             datetime.now(UTC),
         )
@@ -137,9 +149,83 @@ class TestOpenFixturesQueries:
         assert fixture_two is not None
         assert fixture_two["week_number"] == 2
 
+    @pytest.mark.asyncio
+    async def test_created_fixtures_store_guild_ownership(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+
+        fixture_id = await db.create_fixture(
+            "guild-2",
+            4,
+            ["Team A - Team B"],
+            datetime.now(UTC),
+        )
+
+        fixture = await db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+        assert fixture["guild_id"] == "guild-2"
+
+    @pytest.mark.asyncio
+    async def test_create_fixture_rejects_missing_guild_id(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+
+        with pytest.raises(ValueError, match="guild_id is required"):
+            await db.create_fixture("", 1, ["Team A - Team B"], datetime.now(UTC))
+
+    @pytest.mark.asyncio
+    async def test_create_next_fixture_rejects_missing_guild_id(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+
+        with pytest.raises(ValueError, match="guild_id is required"):
+            await db.create_next_fixture("", ["Team A - Team B"], datetime.now(UTC))
+
+    @pytest.mark.asyncio
+    async def test_create_next_fixture_allocates_weeks_per_guild(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+
+        _, guild_one_week = await db.create_next_fixture(
+            "111111",
+            ["Team A - Team B"],
+            datetime.now(UTC),
+        )
+        _, guild_two_week = await db.create_next_fixture(
+            "guild-2",
+            ["Team C - Team D"],
+            datetime.now(UTC),
+        )
+
+        assert guild_one_week == 1
+        assert guild_two_week == 1
+        assert await db.get_max_week_number("111111") == 1
+        assert await db.get_max_week_number("guild-2") == 1
+
 
 class TestSchemaMigration:
     """Test suite for automatic schema migration."""
+
+    @pytest.mark.asyncio
+    async def test_initialize_rejects_fixtures_without_guild_ownership(self, temp_db_path):
+        async with aiosqlite.connect(temp_db_path) as conn:
+            await conn.execute(
+                """
+                CREATE TABLE fixtures (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    week_number INTEGER NOT NULL,
+                    games TEXT NOT NULL,
+                    deadline DATETIME NOT NULL,
+                    status TEXT DEFAULT 'open'
+                )
+                """
+            )
+            await conn.commit()
+
+        db = Database(temp_db_path)
+
+        with pytest.raises(RuntimeError, match="fixtures.guild_id is missing"):
+            await db.initialize()
 
     @pytest.mark.asyncio
     async def test_initialize_adds_missing_columns(self, temp_db_path):
@@ -148,6 +234,7 @@ class TestSchemaMigration:
             await conn.execute("""
                 CREATE TABLE fixtures (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    guild_id TEXT NOT NULL,
                     week_number INTEGER NOT NULL,
                     games TEXT NOT NULL,
                     deadline DATETIME NOT NULL,
@@ -161,7 +248,7 @@ class TestSchemaMigration:
 
         await db.initialize()
 
-        await db.create_fixture(1, ["Team A - Team B"], datetime.now(UTC))
+        await db.create_fixture("111111", 1, ["Team A - Team B"], datetime.now(UTC))
         fixture = await db.get_current_fixture()
         assert fixture is not None
         assert "message_id" in fixture
@@ -174,6 +261,7 @@ class TestSchemaMigration:
                 """
                 CREATE TABLE fixtures (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    guild_id TEXT NOT NULL,
                     week_number INTEGER NOT NULL,
                     games TEXT NOT NULL,
                     deadline DATETIME NOT NULL,
@@ -206,7 +294,7 @@ class TestSchemaMigration:
                 """
             )
             await conn.execute(
-                "INSERT INTO fixtures (id, week_number, games, deadline, status) VALUES (1, 1, 'A - B', ?, 'open')",
+                "INSERT INTO fixtures (id, guild_id, week_number, games, deadline, status) VALUES (1, '111111', 1, 'A - B', ?, 'open')",
                 (datetime.now(UTC).isoformat(),),
             )
             await conn.execute(
@@ -251,6 +339,7 @@ class TestSchemaMigration:
                 """
                 CREATE TABLE fixtures (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    guild_id TEXT NOT NULL,
                     week_number INTEGER NOT NULL,
                     games TEXT NOT NULL,
                     deadline DATETIME NOT NULL,
@@ -283,7 +372,7 @@ class TestSchemaMigration:
                 """
             )
             await conn.execute(
-                "INSERT INTO fixtures (id, week_number, games, deadline, status) VALUES (1, 1, 'A - B', ?, 'open')",
+                "INSERT INTO fixtures (id, guild_id, week_number, games, deadline, status) VALUES (1, '111111', 1, 'A - B', ?, 'open')",
                 (datetime.now(UTC).isoformat(),),
             )
             await conn.execute(
@@ -316,13 +405,13 @@ async def prediction_db(temp_db_path):
 @pytest.fixture
 async def open_fixture_id(prediction_db):
     deadline = datetime.now(UTC) + timedelta(hours=1)
-    return await prediction_db.create_fixture(1, ["A - B", "C - D"], deadline)
+    return await prediction_db.create_fixture("111111", 1, ["A - B", "C - D"], deadline)
 
 
 @pytest.fixture
 async def closed_fixture_id(prediction_db):
     deadline = datetime.now(UTC) + timedelta(hours=1)
-    fixture_id = await prediction_db.create_fixture(2, ["A - B", "C - D"], deadline)
+    fixture_id = await prediction_db.create_fixture("111111", 2, ["A - B", "C - D"], deadline)
     async with aiosqlite.connect(prediction_db.db_path) as conn:
         await conn.execute("UPDATE fixtures SET status = 'closed' WHERE id = ?", (fixture_id,))
         await conn.commit()
@@ -464,8 +553,8 @@ class TestCreateNextFixtureConcurrency:
         await db.initialize()
 
         created = await asyncio.gather(
-            db.create_next_fixture(["A - B"], datetime.now(UTC)),
-            db.create_next_fixture(["C - D"], datetime.now(UTC)),
+            db.create_next_fixture("111111", ["A - B"], datetime.now(UTC)),
+            db.create_next_fixture("111111", ["C - D"], datetime.now(UTC)),
         )
 
         fixture_ids = [fixture_id for fixture_id, _week in created]
@@ -492,8 +581,8 @@ class TestRowToFixture:
 
         async with aiosqlite.connect(temp_db_path) as conn:
             await conn.execute(
-                "INSERT INTO fixtures (week_number, games, deadline, status) VALUES (?, ?, ?, ?)",
-                (99, "", "2030-01-01T00:00:00+00:00", "open"),
+                "INSERT INTO fixtures (guild_id, week_number, games, deadline, status) VALUES (?, ?, ?, ?, ?)",
+                ("111111", 99, "", "2030-01-01T00:00:00+00:00", "open"),
             )
             await conn.commit()
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -196,11 +196,27 @@ class TestOpenFixturesQueries:
             ["Team C - Team D"],
             datetime.now(UTC),
         )
+        guild_one_second_id = await db.create_fixture(
+            "111111",
+            2,
+            ["Team E - Team F"],
+            datetime.now(UTC),
+        )
+        await db.create_fixture(
+            "guild-2",
+            9,
+            ["Team G - Team H"],
+            datetime.now(UTC),
+        )
 
         assert guild_one_week == 1
         assert guild_two_week == 1
-        assert await db.get_max_week_number("111111") == 1
-        assert await db.get_max_week_number("guild-2") == 1
+        assert await db.get_max_week_number("111111") == 2
+        assert await db.get_max_week_number("guild-2") == 9
+
+        guild_one_second = await db.get_fixture_by_id(guild_one_second_id)
+        assert guild_one_second is not None
+        assert guild_one_second["guild_id"] == "111111"
 
 
 class TestSchemaMigration:
@@ -225,6 +241,33 @@ class TestSchemaMigration:
         db = Database(temp_db_path)
 
         with pytest.raises(RuntimeError, match="fixtures.guild_id is missing"):
+            await db.initialize()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("guild_id", [None, "", "   "])
+    async def test_initialize_rejects_blank_fixture_guild_ownership(self, temp_db_path, guild_id):
+        async with aiosqlite.connect(temp_db_path) as conn:
+            await conn.execute(
+                """
+                CREATE TABLE fixtures (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    guild_id TEXT,
+                    week_number INTEGER NOT NULL,
+                    games TEXT NOT NULL,
+                    deadline DATETIME NOT NULL,
+                    status TEXT DEFAULT 'open'
+                )
+                """
+            )
+            await conn.execute(
+                "INSERT INTO fixtures (guild_id, week_number, games, deadline, status) VALUES (?, 1, 'A - B', ?, 'open')",
+                (guild_id, datetime.now(UTC).isoformat()),
+            )
+            await conn.commit()
+
+        db = Database(temp_db_path)
+
+        with pytest.raises(RuntimeError, match="fixtures.guild_id has empty rows"):
             await db.initialize()
 
     @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,7 +13,7 @@ class TestFullWorkflow:
         """End-to-end workflow produces correct standings."""
         games = ["Team A - Team B", "Team C - Team D", "Team E - Team F"]
         deadline = datetime.now(UTC) + timedelta(days=1)
-        fixture_id = await database.create_fixture(1, games, deadline)
+        fixture_id = await database.create_fixture("111111", 1, games, deadline)
         await database.update_fixture_announcement(
             fixture_id, message_id="789012", channel_id="123456"
         )
@@ -59,7 +59,7 @@ class TestFullWorkflow:
         """Late predictions receive 0 points (100% penalty)."""
         games = ["Team A - Team B", "Team C - Team D", "Team E - Team F"]
         deadline = datetime.now(UTC) - timedelta(hours=1)
-        fixture_id = await database.create_fixture(1, games, deadline)
+        fixture_id = await database.create_fixture("111111", 1, games, deadline)
 
         await database.save_prediction(fixture_id, "user1", "User1", ["2-1", "1-1", "0-2"], True)
 
@@ -94,7 +94,7 @@ class TestFullWorkflow:
         """Re-submitting a prediction replaces the existing one (upsert behavior)."""
         games = ["Team A - Team B", "Team C - Team D"]
         deadline = datetime.now(UTC) + timedelta(days=1)
-        fixture_id = await database.create_fixture(1, games, deadline)
+        fixture_id = await database.create_fixture("111111", 1, games, deadline)
 
         await database.save_prediction(fixture_id, "user1", "User1", ["2-1", "1-0"], False)
         await database.save_prediction(fixture_id, "user1", "User1", ["3-0", "2-1"], False)
@@ -112,7 +112,7 @@ class TestEdgeCases:
         """Cascading deletion removes predictions and results."""
         games = ["Team A - Team B"]
         deadline = datetime.now(UTC) + timedelta(days=1)
-        fixture_id = await database.create_fixture(1, games, deadline)
+        fixture_id = await database.create_fixture("111111", 1, games, deadline)
 
         await database.save_prediction(fixture_id, "user1", "User1", "2-1", False)
         await database.save_results(fixture_id, ["2-1"])
@@ -127,7 +127,7 @@ class TestEdgeCases:
         """Standings accumulate across multiple fixtures."""
         games = ["Team A - Team B"]
         deadline = datetime.now(UTC) - timedelta(days=2)
-        fixture1_id = await database.create_fixture(1, games, deadline)
+        fixture1_id = await database.create_fixture("111111", 1, games, deadline)
         await database.save_prediction(fixture1_id, "user1", "User1", "2-1", False)
         await database.save_results(fixture1_id, ["2-1"])
         await database.save_scores(
@@ -144,7 +144,7 @@ class TestEdgeCases:
         )
 
         deadline = datetime.now(UTC) - timedelta(days=1)
-        fixture2_id = await database.create_fixture(2, games, deadline)
+        fixture2_id = await database.create_fixture("111111", 2, games, deadline)
         await database.save_prediction(fixture2_id, "user1", "User1", "1-0", False)
         await database.save_results(fixture2_id, ["1-0"])
         await database.save_scores(
@@ -170,10 +170,10 @@ class TestEdgeCases:
         games = ["Team A - Team B"]
         deadline = datetime.now(UTC) + timedelta(days=1)
 
-        await database.create_fixture(5, games, deadline)
-        await database.create_fixture(3, games, deadline)
+        await database.create_fixture("111111", 5, games, deadline)
+        await database.create_fixture("111111", 3, games, deadline)
 
-        max_week = await database.get_max_week_number()
+        max_week = await database.get_max_week_number("111111")
         assert max_week == 5
 
     @pytest.mark.asyncio
@@ -182,8 +182,8 @@ class TestEdgeCases:
         games = ["Team A - Team B", "Team C - Team D"]
         deadline = datetime.now(UTC) + timedelta(days=1)
 
-        fixture_one_id = await database.create_fixture(1, games, deadline)
-        fixture_two_id = await database.create_fixture(2, games, deadline)
+        fixture_one_id = await database.create_fixture("111111", 1, games, deadline)
+        fixture_two_id = await database.create_fixture("111111", 2, games, deadline)
 
         await database.save_prediction(fixture_one_id, "user1", "User1", ["2-1", "1-1"], False)
         await database.save_results(fixture_one_id, ["2-1", "1-1"])
@@ -219,7 +219,7 @@ class TestDatabaseIntegrity:
         """One prediction per user per fixture - re-submission replaces existing."""
         games = ["Team A - Team B"]
         deadline = datetime.now(UTC) + timedelta(days=1)
-        fixture_id = await database.create_fixture(1, games, deadline)
+        fixture_id = await database.create_fixture("111111", 1, games, deadline)
 
         await database.save_prediction(fixture_id, "user1", "User1", ["2-1"], False)
         await database.save_prediction(fixture_id, "user1", "User1", ["1-0"], False)
@@ -238,7 +238,7 @@ class TestUsernameChangeHandling:
         games = ["Team A - Team B"]
         deadline = datetime.now(UTC) - timedelta(days=2)
 
-        fixture1_id = await database.create_fixture(1, games, deadline)
+        fixture1_id = await database.create_fixture("111111", 1, games, deadline)
         await database.save_prediction(fixture1_id, "user1", "st4chu", ["2-1"], False)
         await database.save_results(fixture1_id, ["2-1"])
         await database.save_scores(
@@ -255,7 +255,7 @@ class TestUsernameChangeHandling:
         )
 
         deadline = datetime.now(UTC) - timedelta(days=1)
-        fixture2_id = await database.create_fixture(2, games, deadline)
+        fixture2_id = await database.create_fixture("111111", 2, games, deadline)
         await database.save_prediction(fixture2_id, "user1", "Stachu", ["1-0"], False)
         await database.save_results(fixture2_id, ["1-0"])
         await database.save_scores(
@@ -282,7 +282,9 @@ class TestUsernameChangeHandling:
         """Should show the most recent username from latest fixture."""
         games = ["Team A - Team B"]
 
-        fixture1_id = await database.create_fixture(1, games, datetime.now(UTC) - timedelta(days=3))
+        fixture1_id = await database.create_fixture(
+            "111111", 1, games, datetime.now(UTC) - timedelta(days=3)
+        )
         await database.save_results(fixture1_id, ["2-1"])
         await database.save_scores(
             fixture1_id,
@@ -297,7 +299,9 @@ class TestUsernameChangeHandling:
             ],
         )
 
-        fixture2_id = await database.create_fixture(2, games, datetime.now(UTC) - timedelta(days=2))
+        fixture2_id = await database.create_fixture(
+            "111111", 2, games, datetime.now(UTC) - timedelta(days=2)
+        )
         await database.save_results(fixture2_id, ["2-1"])
         await database.save_scores(
             fixture2_id,
@@ -312,7 +316,9 @@ class TestUsernameChangeHandling:
             ],
         )
 
-        fixture3_id = await database.create_fixture(3, games, datetime.now(UTC) - timedelta(days=1))
+        fixture3_id = await database.create_fixture(
+            "111111", 3, games, datetime.now(UTC) - timedelta(days=1)
+        )
         await database.save_results(fixture3_id, ["2-1"])
         await database.save_scores(
             fixture3_id,

--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -111,7 +111,7 @@ class TestOnMessage:
     async def test_marks_late_predictions(self, handler, database, mock_message, sample_games):
         """Should mark predictions as late when past deadline."""
         deadline = datetime.now(UTC) - timedelta(hours=1)
-        fixture_id = await database.create_fixture(1, sample_games, deadline)
+        fixture_id = await database.create_fixture("111111", 1, sample_games, deadline)
         await database.update_fixture_announcement(
             fixture_id, message_id="789012", channel_id="123456"
         )
@@ -153,7 +153,7 @@ class TestOnMessage:
         self, handler, database, mock_message, sample_games
     ):
         deadline = datetime.now(UTC) - timedelta(hours=1)
-        fixture_id = await database.create_fixture(1, sample_games, deadline)
+        fixture_id = await database.create_fixture("111111", 1, sample_games, deadline)
         await database.update_fixture_announcement(
             fixture_id, message_id="789012", channel_id="123456"
         )
@@ -454,7 +454,7 @@ class TestIntegration:
         from tests.conftest import MockMessage, MockUser
 
         deadline = datetime.now(UTC) + timedelta(days=1)
-        fixture_id = await database.create_fixture(1, sample_games, deadline)
+        fixture_id = await database.create_fixture("111111", 1, sample_games, deadline)
         await database.update_fixture_announcement(
             fixture_id, message_id="789012", channel_id="123456"
         )

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -58,8 +58,8 @@ class TestPredictCommand:
         self, user_commands, mock_interaction, database, sample_games
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
-        await database.create_fixture(1, sample_games, deadline)
-        await database.create_fixture(2, sample_games, deadline)
+        await database.create_fixture("111111", 1, sample_games, deadline)
+        await database.create_fixture("111111", 2, sample_games, deadline)
 
         await user_commands.predict.callback(user_commands, mock_interaction)
 
@@ -70,8 +70,8 @@ class TestPredictCommand:
         self, user_commands, mock_interaction, database, sample_games
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
-        await database.create_fixture(1, sample_games, deadline)
-        await database.create_fixture(2, sample_games, deadline)
+        await database.create_fixture("111111", 1, sample_games, deadline)
+        await database.create_fixture("111111", 2, sample_games, deadline)
 
         await user_commands.predict.callback(user_commands, mock_interaction)
 
@@ -88,7 +88,7 @@ class TestPredictCommand:
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
         for week in range(1, 27):
-            await database.create_fixture(week, sample_games, deadline)
+            await database.create_fixture("111111", week, sample_games, deadline)
 
         await user_commands.predict.callback(user_commands, mock_interaction)
 
@@ -144,7 +144,7 @@ class TestPredictCommand:
         self, user_commands, mock_interaction, database, sample_games
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
-        fixture_two_id = await database.create_fixture(2, sample_games, deadline)
+        fixture_two_id = await database.create_fixture("111111", 2, sample_games, deadline)
         await _attach_prediction_threads(
             user_commands, database, [1, fixture_two_id], mock_interaction.guild
         )
@@ -514,7 +514,7 @@ class TestPredictCommand:
         self, user_commands, mock_interaction, database, sample_games
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
-        fixture_two_id = await database.create_fixture(2, sample_games, deadline)
+        fixture_two_id = await database.create_fixture("111111", 2, sample_games, deadline)
         await _attach_prediction_threads(
             user_commands, database, [1, fixture_two_id], mock_interaction.guild
         )
@@ -542,8 +542,8 @@ class TestPredictCommand:
         self, user_commands, mock_interaction, database, sample_games
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
-        fixture_one_id = await database.create_fixture(1, sample_games, deadline)
-        fixture_two_id = await database.create_fixture(2, sample_games, deadline)
+        fixture_one_id = await database.create_fixture("111111", 1, sample_games, deadline)
+        fixture_two_id = await database.create_fixture("111111", 2, sample_games, deadline)
         await _attach_prediction_threads(
             user_commands, database, [fixture_one_id, fixture_two_id], mock_interaction.guild
         )
@@ -582,7 +582,9 @@ class TestPredictCommand:
         deadline = datetime.now(UTC) + timedelta(days=1)
         fixture_ids = []
         for week in range(1, 28):
-            fixture_ids.append(await database.create_fixture(week, sample_games, deadline))
+            fixture_ids.append(
+                await database.create_fixture("111111", week, sample_games, deadline)
+            )
         await _attach_prediction_threads(
             user_commands, database, fixture_ids, mock_interaction.guild
         )
@@ -620,8 +622,8 @@ class TestPredictCommand:
         self, user_commands, mock_interaction, database, sample_games
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
-        await database.create_fixture(1, sample_games, deadline)
-        await database.create_fixture(2, sample_games, deadline)
+        await database.create_fixture("111111", 1, sample_games, deadline)
+        await database.create_fixture("111111", 2, sample_games, deadline)
 
         await user_commands.predict.callback(user_commands, mock_interaction)
 
@@ -644,8 +646,8 @@ class TestPredictCommand:
         self, user_commands, mock_interaction, database, sample_games
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
-        await database.create_fixture(1, sample_games, deadline)
-        await database.create_fixture(2, sample_games, deadline)
+        await database.create_fixture("111111", 1, sample_games, deadline)
+        await database.create_fixture("111111", 2, sample_games, deadline)
 
         await user_commands.predict.callback(user_commands, mock_interaction)
 
@@ -674,8 +676,8 @@ class TestPredictCommand:
         self, user_commands, mock_interaction, database, sample_games
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
-        fixture_one_id = await database.create_fixture(1, sample_games, deadline)
-        fixture_two_id = await database.create_fixture(2, sample_games, deadline)
+        fixture_one_id = await database.create_fixture("111111", 1, sample_games, deadline)
+        fixture_two_id = await database.create_fixture("111111", 2, sample_games, deadline)
         await _attach_prediction_threads(
             user_commands, database, [fixture_one_id, fixture_two_id], mock_interaction.guild
         )
@@ -710,8 +712,8 @@ class TestPredictCommand:
         self, user_commands, mock_interaction, database, sample_games
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
-        fixture_one_id = await database.create_fixture(1, sample_games, deadline)
-        fixture_two_id = await database.create_fixture(2, sample_games, deadline)
+        fixture_one_id = await database.create_fixture("111111", 1, sample_games, deadline)
+        fixture_two_id = await database.create_fixture("111111", 2, sample_games, deadline)
         await _attach_prediction_threads(
             user_commands, database, [fixture_one_id, fixture_two_id], mock_interaction.guild
         )
@@ -759,7 +761,9 @@ class TestFixturesCommand:
     async def test_single_open_fixture_lists_games_and_deadline(
         self, user_commands, mock_interaction, database, sample_games
     ):
-        await database.create_fixture(1, sample_games, datetime.now(UTC) + timedelta(days=1))
+        await database.create_fixture(
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
 
         await user_commands.fixtures.callback(user_commands, mock_interaction)
 
@@ -774,8 +778,8 @@ class TestFixturesCommand:
         self, user_commands, mock_interaction, database, sample_games
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
-        await database.create_fixture(1, sample_games, deadline)
-        await database.create_fixture(2, sample_games, deadline)
+        await database.create_fixture("111111", 1, sample_games, deadline)
+        await database.create_fixture("111111", 2, sample_games, deadline)
 
         await user_commands.fixtures.callback(user_commands, mock_interaction)
 
@@ -840,7 +844,9 @@ class TestMyPredictionsCommand:
     async def test_single_fixture_without_prediction_shows_prompt(
         self, user_commands, mock_interaction, database, sample_games
     ):
-        await database.create_fixture(1, sample_games, datetime.now(UTC) + timedelta(days=1))
+        await database.create_fixture(
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
 
         await user_commands.my_predictions.callback(user_commands, mock_interaction)
 
@@ -853,7 +859,7 @@ class TestMyPredictionsCommand:
         self, user_commands, mock_interaction, database, sample_games
     ):
         fixture_id = await database.create_fixture(
-            1, sample_games, datetime.now(UTC) + timedelta(days=1)
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await database.save_prediction(
             fixture_id,
@@ -876,8 +882,8 @@ class TestMyPredictionsCommand:
         self, user_commands, mock_interaction, database, sample_games
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
-        fixture_week_1 = await database.create_fixture(1, sample_games, deadline)
-        await database.create_fixture(2, sample_games, deadline)
+        fixture_week_1 = await database.create_fixture("111111", 1, sample_games, deadline)
+        await database.create_fixture("111111", 2, sample_games, deadline)
         await database.save_prediction(
             fixture_week_1,
             str(mock_interaction.user.id),

--- a/typer_bot/commands/admin_panel/modals.py
+++ b/typer_bot/commands/admin_panel/modals.py
@@ -117,7 +117,11 @@ class CreateFixtureConfirmView(discord.ui.View):
             )
             return
 
-        fixture_id, allocated_week = await self.db.create_next_fixture(self.games, self.deadline)
+        fixture_id, allocated_week = await self.db.create_next_fixture(
+            str(interaction.guild_id),
+            self.games,
+            self.deadline,
+        )
         final_preview = _build_fixture_preview_text(allocated_week, self.games, self.deadline)
 
         created_text = f"**Week {allocated_week} Fixture Created!**\n\n{final_preview}"
@@ -225,7 +229,7 @@ class CreateFixtureModal(discord.ui.Modal):
             await interaction.response.send_message(str(exc), ephemeral=True)
             return
 
-        preview_week_number = await self.db.get_max_week_number() + 1
+        preview_week_number = await self.db.get_max_week_number(str(interaction.guild_id)) + 1
         preview = _build_fixture_preview_text(preview_week_number, games, deadline)
         open_fixtures = await self.db.get_open_fixtures()
         if open_fixtures:

--- a/typer_bot/database/connection.py
+++ b/typer_bot/database/connection.py
@@ -113,6 +113,23 @@ async def _migrate_prediction_columns(db: aiosqlite.Connection) -> None:
         await db.execute("ALTER TABLE predictions ADD COLUMN public_message_kind TEXT")
 
 
+async def _validate_fixture_guild_ownership(db: aiosqlite.Connection) -> None:
+    columns = await _table_columns(db, "fixtures")
+    if "guild_id" not in columns:
+        raise RuntimeError(
+            "fixtures.guild_id is missing. Run the one-time v2.0.0 guild ownership migration before starting the bot."
+        )
+
+    async with db.execute(
+        "SELECT COUNT(*) FROM fixtures WHERE guild_id IS NULL OR TRIM(guild_id) = ''"
+    ) as cursor:
+        row = await cursor.fetchone()
+    if row and row[0] > 0:
+        raise RuntimeError(
+            "fixtures.guild_id has empty rows. Backfill every fixture with the owning Discord guild ID before starting the bot."
+        )
+
+
 class Database:
     """Composition root for SQLite setup and the bot's stable data facade.
 
@@ -214,11 +231,7 @@ class Database:
                 logger.info("Adding channel_id column to fixtures table")
                 await db.execute("ALTER TABLE fixtures ADD COLUMN channel_id TEXT")
 
-            column_names = await _table_columns(db, "fixtures")
-            if "guild_id" not in column_names:
-                raise RuntimeError(
-                    "fixtures.guild_id is missing. Run the one-time v2.0.0 guild ownership migration before starting the bot."
-                )
+            await _validate_fixture_guild_ownership(db)
 
             await _migrate_prediction_columns(db)
             await _migrate_results_table(db)

--- a/typer_bot/database/connection.py
+++ b/typer_bot/database/connection.py
@@ -148,6 +148,7 @@ class Database:
             await db.execute("""
                 CREATE TABLE IF NOT EXISTS fixtures (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    guild_id TEXT NOT NULL,
                     week_number INTEGER NOT NULL,
                     games TEXT NOT NULL,
                     deadline DATETIME NOT NULL,
@@ -213,6 +214,12 @@ class Database:
                 logger.info("Adding channel_id column to fixtures table")
                 await db.execute("ALTER TABLE fixtures ADD COLUMN channel_id TEXT")
 
+            column_names = await _table_columns(db, "fixtures")
+            if "guild_id" not in column_names:
+                raise RuntimeError(
+                    "fixtures.guild_id is missing. Run the one-time v2.0.0 guild ownership migration before starting the bot."
+                )
+
             await _migrate_prediction_columns(db)
             await _migrate_results_table(db)
 
@@ -220,14 +227,20 @@ class Database:
             await db.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS idx_results_fixture_id_unique ON results(fixture_id)"
             )
+            await db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_fixtures_guild_status_week ON fixtures(guild_id, status, week_number)"
+            )
+            await db.execute(
+                "CREATE INDEX IF NOT EXISTS idx_fixtures_guild_week ON fixtures(guild_id, week_number)"
+            )
 
             await db.commit()
 
-    async def create_fixture(self, week_number, games, deadline):
-        return await self._fixtures.create_fixture(week_number, games, deadline)
+    async def create_fixture(self, guild_id, week_number, games, deadline):
+        return await self._fixtures.create_fixture(guild_id, week_number, games, deadline)
 
-    async def create_next_fixture(self, games, deadline):
-        return await self._fixtures.create_next_fixture(games, deadline)
+    async def create_next_fixture(self, guild_id, games, deadline):
+        return await self._fixtures.create_next_fixture(guild_id, games, deadline)
 
     async def get_current_fixture(self):
         return await self._fixtures.get_current_fixture()
@@ -250,8 +263,8 @@ class Database:
     async def get_fixture_by_message_id(self, message_id):
         return await self._fixtures.get_fixture_by_message_id(message_id)
 
-    async def get_max_week_number(self):
-        return await self._fixtures.get_max_week_number()
+    async def get_max_week_number(self, guild_id):
+        return await self._fixtures.get_max_week_number(guild_id)
 
     async def delete_fixture(self, fixture_id):
         return await self._fixtures.delete_fixture(fixture_id)

--- a/typer_bot/database/fixtures.py
+++ b/typer_bot/database/fixtures.py
@@ -11,6 +11,11 @@ from typer_bot.utils.config import DB_PATH
 logger = logging.getLogger(__name__)
 
 
+def _validate_guild_id(guild_id: str) -> None:
+    if not isinstance(guild_id, str) or not guild_id.strip():
+        raise ValueError("guild_id is required")
+
+
 class FixtureRepository:
     """CRUD for the fixtures table."""
 
@@ -25,6 +30,7 @@ class FixtureRepository:
         deadline_text = deadline_val if isinstance(deadline_val, str) else None
         return {
             "id": row_dict.get("id"),
+            "guild_id": row_dict.get("guild_id"),
             "week_number": row_dict.get("week_number"),
             "games": [g for g in games_text.split("\n") if g],
             "deadline": parse_iso(deadline_text) if deadline_text else None,
@@ -33,8 +39,15 @@ class FixtureRepository:
             "channel_id": row_dict.get("channel_id"),
         }
 
-    async def create_fixture(self, week_number: int, games: list[str], deadline) -> int:
+    async def create_fixture(
+        self,
+        guild_id: str,
+        week_number: int,
+        games: list[str],
+        deadline,
+    ) -> int:
         """Create a new fixture and return its ID."""
+        _validate_guild_id(guild_id)
         if deadline.tzinfo is None:
             from typer_bot.utils import APP_TZ
 
@@ -42,8 +55,8 @@ class FixtureRepository:
         start_time = time.perf_counter()
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
-                "INSERT INTO fixtures (week_number, games, deadline) VALUES (?, ?, ?)",
-                (week_number, "\n".join(games), deadline.isoformat()),
+                "INSERT INTO fixtures (guild_id, week_number, games, deadline) VALUES (?, ?, ?, ?)",
+                (guild_id, week_number, "\n".join(games), deadline.isoformat()),
             )
             await db.commit()
             if cursor.lastrowid is None:
@@ -62,12 +75,15 @@ class FixtureRepository:
             )
             return cursor.lastrowid
 
-    async def create_next_fixture(self, games: list[str], deadline) -> tuple[int, int]:
+    async def create_next_fixture(
+        self, guild_id: str, games: list[str], deadline
+    ) -> tuple[int, int]:
         """Create a new fixture with the next available week number atomically.
 
         Returns:
             Tuple of (fixture_id, allocated_week_number).
         """
+        _validate_guild_id(guild_id)
         if deadline.tzinfo is None:
             from typer_bot.utils import APP_TZ
 
@@ -78,14 +94,15 @@ class FixtureRepository:
             await db.execute("BEGIN IMMEDIATE")
             try:
                 async with db.execute(
-                    "SELECT COALESCE(MAX(week_number), 0) FROM fixtures"
+                    "SELECT COALESCE(MAX(week_number), 0) FROM fixtures WHERE guild_id = ?",
+                    (guild_id,),
                 ) as cursor:
                     row = await cursor.fetchone()
                     next_week = int(row[0]) + 1 if row else 1
 
                 insert_cursor = await db.execute(
-                    "INSERT INTO fixtures (week_number, games, deadline) VALUES (?, ?, ?)",
-                    (next_week, "\n".join(games), deadline.isoformat()),
+                    "INSERT INTO fixtures (guild_id, week_number, games, deadline) VALUES (?, ?, ?, ?)",
+                    (guild_id, next_week, "\n".join(games), deadline.isoformat()),
                 )
                 await db.commit()
             except Exception:
@@ -188,15 +205,19 @@ class FixtureRepository:
                 row = await cursor.fetchone()
                 return self._row_to_fixture(row) if row else None
 
-    async def get_max_week_number(self) -> int:
-        """Get the maximum week number from all fixtures.
+    async def get_max_week_number(self, guild_id: str) -> int:
+        """Get the maximum week number for a guild.
 
         Returns:
             Maximum week number, or 0 if no fixtures exist.
         """
+        _validate_guild_id(guild_id)
         async with (
             aiosqlite.connect(self.db_path) as db,
-            db.execute("SELECT MAX(week_number) FROM fixtures") as cursor,
+            db.execute(
+                "SELECT MAX(week_number) FROM fixtures WHERE guild_id = ?",
+                (guild_id,),
+            ) as cursor,
         ):
             row = await cursor.fetchone()
             return row[0] if row and row[0] is not None else 0

--- a/typer_bot/dev/seed_test_data.py
+++ b/typer_bot/dev/seed_test_data.py
@@ -27,6 +27,7 @@ SYNTHETIC_USERS = [
 
 logger = logging.getLogger(__name__)
 DEFAULT_MANUAL_TEST_DIR = Path(".local/manual-discord-test").resolve()
+DEFAULT_MANUAL_GUILD_ID = "manual-test-guild"
 
 
 def _build_argument_parser() -> argparse.ArgumentParser:
@@ -36,6 +37,11 @@ def _build_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--tester-user-id",
         help="Real Discord user ID to include in seeded open-fixture predictions.",
+    )
+    parser.add_argument(
+        "--guild-id",
+        default=DEFAULT_MANUAL_GUILD_ID,
+        help="Discord guild ID to assign to seeded fixtures.",
     )
     parser.add_argument(
         "--force-reset",
@@ -81,6 +87,7 @@ async def seed_mixed_test_data(
     db_path: str,
     backup_dir: str,
     tester_user_id: str | None,
+    guild_id: str = DEFAULT_MANUAL_GUILD_ID,
     *,
     force_reset: bool = False,
 ) -> None:
@@ -90,6 +97,7 @@ async def seed_mixed_test_data(
         db_path: SQLite database file to recreate and seed.
         backup_dir: Backup directory removed before reseeding.
         tester_user_id: Real Discord user ID added only to the open-fixture seed data.
+        guild_id: Discord guild ID assigned to seeded fixtures.
         force_reset: Allows resetting paths outside ``./.local/manual-discord-test``.
 
     Raises:
@@ -112,6 +120,7 @@ async def seed_mixed_test_data(
     users = _build_seed_users()
 
     scored_fixture_id = await db.create_fixture(
+        guild_id,
         1,
         SAMPLE_GAMES,
         current_time - timedelta(days=7),
@@ -154,6 +163,7 @@ async def seed_mixed_test_data(
     await db.save_scores(scored_fixture_id, scored_scores)
 
     open_fixture_id = await db.create_fixture(
+        guild_id,
         2,
         SAMPLE_GAMES,
         current_time + timedelta(days=2),
@@ -179,6 +189,7 @@ async def seed_mixed_test_data(
         )
 
     late_fixture_id = await db.create_fixture(
+        guild_id,
         3,
         SAMPLE_GAMES,
         current_time - timedelta(hours=3),
@@ -192,15 +203,21 @@ async def seed_mixed_test_data(
     )
 
 
-async def _async_main(tester_user_id: str | None, force_reset: bool) -> None:
-    await seed_mixed_test_data(DB_PATH, BACKUP_DIR, tester_user_id, force_reset=force_reset)
+async def _async_main(tester_user_id: str | None, guild_id: str, force_reset: bool) -> None:
+    await seed_mixed_test_data(
+        DB_PATH,
+        BACKUP_DIR,
+        tester_user_id,
+        guild_id,
+        force_reset=force_reset,
+    )
     logger.info("Seeded mixed manual test data into %s", DB_PATH)
 
 
 def main() -> None:
     setup_logging()
     args = _build_argument_parser().parse_args()
-    asyncio.run(_async_main(args.tester_user_id, args.force_reset))
+    asyncio.run(_async_main(args.tester_user_id, args.guild_id, args.force_reset))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add strict guild ownership to fixture creation and fresh fixture schema
- allocate next week numbers per guild while keeping child tables scoped through `fixture_id`
- fail startup clearly when an existing DB has not been manually migrated to include valid `fixtures.guild_id` values
- document the one-time v2 production DB migration path

Closes #195

## Testing
- `uv run pytest --tb=short`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check typer_bot`

## Migration
- Existing live data must be backed up and assigned to the owning Discord guild before deploying this branch.
- Production DB was manually migrated and verified:
  - `fixture_count=13`
  - `bad_guild_rows=0`
  - `guild_counts=[('1062046907851087964', 13)]`

## Notes
- Full guild-scoped fixture reads/mutations are intentionally left for #196; this PR establishes ownership and the write-time contract only.
