### PR TITLE
refactor: scope fixture queries by guild

### DIFF
--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -374,7 +374,7 @@ class TestAdminPanelCommand:
         await cancel_button.callback(mock_interaction_admin)
 
         assert "Fixture creation cancelled" in mock_interaction_admin.response_sent[-1]["content"]
-        assert await admin_cog.db.get_current_fixture() is None
+        assert await admin_cog.db.get_current_fixture("111111") is None
 
     @pytest.mark.asyncio
     async def test_create_fixture_confirm_rechecks_admin_permission(
@@ -403,7 +403,7 @@ class TestAdminPanelCommand:
         await confirm_button.callback(mock_interaction_admin)
 
         assert "no longer have permission" in mock_interaction_admin.response_sent[-1]["content"]
-        assert await admin_cog.db.get_current_fixture() is None
+        assert await admin_cog.db.get_current_fixture("111111") is None
 
     @pytest.mark.asyncio
     async def test_panel_command_returns_view(self, admin_cog, mock_interaction_admin):
@@ -426,7 +426,7 @@ class TestPredictionPanelFlows:
     @pytest.mark.asyncio
     async def test_prediction_panel_blocks_non_owner(self, admin_cog, mock_interaction_admin):
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         outsider = MockInteraction(
             user=MockUser(user_id="999999", name="Outsider"),
@@ -443,7 +443,7 @@ class TestPredictionPanelFlows:
     @pytest.mark.asyncio
     async def test_prediction_panel_rechecks_admin_role(self, admin_cog, mock_interaction_admin):
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
         member.roles = []
@@ -468,6 +468,7 @@ class TestPredictionPanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -496,7 +497,7 @@ class TestPredictionPanelFlows:
         )
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
 
@@ -538,7 +539,7 @@ class TestPredictionPanelFlows:
         )
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -572,7 +573,7 @@ class TestPredictionPanelFlows:
             )
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -610,7 +611,7 @@ class TestPredictionPanelFlows:
             )
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -643,7 +644,7 @@ class TestPredictionPanelFlows:
             )
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -684,7 +685,7 @@ class TestPredictionPanelFlows:
             )
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -716,7 +717,7 @@ class TestPredictionPanelFlows:
         )
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
 
@@ -755,7 +756,7 @@ class TestPredictionPanelFlows:
         admin_cog.bot.get_user.return_value = target_user
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         view.bot = admin_cog.bot
         await view.load_fixture_options()
@@ -793,7 +794,7 @@ class TestPredictionPanelFlows:
         admin_cog.bot.get_user.return_value = failing_user
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         view.bot = admin_cog.bot
         await view.load_fixture_options()
@@ -829,7 +830,7 @@ class TestPredictionPanelFlows:
         admin_cog.bot.fetch_user = AsyncMock(return_value=target_user)
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         view.bot = admin_cog.bot
         await view.load_fixture_options()
@@ -863,7 +864,7 @@ class TestPredictionPanelFlows:
         )
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -898,7 +899,7 @@ class TestPredictionPanelFlows:
         )
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -933,7 +934,7 @@ class TestPredictionPanelFlows:
         )
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -977,7 +978,7 @@ class TestPredictionPanelFlows:
         )
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -1017,6 +1018,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1024,6 +1026,34 @@ class TestFixturePanelFlows:
 
         assert view.fixture_select.disabled is False
         assert view.fixture_select.options[0].label == "Week 4 [OPEN]"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "view_cls",
+        [FixturesPanelView, PredictionsPanelView, ResultsPanelView, UnifiedAdminPanelView],
+    )
+    async def test_admin_fixture_selectors_only_show_current_guild(
+        self,
+        view_cls,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        await admin_cog.db.create_fixture("111111", 1, sample_games, deadline)
+        await admin_cog.db.create_fixture("guild-2", 2, sample_games, deadline)
+
+        view = view_cls(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            "111111",
+        )
+        await view.load_fixture_options()
+
+        option_labels = [option.label for option in view.fixture_select.options]
+        assert "Week 1 [OPEN]" in option_labels
+        assert "Week 2 [OPEN]" not in option_labels
 
     @pytest.mark.asyncio
     async def test_fixture_panel_delete_button_enables_after_fixture_selection(
@@ -1037,7 +1067,11 @@ class TestFixturePanelFlows:
         )
 
         view = FixturesPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), bot=admin_cog.bot
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            "111111",
+            bot=admin_cog.bot,
         )
         await view.load_fixture_options()
 
@@ -1065,6 +1099,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1095,6 +1130,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1109,6 +1145,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1136,6 +1173,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1168,12 +1206,45 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
         await view.load_fixture_options()
 
         assert _has_button(view, "Review Late") is True
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_hides_other_guild_pending_partials(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            "guild-2", 55, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_prediction(
+            fixture_id,
+            "111",
+            "User One",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+            pending_partial_approval=True,
+        )
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            "111111",
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        await view.load_fixture_options()
+
+        assert _has_button(view, "Review Late") is False
 
     @pytest.mark.asyncio
     async def test_unified_panel_review_pending_button_jumps_to_pending_submission(
@@ -1199,6 +1270,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1248,6 +1320,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1279,6 +1352,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1299,6 +1373,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1321,6 +1396,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1348,6 +1424,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1387,6 +1464,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1424,6 +1502,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1455,6 +1534,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1509,6 +1589,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1532,6 +1613,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1559,6 +1641,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1587,6 +1670,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1613,6 +1697,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1636,6 +1721,7 @@ class TestFixturePanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1662,6 +1748,7 @@ class TestFixturePanelFlows:
         confirm_view = DeleteConfirmView(
             db_mock,
             str(mock_interaction_admin.user.id),
+            "111111",
             fixture_id,
             week_number=7,
         )
@@ -1739,7 +1826,7 @@ class TestResultsPanelFlows:
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
 
         view = ResultsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
 
@@ -1769,7 +1856,7 @@ class TestResultsPanelFlows:
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
 
         view = ResultsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
 
@@ -1796,7 +1883,7 @@ class TestResultsPanelFlows:
         )
 
         view = ResultsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
 
@@ -1826,7 +1913,7 @@ class TestResultsPanelFlows:
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
 
         view = ResultsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -1851,7 +1938,7 @@ class TestResultsPanelFlows:
             "111111", 23, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         view = ResultsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         await admin_cog.db.delete_fixture(fixture_id)
@@ -1877,7 +1964,7 @@ class TestResultsPanelFlows:
         await admin_cog.db.save_results(fixture_id, ["1-0"] * len(games))
 
         view = ResultsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -1911,6 +1998,7 @@ class TestResultsPanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1957,6 +2045,7 @@ class TestResultsPanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -1999,6 +2088,7 @@ class TestResultsPanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -2038,6 +2128,7 @@ class TestResultsPanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -2082,6 +2173,7 @@ class TestResultsPanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -2137,6 +2229,7 @@ class TestResultsPanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -2191,6 +2284,7 @@ class TestResultsPanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -2250,6 +2344,7 @@ class TestResultsPanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -2310,6 +2405,7 @@ class TestResultsPanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -2358,6 +2454,7 @@ class TestResultsPanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -2410,6 +2507,7 @@ class TestResultsPanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -2460,6 +2558,7 @@ class TestResultsPanelFlows:
             admin_cog.db,
             admin_cog.service,
             str(mock_interaction_admin.user.id),
+            "111111",
             admin_commands=admin_cog,
             bot=admin_cog.bot,
         )
@@ -2718,7 +2817,7 @@ class TestAdminPanelModals:
             False,
         )
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -2759,7 +2858,7 @@ class TestAdminPanelModals:
             False,
         )
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -2792,7 +2891,7 @@ class TestAdminPanelModals:
             False,
         )
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -2839,7 +2938,7 @@ class TestAdminPanelModals:
         admin_cog.bot.get_user.return_value = target_user
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         view.bot = admin_cog.bot
         await view.load_fixture_options()
@@ -2885,7 +2984,7 @@ class TestAdminPanelModals:
         admin_cog.bot.get_user.return_value = failing_user
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         view.bot = admin_cog.bot
         await view.load_fixture_options()
@@ -2931,7 +3030,7 @@ class TestAdminPanelModals:
         admin_cog.bot.fetch_user = AsyncMock(return_value=target_user)
 
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         view.bot = admin_cog.bot
         await view.load_fixture_options()
@@ -2972,7 +3071,7 @@ class TestAdminPanelModals:
             False,
         )
         view = PredictionsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -3010,7 +3109,7 @@ class TestAdminPanelModals:
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
         view = ResultsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -3039,7 +3138,7 @@ class TestAdminPanelModals:
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
         view = ResultsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -3056,6 +3155,33 @@ class TestAdminPanelModals:
         assert "Fixture not found" in mock_interaction_admin.response_sent[-1]["content"]
 
     @pytest.mark.asyncio
+    async def test_correct_results_modal_rejects_cross_guild_fixture(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            "guild-2", 7, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        original_results = ["0-0", "1-1", "2-2"]
+        await admin_cog.db.save_results(fixture_id, original_results)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+        view = ResultsPanelView(
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
+        )
+        view.selection.fixture_id = fixture_id
+        view.selection.fixture_label = "Week 7 [OPEN]"
+        modal = CorrectResultsModal(view, fixture, original_results)
+        modal.results_input._value = "Team A - Team B 3-0\nTeam C - Team D 3-0\nTeam E - Team F 3-0"
+
+        await modal.on_submit(mock_interaction_admin)
+
+        assert "Fixture not found" in mock_interaction_admin.response_sent[-1]["content"]
+        assert await admin_cog.db.get_results(fixture_id) == original_results
+
+    @pytest.mark.asyncio
     async def test_correct_results_modal_prefills_stored_results(
         self,
         admin_cog,
@@ -3067,7 +3193,7 @@ class TestAdminPanelModals:
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
         view = ResultsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -3093,7 +3219,7 @@ class TestAdminPanelModals:
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
         view = ResultsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
@@ -3137,7 +3263,7 @@ class TestAdminPanelModals:
         )
 
         view = ResultsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         view.bot = admin_cog.bot
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
@@ -3170,7 +3296,7 @@ class TestAdminPanelModals:
         admin_cog.bot.get_user.return_value = failing_user
 
         view = ResultsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         view.bot = admin_cog.bot
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
@@ -3211,7 +3337,7 @@ class TestAdminPanelModals:
         )
 
         view = ResultsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         view.bot = admin_cog.bot
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
@@ -3248,7 +3374,7 @@ class TestAdminPanelModals:
         )
 
         view = ResultsPanelView(
-            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id)
+            admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         view.bot = admin_cog.bot
         fixture = await admin_cog.db.get_fixture_by_id(fixture_id)

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -37,6 +37,10 @@ def _selected_option_labels(select: discord.ui.Select) -> list[str]:
     return [option.label for option in select.options if option.default]
 
 
+def _option_values(select: discord.ui.Select) -> set[str]:
+    return {option.value for option in select.options}
+
+
 class TestAdminPanelCommand:
     """The slash entrypoint should open the panel."""
 
@@ -1040,8 +1044,12 @@ class TestFixturePanelFlows:
         sample_games,
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
-        await admin_cog.db.create_fixture("111111", 1, sample_games, deadline)
-        await admin_cog.db.create_fixture("guild-2", 2, sample_games, deadline)
+        current_guild_fixture_id = await admin_cog.db.create_fixture(
+            "111111", 1, sample_games, deadline
+        )
+        other_guild_fixture_id = await admin_cog.db.create_fixture(
+            "guild-2", 2, sample_games, deadline
+        )
 
         view = view_cls(
             admin_cog.db,
@@ -1051,9 +1059,9 @@ class TestFixturePanelFlows:
         )
         await view.load_fixture_options()
 
-        option_labels = [option.label for option in view.fixture_select.options]
-        assert "Week 1 [OPEN]" in option_labels
-        assert "Week 2 [OPEN]" not in option_labels
+        option_values = _option_values(view.fixture_select)
+        assert str(current_guild_fixture_id) in option_values
+        assert str(other_guild_fixture_id) not in option_values
 
     @pytest.mark.asyncio
     async def test_fixture_panel_delete_button_enables_after_fixture_selection(
@@ -1244,6 +1252,7 @@ class TestFixturePanelFlows:
         )
         await view.load_fixture_options()
 
+        assert view.has_pending_partials is False
         assert _has_button(view, "Review Late") is False
 
     @pytest.mark.asyncio

--- a/tests/test_admin_service.py
+++ b/tests/test_admin_service.py
@@ -101,6 +101,59 @@ class TestAdminFlowErrors:
             await service.get_fixture_prediction_summary(999)
 
     @pytest.mark.asyncio
+    async def test_wrong_guild_service_actions_raise_fixture_not_found(
+        self, database, sample_games
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            "guild-2", 1, sample_games, datetime.now(UTC) - timedelta(hours=2)
+        )
+        original_prediction = ["1-0", "1-1"]
+        original_results = ["0-0", "1-1", "2-2"]
+        await database.save_prediction(
+            fixture_id,
+            "user-1",
+            "User One",
+            original_prediction,
+            True,
+            predicted_game_indexes=[0, 1],
+            pending_partial_approval=True,
+        )
+        await database.save_results(fixture_id, original_results)
+
+        with pytest.raises(FixtureNotFoundError):
+            await service.get_fixture_prediction_summary(fixture_id, "111111")
+        with pytest.raises(FixtureNotFoundError):
+            await service.calculate_fixture_scores(fixture_id, "111111")
+        with pytest.raises(FixtureNotFoundError):
+            await service.replace_prediction(
+                fixture_id,
+                "user-1",
+                "Team A - Team B 3-0\nTeam C - Team D 3-0\nTeam E - Team F 3-0",
+                "admin-1",
+                "111111",
+            )
+        with pytest.raises(FixtureNotFoundError):
+            await service.toggle_late_penalty_waiver(fixture_id, "user-1", "111111")
+        with pytest.raises(FixtureNotFoundError):
+            await service.approve_partial_prediction(fixture_id, "user-1", "admin-1", "111111")
+        with pytest.raises(FixtureNotFoundError):
+            await service.reject_partial_prediction(fixture_id, "user-1", "111111")
+        with pytest.raises(FixtureNotFoundError):
+            await service.correct_results(
+                fixture_id,
+                "Team A - Team B 3-0\nTeam C - Team D 3-0\nTeam E - Team F 3-0",
+                "111111",
+            )
+
+        prediction = await database.get_prediction(fixture_id, "user-1")
+        assert prediction is not None
+        assert prediction["predictions"] == original_prediction
+        assert prediction["pending_partial_approval"] is True
+        assert await database.get_results(fixture_id) == original_results
+        assert await database.get_scores_for_fixture(fixture_id) == []
+
+    @pytest.mark.asyncio
     async def test_get_fixture_prediction_summary_raises_typed_no_predictions(
         self, database, sample_games
     ):

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -205,7 +205,7 @@ class TestFixtureAnnouncementSync:
         message.thread = MagicMock(id=789012)
         channel = MagicMock()
         channel.fetch_message = AsyncMock(return_value=message)
-        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        bot_instance.db.get_all_open_fixtures = AsyncMock(return_value=[fixture])
         bot_instance.get_channel.return_value = channel
 
         await bot_instance._sync_fixture_thread()
@@ -230,7 +230,7 @@ class TestFixtureAnnouncementSync:
         guild = MagicMock()
         guild.text_channels = [miss_channel, hit_channel]
         bot_instance.guilds = [guild]
-        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        bot_instance.db.get_all_open_fixtures = AsyncMock(return_value=[fixture])
 
         await bot_instance._sync_fixture_thread()
 
@@ -247,7 +247,7 @@ class TestFixtureAnnouncementSync:
         guild = MagicMock()
         guild.text_channels = [MagicMock()]
         bot_instance.guilds = [guild]
-        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        bot_instance.db.get_all_open_fixtures = AsyncMock(return_value=[fixture])
         bot_instance.get_channel.return_value = None
         bot_instance.fetch_channel.side_effect = discord.NotFound(MagicMock(), "missing")
 
@@ -265,7 +265,7 @@ class TestFixtureAnnouncementSync:
         guild = MagicMock()
         guild.text_channels = [MagicMock()]
         bot_instance.guilds = [guild]
-        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        bot_instance.db.get_all_open_fixtures = AsyncMock(return_value=[fixture])
         bot_instance.get_channel.return_value = channel
 
         await bot_instance._sync_fixture_thread()
@@ -280,7 +280,7 @@ class TestFixtureAnnouncementSync:
         message.thread = MagicMock(id=789012)
         channel = MagicMock()
         channel.fetch_message = AsyncMock(return_value=message)
-        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        bot_instance.db.get_all_open_fixtures = AsyncMock(return_value=[fixture])
         bot_instance.get_channel.return_value = None
         bot_instance.fetch_channel.return_value = channel
 
@@ -295,7 +295,7 @@ class TestFixtureAnnouncementSync:
         guild = MagicMock()
         guild.text_channels = [MagicMock()]
         bot_instance.guilds = [guild]
-        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        bot_instance.db.get_all_open_fixtures = AsyncMock(return_value=[fixture])
 
         await bot_instance._sync_fixture_thread()
 
@@ -328,7 +328,7 @@ class TestReminderSystem:
             "deadline": deadline,
             "week_number": 1,
         }
-        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        bot_instance.db.get_all_open_fixtures = AsyncMock(return_value=[fixture])
 
         await bot_instance.reminder_task()
 
@@ -347,7 +347,7 @@ class TestReminderSystem:
             "deadline": deadline,
             "week_number": 1,
         }
-        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        bot_instance.db.get_all_open_fixtures = AsyncMock(return_value=[fixture])
 
         await bot_instance.reminder_task()
 
@@ -366,7 +366,7 @@ class TestReminderSystem:
             "deadline": deadline,
             "week_number": 1,
         }
-        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        bot_instance.db.get_all_open_fixtures = AsyncMock(return_value=[fixture])
 
         with freeze_time(current_time):
             await bot_instance.reminder_task()
@@ -381,7 +381,7 @@ class TestReminderSystem:
     async def test_reminder_skips_if_no_fixture(self, mock_now, bot_instance):
         """Reminders are skipped when no fixture is active."""
         mock_now.return_value = datetime.now(UTC)
-        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[])
+        bot_instance.db.get_all_open_fixtures = AsyncMock(return_value=[])
 
         await bot_instance.reminder_task()
 
@@ -396,7 +396,7 @@ class TestReminderSystem:
 
         fixture_a = {"id": 1, "deadline": deadline, "week_number": 1}
         fixture_b = {"id": 2, "deadline": deadline, "week_number": 2}
-        bot_instance.db.get_open_fixtures = AsyncMock(return_value=[fixture_a, fixture_b])
+        bot_instance.db.get_all_open_fixtures = AsyncMock(return_value=[fixture_a, fixture_b])
 
         await bot_instance.reminder_task()
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -93,7 +93,9 @@ class TestOpenFixturesQueries:
         # Close week 3 fixture so only weeks 1 and 2 remain open
         await db.save_scores(fixture_week_3, [])
 
-        open_fixtures = await db.get_open_fixtures()
+        await db.create_fixture("guild-2", 1, ["Other A - Other B"], datetime.now(UTC))
+
+        open_fixtures = await db.get_open_fixtures("111111")
         open_ids = [fixture["id"] for fixture in open_fixtures]
         open_weeks = [fixture["week_number"] for fixture in open_fixtures]
 
@@ -115,12 +117,44 @@ class TestOpenFixturesQueries:
         )
         await db.save_scores(closed_fixture_id, [])
 
-        open_fixture = await db.get_open_fixture_by_week(7)
-        closed_fixture = await db.get_open_fixture_by_week(8)
+        open_fixture = await db.get_open_fixture_by_week("111111", 7)
+        closed_fixture = await db.get_open_fixture_by_week("111111", 8)
 
         assert open_fixture is not None
         assert open_fixture["id"] == open_fixture_id
         assert closed_fixture is None
+
+    @pytest.mark.asyncio
+    async def test_week_and_recent_fixture_queries_are_guild_scoped(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+
+        guild_one_week = await db.create_fixture(
+            "111111", 1, ["Team A - Team B"], datetime.now(UTC)
+        )
+        guild_two_week = await db.create_fixture(
+            "guild-2", 1, ["Team C - Team D"], datetime.now(UTC)
+        )
+
+        assert (await db.get_fixture_by_week("111111", 1))["id"] == guild_one_week
+        assert (await db.get_fixture_by_week("guild-2", 1))["id"] == guild_two_week
+        assert [fixture["id"] for fixture in await db.get_recent_fixtures("111111")] == [
+            guild_one_week
+        ]
+        assert await db.get_fixture_by_id(guild_two_week, "111111") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_fixture_can_require_guild_ownership(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+
+        fixture_id = await db.create_fixture("guild-2", 1, ["Team A - Team B"], datetime.now(UTC))
+
+        assert await db.delete_fixture(fixture_id, "111111") is False
+        assert await db.get_fixture_by_id(fixture_id) is not None
+
+        assert await db.delete_fixture(fixture_id, "guild-2") is True
+        assert await db.get_fixture_by_id(fixture_id) is None
 
     @pytest.mark.asyncio
     async def test_create_next_fixture_allocates_incrementing_weeks(self, temp_db_path):
@@ -292,7 +326,7 @@ class TestSchemaMigration:
         await db.initialize()
 
         await db.create_fixture("111111", 1, ["Team A - Team B"], datetime.now(UTC))
-        fixture = await db.get_current_fixture()
+        fixture = await db.get_current_fixture("111111")
         assert fixture is not None
         assert "message_id" in fixture
 
@@ -629,6 +663,6 @@ class TestRowToFixture:
             )
             await conn.commit()
 
-        fixture = await db.get_current_fixture()
+        fixture = await db.get_current_fixture("111111")
         assert fixture is not None
         assert fixture["games"] == []

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -202,7 +202,7 @@ class TestEdgeCases:
 
         fixture_one = await database.get_fixture_by_id(fixture_one_id)
         fixture_two = await database.get_fixture_by_id(fixture_two_id)
-        open_fixtures = await database.get_open_fixtures()
+        open_fixtures = await database.get_open_fixtures("111111")
 
         assert fixture_one is not None
         assert fixture_one["status"] == "closed"

--- a/tests/test_seed_test_data.py
+++ b/tests/test_seed_test_data.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from typer_bot.dev.seed_test_data import seed_mixed_test_data
+from typer_bot.dev.seed_test_data import DEFAULT_MANUAL_GUILD_ID, seed_mixed_test_data
 
 
 def _write_cleanup_artifacts(temp_db_path: str, backup_dir: Path) -> None:
@@ -32,11 +32,11 @@ async def test_seed_mixed_data_creates_expected_fixture_states(temp_db_path, tmp
     from typer_bot.database import Database
 
     db = Database(temp_db_path)
-    open_fixtures = await db.get_open_fixtures()
+    open_fixtures = await db.get_open_fixtures(DEFAULT_MANUAL_GUILD_ID)
     standings = await db.get_standings()
-    week_one = await db.get_fixture_by_week(1)
-    week_two = await db.get_fixture_by_week(2)
-    week_three = await db.get_fixture_by_week(3)
+    week_one = await db.get_fixture_by_week(DEFAULT_MANUAL_GUILD_ID, 1)
+    week_two = await db.get_fixture_by_week(DEFAULT_MANUAL_GUILD_ID, 2)
+    week_three = await db.get_fixture_by_week(DEFAULT_MANUAL_GUILD_ID, 3)
 
     assert [fixture["week_number"] for fixture in open_fixtures] == [2, 3]
     assert week_one is not None
@@ -75,8 +75,8 @@ async def test_seed_mixed_data_includes_real_tester_when_user_id_provided(temp_d
     from typer_bot.database import Database
 
     db = Database(temp_db_path)
-    week_one = await db.get_fixture_by_week(1)
-    week_two = await db.get_fixture_by_week(2)
+    week_one = await db.get_fixture_by_week(DEFAULT_MANUAL_GUILD_ID, 1)
+    week_two = await db.get_fixture_by_week(DEFAULT_MANUAL_GUILD_ID, 2)
     assert week_one is not None
     assert week_two is not None
 
@@ -99,14 +99,14 @@ async def test_seed_mixed_data_resets_existing_database(temp_db_path, tmp_path):
     from typer_bot.database import Database
 
     db = Database(temp_db_path)
-    week_two = await db.get_fixture_by_week(2)
+    week_two = await db.get_fixture_by_week(DEFAULT_MANUAL_GUILD_ID, 2)
     assert week_two is not None
     await db.delete_fixture(week_two["id"])
 
     await seed_mixed_test_data(temp_db_path, str(backup_dir), None, force_reset=True)
 
     refreshed_db = Database(temp_db_path)
-    open_fixtures = await refreshed_db.get_open_fixtures()
+    open_fixtures = await refreshed_db.get_open_fixtures(DEFAULT_MANUAL_GUILD_ID)
     assert [fixture["week_number"] for fixture in open_fixtures] == [2, 3]
 
 

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -66,6 +66,61 @@ class TestPredictCommand:
         assert isinstance(mock_interaction.response_sent[0]["view"], FixtureSelectView)
 
     @pytest.mark.asyncio
+    async def test_predict_only_uses_current_guild_fixtures(
+        self, user_commands, mock_interaction, database, sample_games
+    ):
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        await database.create_fixture("guild-2", 1, sample_games, deadline)
+
+        await user_commands.predict.callback(user_commands, mock_interaction)
+
+        assert "No active fixture" in mock_interaction.response_sent[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_fixture_picker_rejects_cross_guild_fixture(
+        self, user_commands, mock_interaction, database, sample_games
+    ):
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        fixture_id = await database.create_fixture("guild-2", 1, sample_games, deadline)
+        fixture = await database.get_fixture_by_id(fixture_id)
+
+        view = FixtureSelectView(
+            database,
+            user_commands.bot,
+            str(mock_interaction.user.id),
+            "111111",
+            [fixture],
+        )
+        select = view.children[0]
+        select._values = [str(fixture_id)]
+        await select.callback(mock_interaction)
+
+        assert not hasattr(mock_interaction, "modal_sent")
+        assert "no longer open" in mock_interaction.response_sent[-1]["content"].lower()
+
+    @pytest.mark.asyncio
+    async def test_continue_predict_rejects_cross_guild_fixture(
+        self, user_commands, mock_interaction, database, sample_games
+    ):
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        fixture_id = await database.create_fixture("guild-2", 1, sample_games, deadline)
+        fixture = await database.get_fixture_by_id(fixture_id)
+
+        view = ContinuePredictView(
+            database,
+            user_commands.bot,
+            str(mock_interaction.user.id),
+            "111111",
+            [fixture],
+            set(),
+        )
+        button = view.children[0]
+        await button.callback(mock_interaction)
+
+        assert not hasattr(mock_interaction, "modal_sent")
+        assert "no longer open" in mock_interaction.response_sent[-1]["content"].lower()
+
+    @pytest.mark.asyncio
     async def test_multiple_open_fixture_picker_opens_modal_for_selection(
         self, user_commands, mock_interaction, database, sample_games
     ):
@@ -788,6 +843,20 @@ class TestFixturesCommand:
         assert "Week 1" in content
         assert "Week 2" in content
 
+    @pytest.mark.asyncio
+    async def test_fixtures_only_shows_current_guild(
+        self, user_commands, mock_interaction, database, sample_games
+    ):
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        await database.create_fixture("111111", 1, sample_games, deadline)
+        await database.create_fixture("guild-2", 2, sample_games, deadline)
+
+        await user_commands.fixtures.callback(user_commands, mock_interaction)
+
+        content = mock_interaction.response_sent[0]["content"]
+        assert "Week 1" in content
+        assert "Week 2" not in content
+
 
 class TestStandingsCommand:
     @pytest.mark.asyncio
@@ -836,6 +905,24 @@ class TestStandingsCommand:
 class TestMyPredictionsCommand:
     @pytest.mark.asyncio
     async def test_no_open_fixture_shows_error(self, user_commands, mock_interaction):
+        await user_commands.my_predictions.callback(user_commands, mock_interaction)
+
+        assert mock_interaction.response_sent[0]["content"] == "❌ No active fixture found!"
+
+    @pytest.mark.asyncio
+    async def test_only_uses_current_guild_fixtures(
+        self, user_commands, mock_interaction, database, sample_games
+    ):
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        fixture_id = await database.create_fixture("guild-2", 1, sample_games, deadline)
+        await database.save_prediction(
+            fixture_id,
+            str(mock_interaction.user.id),
+            mock_interaction.user.name,
+            ["2-1", "1-1", "0-2"],
+            False,
+        )
+
         await user_commands.my_predictions.callback(user_commands, mock_interaction)
 
         assert mock_interaction.response_sent[0]["content"] == "❌ No active fixture found!"

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -810,7 +810,7 @@ class TestFixturesCommand:
     async def test_no_open_fixture_shows_error(self, user_commands, mock_interaction):
         await user_commands.fixtures.callback(user_commands, mock_interaction)
 
-        assert mock_interaction.response_sent[0]["content"] == "❌ No active fixture found!"
+        assert "No active fixture" in mock_interaction.response_sent[0]["content"]
 
     @pytest.mark.asyncio
     async def test_single_open_fixture_lists_games_and_deadline(
@@ -907,7 +907,7 @@ class TestMyPredictionsCommand:
     async def test_no_open_fixture_shows_error(self, user_commands, mock_interaction):
         await user_commands.my_predictions.callback(user_commands, mock_interaction)
 
-        assert mock_interaction.response_sent[0]["content"] == "❌ No active fixture found!"
+        assert "No active fixture" in mock_interaction.response_sent[0]["content"]
 
     @pytest.mark.asyncio
     async def test_only_uses_current_guild_fixtures(
@@ -925,7 +925,7 @@ class TestMyPredictionsCommand:
 
         await user_commands.my_predictions.callback(user_commands, mock_interaction)
 
-        assert mock_interaction.response_sent[0]["content"] == "❌ No active fixture found!"
+        assert "No active fixture" in mock_interaction.response_sent[0]["content"]
 
     @pytest.mark.asyncio
     async def test_single_fixture_without_prediction_shows_prompt(

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -171,7 +171,7 @@ class TyperBot(commands.Bot):
     async def reminder_task(self):
         """Send reminders 24h and 1h before each open fixture deadline."""
         current_time = now()
-        open_fixtures = await self.db.get_open_fixtures()
+        open_fixtures = await self.db.get_all_open_fixtures()
 
         if not open_fixtures:
             return
@@ -252,7 +252,7 @@ class TyperBot(commands.Bot):
         logger.info("Verifying fixture announcement...")
 
         try:
-            open_fixtures = await self.db.get_open_fixtures()
+            open_fixtures = await self.db.get_all_open_fixtures()
             if not open_fixtures:
                 logger.info("No open fixture found, skipping verification")
                 return

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -150,6 +150,7 @@ class AdminCommands(commands.Cog):
             self.db,
             self.service,
             str(interaction.user.id),
+            str(interaction.guild_id),
             admin_commands=self,
             bot=self.bot,
         )

--- a/typer_bot/commands/admin_panel/base.py
+++ b/typer_bot/commands/admin_panel/base.py
@@ -133,6 +133,7 @@ class OwnerRestrictedView(discord.ui.View):
         db: Database,
         service: AdminService,
         owner_user_id: str,
+        guild_id: str,
         bot: discord.Client | None = None,
         timeout: float = 180,
     ):
@@ -140,6 +141,7 @@ class OwnerRestrictedView(discord.ui.View):
         self.db = db
         self.service = service
         self.owner_user_id = owner_user_id
+        self.guild_id = guild_id
         self.bot = bot
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
@@ -372,7 +374,7 @@ class FixtureSelect(discord.ui.Select):
         self.parent_view.selection.user_label = ""
         self.parent_view.selection.detail_lines = []
 
-        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
+        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id, self.parent_view.guild_id)
         if fixture is None:
             self.parent_view.selection.fixture_id = None
             self.parent_view.selection.fixture_label = ""

--- a/typer_bot/commands/admin_panel/fixtures.py
+++ b/typer_bot/commands/admin_panel/fixtures.py
@@ -66,9 +66,10 @@ class FixturesPanelView(OwnerRestrictedView):
         db: Database,
         service: AdminService,
         owner_user_id: str,
+        guild_id: str,
         bot: discord.Client | None = None,
     ):
-        super().__init__(db, service, owner_user_id, bot=bot)
+        super().__init__(db, service, owner_user_id, guild_id, bot=bot)
         self.selection = PanelSelectionState()
         self.fixture_select = FixtureSelect(self)
         self._refresh_items()
@@ -79,7 +80,7 @@ class FixturesPanelView(OwnerRestrictedView):
         self.add_item(FixturesDeleteButton(self, disabled=self.selection.fixture_id is None))
 
     async def load_fixture_options(self) -> None:
-        fixtures = await self.db.get_open_fixtures()
+        fixtures = await self.db.get_open_fixtures(self.guild_id)
         self.fixture_select.update_options(fixtures)
 
     def render_content(self) -> str:
@@ -123,7 +124,7 @@ class FixturesDeleteButton(discord.ui.Button):
             await interaction.response.send_message("Select an open fixture first.", ephemeral=True)
             return
 
-        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
+        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id, self.parent_view.guild_id)
         if fixture is None or fixture["status"] != "open":
             await interaction.response.send_message(
                 "Only open fixtures can be deleted from the panel.", ephemeral=True
@@ -133,6 +134,7 @@ class FixturesDeleteButton(discord.ui.Button):
         confirm_view = DeleteConfirmView(
             self.parent_view.db,
             self.parent_view.owner_user_id,
+            self.parent_view.guild_id,
             fixture_id,
             fixture["week_number"],
             bot=self.parent_view.bot,
@@ -150,6 +152,7 @@ class DeleteConfirmView(discord.ui.View):
         self,
         db: Database,
         user_id: str,
+        guild_id: str,
         fixture_id: int,
         week_number: int,
         bot: discord.Client | None = None,
@@ -159,6 +162,7 @@ class DeleteConfirmView(discord.ui.View):
         super().__init__(timeout=60)
         self.db = db
         self.user_id = user_id
+        self.guild_id = guild_id
         self.fixture_id = fixture_id
         self.week_number = week_number
         self.bot = bot
@@ -179,7 +183,13 @@ class DeleteConfirmView(discord.ui.View):
             return
 
         try:
-            await self.db.delete_fixture(self.fixture_id)
+            deleted = await self.db.delete_fixture(self.fixture_id, self.guild_id)
+            if not deleted:
+                await interaction.response.edit_message(
+                    content="Fixture no longer exists or belongs to another server.",
+                    view=None,
+                )
+                return
         except Exception:
             logger.exception(
                 "Failed to delete fixture %s (week %s)", self.fixture_id, self.week_number

--- a/typer_bot/commands/admin_panel/modals.py
+++ b/typer_bot/commands/admin_panel/modals.py
@@ -231,7 +231,7 @@ class CreateFixtureModal(discord.ui.Modal):
 
         preview_week_number = await self.db.get_max_week_number(str(interaction.guild_id)) + 1
         preview = _build_fixture_preview_text(preview_week_number, games, deadline)
-        open_fixtures = await self.db.get_open_fixtures()
+        open_fixtures = await self.db.get_open_fixtures(str(interaction.guild_id))
         if open_fixtures:
             open_weeks = ", ".join(str(fixture["week_number"]) for fixture in open_fixtures)
             preview += (
@@ -424,6 +424,7 @@ class ReplacePredictionModal(discord.ui.Modal):
                 self.prediction["user_id"],
                 self.predictions_input.value,
                 str(interaction.user.id),
+                self.parent_view.guild_id,
             )
         except (FixtureNotFoundError, PredictionNotFoundError, PredictionDisappearedError) as exc:
             self.parent_view.selection.user_id = None
@@ -533,6 +534,7 @@ class CorrectResultsModal(discord.ui.Modal):
             ) = await self.parent_view.service.correct_results(
                 self.fixture["id"],
                 self.results_input.value,
+                self.parent_view.guild_id,
             )
         except FixtureNotFoundError as exc:
             self.parent_view.selection.fixture_id = None

--- a/typer_bot/commands/admin_panel/predictions.py
+++ b/typer_bot/commands/admin_panel/predictions.py
@@ -35,8 +35,8 @@ if TYPE_CHECKING:
 class PredictionsPanelView(OwnerRestrictedView):
     """Panel for prediction lookup and override actions."""
 
-    def __init__(self, db: Database, service: AdminService, owner_user_id: str):
-        super().__init__(db, service, owner_user_id)
+    def __init__(self, db: Database, service: AdminService, owner_user_id: str, guild_id: str):
+        super().__init__(db, service, owner_user_id, guild_id)
         self.selection = PanelSelectionState()
         self.has_user_overflow = False
         self.fixture_select = FixtureSelect(self)
@@ -64,7 +64,7 @@ class PredictionsPanelView(OwnerRestrictedView):
         )
 
     async def load_fixture_options(self) -> None:
-        fixtures = await self.db.get_recent_fixtures(MAX_SELECT_OPTIONS)
+        fixtures = await self.db.get_recent_fixtures(self.guild_id, MAX_SELECT_OPTIONS)
         self.fixture_select.update_options(fixtures)
 
     async def load_user_options(self) -> None:
@@ -161,7 +161,7 @@ class PredictionUserSelect(discord.ui.Select):
             await interaction.response.send_message("Select a fixture first.", ephemeral=True)
             return
 
-        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
+        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id, self.parent_view.guild_id)
         if fixture is None:
             self.parent_view.selection.fixture_id = None
             self.parent_view.selection.fixture_label = ""
@@ -235,7 +235,7 @@ class ReplacePredictionButton(discord.ui.Button):
             )
             return
 
-        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
+        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id, self.parent_view.guild_id)
         prediction = await self.parent_view.db.get_prediction(fixture_id, user_id)
         if fixture is None:
             self.parent_view.selection.fixture_id = None
@@ -292,7 +292,7 @@ class ViewPredictionsButton(discord.ui.Button):
 
         try:
             fixture, predictions = await self.parent_view.service.get_fixture_prediction_summary(
-                fixture_id
+                fixture_id, self.parent_view.guild_id
             )
         except FixtureNotFoundError as exc:
             self.parent_view.selection.fixture_id = None
@@ -360,7 +360,7 @@ class ToggleWaiverButton(discord.ui.Button):
             )
             return
 
-        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
+        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id, self.parent_view.guild_id)
         if fixture is None:
             self.parent_view.selection.fixture_id = None
             self.parent_view.selection.fixture_label = ""
@@ -399,6 +399,7 @@ class ToggleWaiverButton(discord.ui.Button):
             ) = await self.parent_view.service.toggle_late_penalty_waiver(
                 fixture_id,
                 user_id,
+                self.parent_view.guild_id,
             )
         except FixtureNotFoundError as exc:
             self.parent_view.selection.fixture_id = None

--- a/typer_bot/commands/admin_panel/results.py
+++ b/typer_bot/commands/admin_panel/results.py
@@ -26,8 +26,8 @@ if TYPE_CHECKING:
 class ResultsPanelView(OwnerRestrictedView):
     """Panel for result correction workflows."""
 
-    def __init__(self, db: Database, service: AdminService, owner_user_id: str):
-        super().__init__(db, service, owner_user_id)
+    def __init__(self, db: Database, service: AdminService, owner_user_id: str, guild_id: str):
+        super().__init__(db, service, owner_user_id, guild_id)
         self.selection = PanelSelectionState()
         self.fixture_select = FixtureSelect(self)
         self._refresh_items()
@@ -38,7 +38,7 @@ class ResultsPanelView(OwnerRestrictedView):
         self.add_item(CorrectResultsButton(self, disabled=self.selection.fixture_id is None))
 
     async def load_fixture_options(self) -> None:
-        fixtures = await self.db.get_recent_fixtures(MAX_SELECT_OPTIONS)
+        fixtures = await self.db.get_recent_fixtures(self.guild_id, MAX_SELECT_OPTIONS)
         self.fixture_select.update_options(fixtures)
 
     async def populate_fixture_details(self, fixture: dict | None) -> None:
@@ -93,7 +93,7 @@ class CorrectResultsButton(discord.ui.Button):
             await interaction.response.send_message("Select a fixture first.", ephemeral=True)
             return
 
-        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
+        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id, self.parent_view.guild_id)
         if fixture is None:
             self.parent_view.selection.fixture_id = None
             self.parent_view.selection.fixture_label = ""

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -55,6 +55,7 @@ class ApprovePartialButton(discord.ui.Button):
                 fixture_id,
                 user_id,
                 str(interaction.user.id),
+                self.parent_view.guild_id,
             )
         except ValueError as exc:
             await interaction.response.send_message(str(exc), ephemeral=True)
@@ -119,6 +120,7 @@ class RejectPartialButton(discord.ui.Button):
             ) = await self.parent_view.service.reject_partial_prediction(
                 fixture_id,
                 user_id,
+                self.parent_view.guild_id,
             )
         except ValueError as exc:
             await interaction.response.send_message(str(exc), ephemeral=True)
@@ -163,7 +165,11 @@ class ReviewPendingPartialsButton(discord.ui.Button):
         super().__init__(label="Review Late", style=discord.ButtonStyle.primary, row=4)
 
     async def callback(self, interaction: discord.Interaction):
-        pending_predictions = await self.parent_view.db.get_pending_partial_predictions()
+        pending_predictions = [
+            pending
+            for pending in await self.parent_view.db.get_pending_partial_predictions()
+            if pending.get("guild_id") == self.parent_view.guild_id
+        ]
         if not pending_predictions:
             await interaction.response.send_message(
                 "There are no late predictions awaiting review right now.", ephemeral=True
@@ -177,7 +183,9 @@ class ReviewPendingPartialsButton(discord.ui.Button):
                 next_prediction = pending_predictions[(index + 1) % len(pending_predictions)]
                 break
 
-        fixture = await self.parent_view.db.get_fixture_by_id(next_prediction["fixture_id"])
+        fixture = await self.parent_view.db.get_fixture_by_id(
+            next_prediction["fixture_id"], self.parent_view.guild_id
+        )
         if fixture is None:
             await interaction.response.send_message(
                 "That fixture no longer exists. Try again after refreshing the panel.",
@@ -264,7 +272,7 @@ class JumpToWeekModal(discord.ui.Modal):
             )
             return
 
-        open_fixtures = await self.parent_view.db.get_open_fixtures()
+        open_fixtures = await self.parent_view.db.get_open_fixtures(self.parent_view.guild_id)
         matching = [fixture for fixture in open_fixtures if fixture["week_number"] == week_number]
         if not matching:
             await interaction.response.send_message(
@@ -321,7 +329,7 @@ class EnterResultsButton(discord.ui.Button):
         if fixture_id is None:
             await interaction.response.send_message("Select a fixture first.", ephemeral=True)
             return
-        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
+        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id, self.parent_view.guild_id)
         if fixture is None or fixture["status"] != "open":
             await interaction.response.send_message(
                 "That fixture is no longer open.", ephemeral=True
@@ -352,7 +360,7 @@ class CalculateScoresButton(discord.ui.Button):
         if fixture_id is None:
             await interaction.response.send_message("Select a fixture first.", ephemeral=True)
             return
-        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id)
+        fixture = await self.parent_view.db.get_fixture_by_id(fixture_id, self.parent_view.guild_id)
         if fixture is None or fixture["status"] != "open":
             await interaction.response.send_message(
                 "That fixture is no longer open.", ephemeral=True
@@ -379,7 +387,9 @@ class CalculateScoresButton(discord.ui.Button):
             return
 
         try:
-            score_result = await self.parent_view.service.calculate_fixture_scores(fixture_id)
+            score_result = await self.parent_view.service.calculate_fixture_scores(
+                fixture_id, self.parent_view.guild_id
+            )
         except ValueError as exc:
             await interaction.response.send_message(str(exc), ephemeral=True)
             return
@@ -474,10 +484,11 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
         db: Database,
         service: AdminService,
         owner_user_id: str,
+        guild_id: str,
         admin_commands: AdminCommands | None = None,
         bot: discord.Client | None = None,
     ):
-        super().__init__(db, service, owner_user_id, bot=bot)
+        super().__init__(db, service, owner_user_id, guild_id, bot=bot)
         self.admin_commands = admin_commands
         self.selection = PanelSelectionState()
         self.has_user_overflow = False
@@ -525,9 +536,12 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
             )
 
     async def load_fixture_options(self) -> None:
-        fixtures = await self.db.get_recent_fixtures(MAX_SELECT_OPTIONS)
+        fixtures = await self.db.get_recent_fixtures(self.guild_id, MAX_SELECT_OPTIONS)
         self.fixture_select.update_options(fixtures)
-        self.has_pending_partials = bool(await self.db.get_pending_partial_predictions())
+        self.has_pending_partials = any(
+            pending.get("guild_id") == self.guild_id
+            for pending in await self.db.get_pending_partial_predictions()
+        )
         self._refresh_items()
 
     async def load_user_options(self) -> None:
@@ -545,6 +559,9 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
     async def set_selected_prediction(self) -> None:
         self.current_prediction = None
         if self.selection.fixture_id is None or self.selection.user_id is None:
+            return
+        fixture = await self.db.get_fixture_by_id(self.selection.fixture_id, self.guild_id)
+        if fixture is None:
             return
         self.current_prediction = await self.db.get_prediction(
             self.selection.fixture_id, self.selection.user_id

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -25,6 +25,15 @@ BUTTON_PAGE_SIZE = 23
 logger = logging.getLogger(__name__)
 
 
+async def _require_guild_id(interaction: discord.Interaction) -> str | None:
+    if interaction.guild_id is None:
+        await interaction.response.send_message(
+            "This command can only be used in a server.", ephemeral=True
+        )
+        return None
+    return str(interaction.guild_id)
+
+
 def _prediction_template(games: list[str]) -> str:
     return "\n".join(f"{game} 2:0" for game in games)
 
@@ -197,7 +206,7 @@ class ContinuePredictButton(discord.ui.Button):
             )
             return
 
-        latest_fixture = await view.db.get_fixture_by_id(self.fixture["id"])
+        latest_fixture = await view.db.get_fixture_by_id(self.fixture["id"], view.guild_id)
         if latest_fixture is None or latest_fixture["status"] != "open":
             await interaction.response.edit_message(
                 content="That fixture is no longer open. Use `/predict` to refresh the list.",
@@ -225,12 +234,14 @@ class ContinuePredictView(PaginatedFixtureView):
         db: Database,
         bot: commands.Bot,
         owner_user_id: str,
+        guild_id: str,
         remaining_fixtures: list[dict],
         completed_fixture_ids: set[int],
     ):
         super().__init__(owner_user_id, timeout=3600)
         self.bot = bot
         self.db = db
+        self.guild_id = guild_id
         self.completed_fixture_ids = completed_fixture_ids
         self.fixtures = remaining_fixtures
         self.page_size = BUTTON_PAGE_SIZE
@@ -267,7 +278,7 @@ class FixtureSelect(discord.ui.Select):
             return
 
         fixture_id = int(self.values[0])
-        fixture = await view.db.get_fixture_by_id(fixture_id)
+        fixture = await view.db.get_fixture_by_id(fixture_id, view.guild_id)
         if fixture is None or fixture["status"] != "open":
             await interaction.response.edit_message(
                 content="That fixture is no longer open. Use `/predict` to refresh the list.",
@@ -295,12 +306,14 @@ class FixtureSelectView(PaginatedFixtureView):
         db: Database,
         bot: commands.Bot,
         owner_user_id: str,
+        guild_id: str,
         fixtures: list[dict],
         completed_fixture_ids: set[int] | None = None,
     ):
         super().__init__(owner_user_id, timeout=3600)
         self.bot = bot
         self.db = db
+        self.guild_id = guild_id
         self.fixtures = fixtures
         self.page_size = SELECT_PAGE_SIZE
         self.completed_fixture_ids = completed_fixture_ids or set()
@@ -358,7 +371,7 @@ class PredictModal(discord.ui.Modal):
         self.add_item(self.predictions_input)
 
     async def on_submit(self, interaction: discord.Interaction):
-        fixture = await self.db.get_fixture_by_id(self.fixture["id"])
+        fixture = await self.db.get_fixture_by_id(self.fixture["id"], self.fixture["guild_id"])
         if fixture is None or fixture["status"] != "open":
             await interaction.response.send_message(
                 "This fixture is no longer open. Use `/predict` to refresh the list.",
@@ -479,13 +492,14 @@ class PredictModal(discord.ui.Modal):
 
         completed_fixture_ids = set(self.completed_fixture_ids)
         completed_fixture_ids.add(fixture["id"])
-        open_fixtures = await self.db.get_open_fixtures()
+        open_fixtures = await self.db.get_open_fixtures(fixture["guild_id"])
         remaining_fixtures = _remaining_open_fixtures(open_fixtures, completed_fixture_ids)
         if remaining_fixtures:
             view = ContinuePredictView(
                 self.db,
                 self.bot,
                 str(interaction.user.id),
+                fixture["guild_id"],
                 remaining_fixtures,
                 completed_fixture_ids,
             )
@@ -555,7 +569,11 @@ class UserCommands(commands.Cog):
     @app_commands.checks.cooldown(1, 1.0)
     async def predict(self, interaction: discord.Interaction):
         """Open a modal to submit predictions for open fixtures."""
-        open_fixtures = await self.db.get_open_fixtures()
+        guild_id = await _require_guild_id(interaction)
+        if guild_id is None:
+            return
+
+        open_fixtures = await self.db.get_open_fixtures(guild_id)
         if not open_fixtures:
             await interaction.response.send_message(
                 "❌ No active fixture found! Ask an admin to create one.", ephemeral=True
@@ -578,7 +596,9 @@ class UserCommands(commands.Cog):
             await interaction.response.send_modal(modal)
             return
 
-        view = FixtureSelectView(self.db, self.bot, str(interaction.user.id), open_fixtures)
+        view = FixtureSelectView(
+            self.db, self.bot, str(interaction.user.id), guild_id, open_fixtures
+        )
         await interaction.response.send_message(
             "Multiple fixtures are open. Choose which week you want to predict first.",
             ephemeral=True,
@@ -661,7 +681,11 @@ Use these directly in Discord."""
     @app_commands.command(name="fixtures", description="View open fixtures")
     async def fixtures(self, interaction: discord.Interaction):
         """Display current fixtures."""
-        open_fixtures = await self.db.get_open_fixtures()
+        guild_id = await _require_guild_id(interaction)
+        if guild_id is None:
+            return
+
+        open_fixtures = await self.db.get_open_fixtures(guild_id)
 
         if not open_fixtures:
             await interaction.response.send_message("❌ No active fixture found!", ephemeral=True)
@@ -707,7 +731,11 @@ Use these directly in Discord."""
     )
     async def my_predictions(self, interaction: discord.Interaction):
         """Show user's current predictions."""
-        open_fixtures = await self.db.get_open_fixtures()
+        guild_id = await _require_guild_id(interaction)
+        if guild_id is None:
+            return
+
+        open_fixtures = await self.db.get_open_fixtures(guild_id)
 
         if not open_fixtures:
             await interaction.response.send_message("❌ No active fixture found!", ephemeral=True)

--- a/typer_bot/database/connection.py
+++ b/typer_bot/database/connection.py
@@ -255,32 +255,35 @@ class Database:
     async def create_next_fixture(self, guild_id, games, deadline):
         return await self._fixtures.create_next_fixture(guild_id, games, deadline)
 
-    async def get_current_fixture(self):
-        return await self._fixtures.get_current_fixture()
+    async def get_current_fixture(self, guild_id):
+        return await self._fixtures.get_current_fixture(guild_id)
 
-    async def get_open_fixtures(self):
-        return await self._fixtures.get_open_fixtures()
+    async def get_open_fixtures(self, guild_id):
+        return await self._fixtures.get_open_fixtures(guild_id)
 
-    async def get_open_fixture_by_week(self, week_number):
-        return await self._fixtures.get_open_fixture_by_week(week_number)
+    async def get_all_open_fixtures(self):
+        return await self._fixtures.get_all_open_fixtures()
 
-    async def get_fixture_by_id(self, fixture_id):
-        return await self._fixtures.get_fixture_by_id(fixture_id)
+    async def get_open_fixture_by_week(self, guild_id, week_number):
+        return await self._fixtures.get_open_fixture_by_week(guild_id, week_number)
 
-    async def get_fixture_by_week(self, week_number):
-        return await self._fixtures.get_fixture_by_week(week_number)
+    async def get_fixture_by_id(self, fixture_id, guild_id=None):
+        return await self._fixtures.get_fixture_by_id(fixture_id, guild_id)
 
-    async def get_recent_fixtures(self, limit=25):
-        return await self._fixtures.get_recent_fixtures(limit)
+    async def get_fixture_by_week(self, guild_id, week_number):
+        return await self._fixtures.get_fixture_by_week(guild_id, week_number)
 
-    async def get_fixture_by_message_id(self, message_id):
-        return await self._fixtures.get_fixture_by_message_id(message_id)
+    async def get_recent_fixtures(self, guild_id, limit=25):
+        return await self._fixtures.get_recent_fixtures(guild_id, limit)
+
+    async def get_fixture_by_message_id(self, message_id, guild_id=None):
+        return await self._fixtures.get_fixture_by_message_id(message_id, guild_id)
 
     async def get_max_week_number(self, guild_id):
         return await self._fixtures.get_max_week_number(guild_id)
 
-    async def delete_fixture(self, fixture_id):
-        return await self._fixtures.delete_fixture(fixture_id)
+    async def delete_fixture(self, fixture_id, guild_id=None):
+        return await self._fixtures.delete_fixture(fixture_id, guild_id)
 
     async def update_fixture_announcement(self, fixture_id, message_id, channel_id):
         return await self._fixtures.update_fixture_announcement(fixture_id, message_id, channel_id)

--- a/typer_bot/database/fixtures.py
+++ b/typer_bot/database/fixtures.py
@@ -125,72 +125,94 @@ class FixtureRepository:
             )
             return insert_cursor.lastrowid, next_week
 
-    async def get_current_fixture(self) -> dict | None:
-        """Get the most recently created open fixture.
-
-        Kept for backward compatibility with older call sites that assume a
-        single active fixture.
-        """
+    async def get_current_fixture(self, guild_id: str) -> dict | None:
+        """Get the most recently created open fixture for a guild."""
+        _validate_guild_id(guild_id)
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
-                "SELECT * FROM fixtures WHERE status = 'open' ORDER BY id DESC LIMIT 1"
+                "SELECT * FROM fixtures WHERE guild_id = ? AND status = 'open' ORDER BY id DESC LIMIT 1",
+                (guild_id,),
             ) as cursor:
                 row = await cursor.fetchone()
                 return self._row_to_fixture(row) if row else None
 
-    async def get_open_fixtures(self) -> list[dict]:
-        """Get all open fixtures ordered by week and creation order."""
+    async def get_open_fixtures(self, guild_id: str) -> list[dict]:
+        """Get open fixtures for a guild ordered by week and creation order."""
+        _validate_guild_id(guild_id)
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
-                "SELECT * FROM fixtures WHERE status = 'open' ORDER BY week_number ASC, id ASC"
+                "SELECT * FROM fixtures WHERE guild_id = ? AND status = 'open' ORDER BY week_number ASC, id ASC",
+                (guild_id,),
             ) as cursor:
                 rows = await cursor.fetchall()
                 return [self._row_to_fixture(row) for row in rows]
 
-    async def get_open_fixture_by_week(self, week_number: int) -> dict | None:
-        """Get an open fixture by week number."""
+    async def get_all_open_fixtures(self) -> list[dict]:
+        """Get all open fixtures for process-level background tasks."""
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
-                "SELECT * FROM fixtures WHERE status = 'open' AND week_number = ? ORDER BY id DESC LIMIT 1",
-                (week_number,),
-            ) as cursor:
-                row = await cursor.fetchone()
-                return self._row_to_fixture(row) if row else None
-
-    async def get_fixture_by_id(self, fixture_id: int) -> dict | None:
-        """Get a specific fixture by ID."""
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            async with db.execute("SELECT * FROM fixtures WHERE id = ?", (fixture_id,)) as cursor:
-                row = await cursor.fetchone()
-                return self._row_to_fixture(row) if row else None
-
-    async def get_fixture_by_week(self, week_number: int) -> dict | None:
-        """Get the most recent fixture for a week, regardless of status."""
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            async with db.execute(
-                "SELECT * FROM fixtures WHERE week_number = ? ORDER BY id DESC LIMIT 1",
-                (week_number,),
-            ) as cursor:
-                row = await cursor.fetchone()
-                return self._row_to_fixture(row) if row else None
-
-    async def get_recent_fixtures(self, limit: int = 25) -> list[dict]:
-        """Get recent fixtures ordered by newest first."""
-        async with aiosqlite.connect(self.db_path) as db:
-            db.row_factory = aiosqlite.Row
-            async with db.execute(
-                "SELECT * FROM fixtures ORDER BY id DESC LIMIT ?",
-                (limit,),
+                "SELECT * FROM fixtures WHERE status = 'open' ORDER BY guild_id ASC, week_number ASC, id ASC"
             ) as cursor:
                 rows = await cursor.fetchall()
                 return [self._row_to_fixture(row) for row in rows]
 
-    async def get_fixture_by_message_id(self, message_id: str) -> dict | None:
+    async def get_open_fixture_by_week(self, guild_id: str, week_number: int) -> dict | None:
+        """Get an open fixture by guild and week number."""
+        _validate_guild_id(guild_id)
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM fixtures WHERE guild_id = ? AND status = 'open' AND week_number = ? ORDER BY id DESC LIMIT 1",
+                (guild_id, week_number),
+            ) as cursor:
+                row = await cursor.fetchone()
+                return self._row_to_fixture(row) if row else None
+
+    async def get_fixture_by_id(self, fixture_id: int, guild_id: str | None = None) -> dict | None:
+        """Get a fixture by ID, optionally requiring guild ownership."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            if guild_id is None:
+                query = "SELECT * FROM fixtures WHERE id = ?"
+                params = (fixture_id,)
+            else:
+                _validate_guild_id(guild_id)
+                query = "SELECT * FROM fixtures WHERE id = ? AND guild_id = ?"
+                params = (fixture_id, guild_id)
+            async with db.execute(query, params) as cursor:
+                row = await cursor.fetchone()
+                return self._row_to_fixture(row) if row else None
+
+    async def get_fixture_by_week(self, guild_id: str, week_number: int) -> dict | None:
+        """Get the most recent fixture for a guild week, regardless of status."""
+        _validate_guild_id(guild_id)
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM fixtures WHERE guild_id = ? AND week_number = ? ORDER BY id DESC LIMIT 1",
+                (guild_id, week_number),
+            ) as cursor:
+                row = await cursor.fetchone()
+                return self._row_to_fixture(row) if row else None
+
+    async def get_recent_fixtures(self, guild_id: str, limit: int = 25) -> list[dict]:
+        """Get recent fixtures for a guild ordered by newest first."""
+        _validate_guild_id(guild_id)
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                "SELECT * FROM fixtures WHERE guild_id = ? ORDER BY id DESC LIMIT ?",
+                (guild_id, limit),
+            ) as cursor:
+                rows = await cursor.fetchall()
+                return [self._row_to_fixture(row) for row in rows]
+
+    async def get_fixture_by_message_id(
+        self, message_id: str, guild_id: str | None = None
+    ) -> dict | None:
         """Get a fixture by its Discord message ID.
 
         Args:
@@ -199,9 +221,14 @@ class FixtureRepository:
         """
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
-            async with db.execute(
-                "SELECT * FROM fixtures WHERE message_id = ? AND status = 'open'", (message_id,)
-            ) as cursor:
+            if guild_id is None:
+                query = "SELECT * FROM fixtures WHERE message_id = ? AND status = 'open'"
+                params = (message_id,)
+            else:
+                _validate_guild_id(guild_id)
+                query = "SELECT * FROM fixtures WHERE guild_id = ? AND message_id = ? AND status = 'open'"
+                params = (guild_id, message_id)
+            async with db.execute(query, params) as cursor:
                 row = await cursor.fetchone()
                 return self._row_to_fixture(row) if row else None
 
@@ -222,14 +249,23 @@ class FixtureRepository:
             row = await cursor.fetchone()
             return row[0] if row and row[0] is not None else 0
 
-    async def delete_fixture(self, fixture_id: int) -> None:
-        """Delete a fixture and all associated data."""
+    async def delete_fixture(self, fixture_id: int, guild_id: str | None = None) -> bool:
+        """Delete a fixture and all associated data, optionally requiring guild ownership."""
         async with aiosqlite.connect(self.db_path) as db:
+            if guild_id is not None:
+                _validate_guild_id(guild_id)
+                async with db.execute(
+                    "SELECT 1 FROM fixtures WHERE id = ? AND guild_id = ?",
+                    (fixture_id, guild_id),
+                ) as cursor:
+                    if await cursor.fetchone() is None:
+                        return False
             await db.execute("DELETE FROM scores WHERE fixture_id = ?", (fixture_id,))
             await db.execute("DELETE FROM results WHERE fixture_id = ?", (fixture_id,))
             await db.execute("DELETE FROM predictions WHERE fixture_id = ?", (fixture_id,))
-            await db.execute("DELETE FROM fixtures WHERE id = ?", (fixture_id,))
+            cursor = await db.execute("DELETE FROM fixtures WHERE id = ?", (fixture_id,))
             await db.commit()
+            return cursor.rowcount > 0
 
     async def update_fixture_announcement(
         self,

--- a/typer_bot/database/predictions.py
+++ b/typer_bot/database/predictions.py
@@ -589,6 +589,7 @@ class PredictionRepository:
                     p.pending_partial_approval,
                     p.public_message_id,
                     p.public_message_kind,
+                    f.guild_id,
                     f.week_number,
                     f.games,
                     f.status
@@ -614,6 +615,7 @@ class PredictionRepository:
                         "pending_partial_approval": bool(row["pending_partial_approval"]),
                         "public_message_id": row["public_message_id"],
                         "public_message_kind": row["public_message_kind"],
+                        "guild_id": row["guild_id"],
                         "week_number": row["week_number"],
                         "games": row["games"].split("\n"),
                         "status": row["status"],

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -89,7 +89,7 @@ class ThreadPredictionHandler:
             return False
 
         message_id = str(message.channel.id)
-        fixture = await self.db.get_fixture_by_message_id(message_id)
+        fixture = await self.db.get_fixture_by_message_id(message_id, str(message.guild.id))
         if not fixture:
             return False
 

--- a/typer_bot/services/admin_service.py
+++ b/typer_bot/services/admin_service.py
@@ -32,8 +32,10 @@ class AdminService:
     def __init__(self, db: Database):
         self.db = db
 
-    async def _build_score_result(self, fixture_id: int) -> FixtureScoreResult:
-        fixture = await self.db.get_fixture_by_id(fixture_id)
+    async def _build_score_result(
+        self, fixture_id: int, guild_id: str | None = None
+    ) -> FixtureScoreResult:
+        fixture = await self.db.get_fixture_by_id(fixture_id, guild_id)
         if fixture is None:
             raise FixtureNotFoundError
 
@@ -57,9 +59,11 @@ class AdminService:
             last_fixture=last_fixture,
         )
 
-    async def calculate_fixture_scores(self, fixture_id: int) -> FixtureScoreResult:
+    async def calculate_fixture_scores(
+        self, fixture_id: int, guild_id: str | None = None
+    ) -> FixtureScoreResult:
         """Recalculate one fixture and refresh standings."""
-        fixture = await self.db.get_fixture_by_id(fixture_id)
+        fixture = await self.db.get_fixture_by_id(fixture_id, guild_id)
         if fixture is None:
             raise FixtureNotFoundError
 
@@ -104,22 +108,26 @@ class AdminService:
         )
         await self.db.save_scores(fixture_id, scores)
 
-        return await self._build_score_result(fixture_id)
+        return await self._build_score_result(fixture_id, guild_id)
 
-    async def maybe_recalculate_fixture(self, fixture_id: int) -> FixtureScoreResult | None:
+    async def maybe_recalculate_fixture(
+        self, fixture_id: int, guild_id: str | None = None
+    ) -> FixtureScoreResult | None:
         """Recalculate a fixture only when it has already been scored."""
         if not await self.db.fixture_has_scores(fixture_id):
             return None
-        return await self.calculate_fixture_scores(fixture_id)
+        return await self.calculate_fixture_scores(fixture_id, guild_id)
 
-    async def get_fixture_prediction_summary(self, fixture_id: int) -> tuple[dict, list[dict]]:
+    async def get_fixture_prediction_summary(
+        self, fixture_id: int, guild_id: str | None = None
+    ) -> tuple[dict, list[dict]]:
         """Return fixture and its predictions for panel display.
 
         Raises:
             FixtureNotFoundError: Fixture was deleted before the panel action ran.
             NoPredictionsSavedError: Fixture still exists but has no saved predictions.
         """
-        fixture = await self.db.get_fixture_by_id(fixture_id)
+        fixture = await self.db.get_fixture_by_id(fixture_id, guild_id)
         if fixture is None:
             raise FixtureNotFoundError
 
@@ -135,8 +143,9 @@ class AdminService:
         fixture_id: int,
         user_id: str,
         admin_user_id: str,
+        guild_id: str | None = None,
     ) -> tuple[dict, dict, FixtureScoreResult | None]:
-        fixture = await self.db.get_fixture_by_id(fixture_id)
+        fixture = await self.db.get_fixture_by_id(fixture_id, guild_id)
         if fixture is None:
             raise FixtureNotFoundError
 
@@ -154,15 +163,16 @@ class AdminService:
 
         recalculation = None
         if await self.db.fixture_has_scores(fixture_id):
-            recalculation = await self._build_score_result(fixture_id)
+            recalculation = await self._build_score_result(fixture_id, guild_id)
         return fixture, refreshed_prediction, recalculation
 
     async def reject_partial_prediction(
         self,
         fixture_id: int,
         user_id: str,
+        guild_id: str | None = None,
     ) -> tuple[dict, dict, FixtureScoreResult | None]:
-        fixture = await self.db.get_fixture_by_id(fixture_id)
+        fixture = await self.db.get_fixture_by_id(fixture_id, guild_id)
         if fixture is None:
             raise FixtureNotFoundError
 
@@ -176,7 +186,7 @@ class AdminService:
 
         recalculation = None
         if await self.db.fixture_has_scores(fixture_id):
-            recalculation = await self._build_score_result(fixture_id)
+            recalculation = await self._build_score_result(fixture_id, guild_id)
         return fixture, prediction, recalculation
 
     async def replace_prediction(
@@ -185,6 +195,7 @@ class AdminService:
         user_id: str,
         prediction_lines: str,
         admin_user_id: str,
+        guild_id: str | None = None,
     ) -> tuple[dict, dict, FixtureScoreResult | None]:
         """Replace a stored prediction through an explicit admin action.
 
@@ -194,7 +205,7 @@ class AdminService:
             PredictionDisappearedError: Update succeeded but the refreshed row vanished.
             ValueError: Validation or write failures that should surface directly to admins.
         """
-        fixture = await self.db.get_fixture_by_id(fixture_id)
+        fixture = await self.db.get_fixture_by_id(fixture_id, guild_id)
         if fixture is None:
             raise FixtureNotFoundError
 
@@ -221,13 +232,14 @@ class AdminService:
 
         recalculation = None
         if await self.db.fixture_has_scores(fixture_id):
-            recalculation = await self._build_score_result(fixture_id)
+            recalculation = await self._build_score_result(fixture_id, guild_id)
         return fixture, refreshed_prediction, recalculation
 
     async def toggle_late_penalty_waiver(
         self,
         fixture_id: int,
         user_id: str,
+        guild_id: str | None = None,
     ) -> tuple[dict, dict, FixtureScoreResult | None]:
         """Toggle the waiver flag for a stored late prediction.
 
@@ -237,7 +249,7 @@ class AdminService:
             PredictionDisappearedError: Waiver update succeeded but the refreshed row vanished.
             ValueError: On-time or write-failure cases that should surface directly to admins.
         """
-        fixture = await self.db.get_fixture_by_id(fixture_id)
+        fixture = await self.db.get_fixture_by_id(fixture_id, guild_id)
         if fixture is None:
             raise FixtureNotFoundError
 
@@ -257,16 +269,17 @@ class AdminService:
 
         recalculation = None
         if await self.db.fixture_has_scores(fixture_id):
-            recalculation = await self._build_score_result(fixture_id)
+            recalculation = await self._build_score_result(fixture_id, guild_id)
         return fixture, refreshed_prediction, recalculation
 
     async def correct_results(
         self,
         fixture_id: int,
         results_lines: str,
+        guild_id: str | None = None,
     ) -> tuple[dict, list[str], FixtureScoreResult | None]:
         """Replace stored results and recalculate scored fixtures."""
-        fixture = await self.db.get_fixture_by_id(fixture_id)
+        fixture = await self.db.get_fixture_by_id(fixture_id, guild_id)
         if fixture is None:
             raise FixtureNotFoundError
 
@@ -275,5 +288,7 @@ class AdminService:
             raise ValueError("\n".join(errors))
 
         recalculated = await self.db.save_results_with_recalc(fixture_id, results)
-        recalculation = await self._build_score_result(fixture_id) if recalculated else None
+        recalculation = (
+            await self._build_score_result(fixture_id, guild_id) if recalculated else None
+        )
         return fixture, results, recalculation


### PR DESCRIPTION
## Summary
- scope fixture reads, week lookups, and recent fixture selectors by guild
- pass guild context through user prediction flows and admin panel fixture selectors
- guard stale by-id admin and user fixture actions against cross-guild fixture IDs
- keep process-wide open fixture reads explicit for the later runtime/background task work

Closes #196

## Testing
- `uv run pytest --tb=short`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check typer_bot`

## Notes
- Standings/latest-results aggregation remains global and is intentionally left for #197.
- Reminder routing and process-local cooldown scoping remain #199 work.
