### PR TITLE
refactor: scope standings by guild

### DIFF
--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1605,7 +1605,65 @@ class TestFixturePanelFlows:
         post_button = _get_button(view, "Re-post Results")
         await post_button.callback(mock_interaction_admin)
 
+        admin_cog.db.get_last_fixture_scores.assert_awaited_once_with("111111")
+        admin_cog.db.get_standings.assert_awaited_once_with("111111")
         assert isinstance(mock_interaction_admin.response_sent[-1]["view"], PostResultsConfirmView)
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_post_results_only_previews_current_guild_scores(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+    ):
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.id = mock_interaction_admin.channel.id
+        mock_interaction_admin.channel = channel
+        deadline = datetime.now(UTC) - timedelta(days=1)
+        current_fixture_id = await admin_cog.db.create_fixture(
+            "111111", 1, ["Team A - Team B"], deadline
+        )
+        other_fixture_id = await admin_cog.db.create_fixture(
+            "guild-2", 2, ["Team C - Team D"], deadline
+        )
+        await admin_cog.db.save_scores(
+            current_fixture_id,
+            [
+                {
+                    "user_id": "current-user",
+                    "user_name": "Current Guild",
+                    "points": 3,
+                    "exact_scores": 1,
+                    "correct_results": 0,
+                }
+            ],
+        )
+        await admin_cog.db.save_scores(
+            other_fixture_id,
+            [
+                {
+                    "user_id": "other-user",
+                    "user_name": "Other Guild",
+                    "points": 9,
+                    "exact_scores": 3,
+                    "correct_results": 3,
+                }
+            ],
+        )
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            "111111",
+            admin_commands=admin_cog,
+            bot=admin_cog.bot,
+        )
+        post_button = _get_button(view, "Re-post Results")
+        await post_button.callback(mock_interaction_admin)
+
+        content = mock_interaction_admin.response_sent[-1]["content"]
+        assert "Current Guild" in content
+        assert "Other Guild" not in content
 
     @pytest.mark.asyncio
     async def test_unified_panel_jump_to_week_reaches_older_open_fixture(
@@ -1713,6 +1771,8 @@ class TestFixturePanelFlows:
         post_button = _get_button(view, "Re-post Results")
         await post_button.callback(mock_interaction_admin)
 
+        admin_cog.db.get_last_fixture_scores.assert_awaited_once_with("111111")
+        admin_cog.db.get_standings.assert_awaited_once_with("111111")
         assert "text channels" in mock_interaction_admin.response_sent[-1]["content"]
 
     @pytest.mark.asyncio
@@ -1737,6 +1797,7 @@ class TestFixturePanelFlows:
         post_button = _get_button(view, "Re-post Results")
         await post_button.callback(mock_interaction_admin)
 
+        admin_cog.db.get_last_fixture_scores.assert_awaited_once_with("111111")
         assert "No completed fixtures found" in mock_interaction_admin.response_sent[-1]["content"]
 
     @pytest.mark.asyncio
@@ -2529,7 +2590,7 @@ class TestResultsPanelFlows:
         approve_button = _get_button(view, "Approve Late")
         await approve_button.callback(mock_interaction_admin)
 
-        standings = await admin_cog.db.get_standings()
+        standings = await admin_cog.db.get_standings("111111")
         assert {row["user_id"] for row in standings} == {"999", "111"}
 
     @pytest.mark.asyncio
@@ -2580,7 +2641,7 @@ class TestResultsPanelFlows:
         reject_button = _get_button(view, "Reject Late")
         await reject_button.callback(mock_interaction_admin)
 
-        standings = await admin_cog.db.get_standings()
+        standings = await admin_cog.db.get_standings("111111")
         assert {row["user_id"] for row in standings} == {"999"}
 
 

--- a/tests/test_admin_service.py
+++ b/tests/test_admin_service.py
@@ -40,7 +40,7 @@ class TestLatePenaltyWaiver:
         await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
         await service.calculate_fixture_scores(fixture_id)
 
-        standings = await database.get_standings()
+        standings = await database.get_standings("111111")
         assert standings[0]["total_points"] == 0
 
         fixture, prediction, recalculation = await service.toggle_late_penalty_waiver(
@@ -52,7 +52,7 @@ class TestLatePenaltyWaiver:
         assert prediction["late_penalty_waived"] == 1
         assert recalculation is not None
 
-        standings = await database.get_standings()
+        standings = await database.get_standings("111111")
         assert standings[0]["total_points"] == 9
 
     @pytest.mark.asyncio
@@ -315,7 +315,7 @@ class TestPredictionReplacement:
         await database.save_results(fixture_id, ["1-0", "1-1", "0-0"])
         await service.calculate_fixture_scores(fixture_id)
 
-        before = await database.get_standings()
+        before = await database.get_standings("111111")
         assert before[0]["total_points"] == 9
 
         _fixture, updated_prediction, recalculation = await service.replace_prediction(
@@ -328,7 +328,7 @@ class TestPredictionReplacement:
         assert updated_prediction["admin_edited_by"] == "admin-1"
         assert recalculation is not None
 
-        after = await database.get_standings()
+        after = await database.get_standings("111111")
         assert after[0]["total_points"] == 2
 
 
@@ -376,7 +376,7 @@ class TestResultCorrection:
         await database.save_results(fixture2_id, ["2-0", "0-0", "1-1"])
         await service.calculate_fixture_scores(fixture2_id)
 
-        before = await database.get_standings()
+        before = await database.get_standings("111111")
         assert before[0]["user_id"] == "user-1"
         assert before[0]["total_points"] == 18
         assert before[1]["total_points"] == 7
@@ -390,7 +390,7 @@ class TestResultCorrection:
         assert results == ["2-1", "1-1", "0-2"]
         assert recalculation is not None
 
-        after = await database.get_standings()
+        after = await database.get_standings("111111")
         assert after[0]["user_id"] == "user-1"
         assert after[0]["total_points"] == 16
         assert after[1]["user_id"] == "user-2"
@@ -475,6 +475,45 @@ class TestPartialPredictionApproval:
         assert [score["user_id"] for score in result.scores] == ["111"]
 
     @pytest.mark.asyncio
+    async def test_calculated_score_payload_uses_fixture_guild_standings(
+        self,
+        database,
+        sample_games,
+    ):
+        service = AdminService(database)
+        current_fixture_id = await database.create_fixture(
+            "111111", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        other_fixture_id = await database.create_fixture(
+            "guild-2", 1, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await database.save_results(current_fixture_id, ["2-1", "1-1", "0-2"])
+        await database.save_prediction(
+            current_fixture_id,
+            "shared-user",
+            "Guild One",
+            ["2-1", "1-1", "0-2"],
+            False,
+        )
+        await database.save_results(other_fixture_id, ["2-1", "1-1", "0-2"])
+        await database.save_prediction(
+            other_fixture_id,
+            "shared-user",
+            "Guild Two",
+            ["2-1", "1-1", "0-2"],
+            False,
+        )
+
+        await service.calculate_fixture_scores(other_fixture_id)
+        result = await service.calculate_fixture_scores(current_fixture_id)
+
+        assert [row["user_id"] for row in result.standings] == ["shared-user"]
+        assert result.standings[0]["user_name"] == "Guild One"
+        assert result.standings[0]["weeks_played"] == 1
+        assert result.last_fixture is not None
+        assert result.last_fixture["fixture_id"] == current_fixture_id
+
+    @pytest.mark.asyncio
     async def test_approved_partial_prediction_scores_only_selected_rows(
         self,
         database,
@@ -546,7 +585,7 @@ class TestPartialPredictionApproval:
 
         assert approved_prediction["pending_partial_approval"] is False
         assert recalculation is not None
-        standings = await database.get_standings()
+        standings = await database.get_standings("111111")
         assert {row["user_id"] for row in standings} == {"111", "222"}
 
     @pytest.mark.asyncio

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -157,6 +157,42 @@ class TestOpenFixturesQueries:
         assert await db.get_fixture_by_id(fixture_id) is None
 
     @pytest.mark.asyncio
+    async def test_pending_partial_predictions_are_guild_scoped(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        deadline = datetime.now(UTC) - timedelta(hours=1)
+        guild_one_fixture_id = await db.create_fixture(
+            "111111", 1, ["Team A - Team B", "Team C - Team D"], deadline
+        )
+        guild_two_fixture_id = await db.create_fixture(
+            "guild-2", 1, ["Team E - Team F", "Team G - Team H"], deadline
+        )
+        await db.save_prediction(
+            guild_one_fixture_id,
+            "guild-one-user",
+            "Guild One",
+            ["1-1"],
+            True,
+            predicted_game_indexes=[0],
+            pending_partial_approval=True,
+        )
+        await db.save_prediction(
+            guild_two_fixture_id,
+            "guild-two-user",
+            "Guild Two",
+            ["2-2"],
+            True,
+            predicted_game_indexes=[1],
+            pending_partial_approval=True,
+        )
+
+        guild_one_pending = await db.get_pending_partial_predictions("111111")
+        guild_two_pending = await db.get_pending_partial_predictions("guild-2")
+
+        assert [prediction["user_id"] for prediction in guild_one_pending] == ["guild-one-user"]
+        assert [prediction["user_id"] for prediction in guild_two_pending] == ["guild-two-user"]
+
+    @pytest.mark.asyncio
     async def test_create_next_fixture_allocates_incrementing_weeks(self, temp_db_path):
         """Atomic allocator should issue increasing week numbers."""
         db = Database(temp_db_path)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -160,9 +160,94 @@ class TestEdgeCases:
             ],
         )
 
-        standings = await database.get_standings()
+        standings = await database.get_standings("111111")
         assert len(standings) == 1
         assert standings[0]["total_points"] == 6
+
+    @pytest.mark.asyncio
+    async def test_standings_are_guild_scoped_for_same_user(self, database):
+        games = ["Team A - Team B"]
+        deadline = datetime.now(UTC) - timedelta(days=1)
+        guild_one_fixture_id = await database.create_fixture("111111", 1, games, deadline)
+        guild_two_fixture_id = await database.create_fixture("guild-2", 1, games, deadline)
+
+        await database.save_scores(
+            guild_one_fixture_id,
+            [
+                {
+                    "user_id": "shared-user",
+                    "user_name": "Guild One",
+                    "points": 3,
+                    "exact_scores": 1,
+                    "correct_results": 0,
+                }
+            ],
+        )
+        await database.save_scores(
+            guild_two_fixture_id,
+            [
+                {
+                    "user_id": "shared-user",
+                    "user_name": "Guild Two",
+                    "points": 9,
+                    "exact_scores": 3,
+                    "correct_results": 3,
+                }
+            ],
+        )
+
+        guild_one_standings = await database.get_standings("111111")
+        guild_two_standings = await database.get_standings("guild-2")
+
+        assert [row["user_id"] for row in guild_one_standings] == ["shared-user"]
+        assert guild_one_standings[0]["user_name"] == "Guild One"
+        assert guild_one_standings[0]["total_points"] == 3
+        assert guild_one_standings[0]["weeks_played"] == 1
+        assert [row["user_id"] for row in guild_two_standings] == ["shared-user"]
+        assert guild_two_standings[0]["user_name"] == "Guild Two"
+        assert guild_two_standings[0]["total_points"] == 9
+        assert guild_two_standings[0]["weeks_played"] == 1
+
+    @pytest.mark.asyncio
+    async def test_last_fixture_scores_are_guild_scoped(self, database):
+        games = ["Team A - Team B"]
+        deadline = datetime.now(UTC) - timedelta(days=1)
+        guild_one_fixture_id = await database.create_fixture("111111", 1, games, deadline)
+        guild_two_fixture_id = await database.create_fixture("guild-2", 2, games, deadline)
+
+        await database.save_scores(
+            guild_one_fixture_id,
+            [
+                {
+                    "user_id": "guild-one-user",
+                    "user_name": "Guild One",
+                    "points": 3,
+                    "exact_scores": 1,
+                    "correct_results": 0,
+                }
+            ],
+        )
+        await database.save_scores(
+            guild_two_fixture_id,
+            [
+                {
+                    "user_id": "guild-two-user",
+                    "user_name": "Guild Two",
+                    "points": 9,
+                    "exact_scores": 3,
+                    "correct_results": 3,
+                }
+            ],
+        )
+
+        guild_one_last = await database.get_last_fixture_scores("111111")
+        guild_two_last = await database.get_last_fixture_scores("guild-2")
+
+        assert guild_one_last is not None
+        assert guild_one_last["fixture_id"] == guild_one_fixture_id
+        assert [score["user_id"] for score in guild_one_last["scores"]] == ["guild-one-user"]
+        assert guild_two_last is not None
+        assert guild_two_last["fixture_id"] == guild_two_fixture_id
 
     @pytest.mark.asyncio
     async def test_max_week_number_increment(self, database):
@@ -271,7 +356,7 @@ class TestUsernameChangeHandling:
             ],
         )
 
-        standings = await database.get_standings()
+        standings = await database.get_standings("111111")
         assert len(standings) == 1
         assert standings[0]["total_points"] == 6
         assert standings[0]["weeks_played"] == 2
@@ -333,7 +418,7 @@ class TestUsernameChangeHandling:
             ],
         )
 
-        standings = await database.get_standings()
+        standings = await database.get_standings("111111")
         assert len(standings) == 1
         assert standings[0]["user_name"] == "NewName"
         assert standings[0]["total_points"] == 3

--- a/tests/test_seed_test_data.py
+++ b/tests/test_seed_test_data.py
@@ -33,7 +33,7 @@ async def test_seed_mixed_data_creates_expected_fixture_states(temp_db_path, tmp
 
     db = Database(temp_db_path)
     open_fixtures = await db.get_open_fixtures(DEFAULT_MANUAL_GUILD_ID)
-    standings = await db.get_standings()
+    standings = await db.get_standings(DEFAULT_MANUAL_GUILD_ID)
     week_one = await db.get_fixture_by_week(DEFAULT_MANUAL_GUILD_ID, 1)
     week_two = await db.get_fixture_by_week(DEFAULT_MANUAL_GUILD_ID, 2)
     week_three = await db.get_fixture_by_week(DEFAULT_MANUAL_GUILD_ID, 3)

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -896,10 +896,50 @@ class TestStandingsCommand:
 
         await user_commands.standings.callback(user_commands, mock_interaction)
 
+        user_commands.db.get_standings.assert_awaited_once_with("111111")
+        user_commands.db.get_last_fixture_scores.assert_awaited_once_with("111111")
         content = mock_interaction.response_sent[0]["content"]
         assert "User1" in content
         assert "9" in content
-        assert "Week 4" in content
+
+    @pytest.mark.asyncio
+    async def test_standings_only_shows_current_guild_scores(
+        self, user_commands, mock_interaction, database
+    ):
+        games = ["Team A - Team B"]
+        deadline = datetime.now(UTC) - timedelta(days=1)
+        current_fixture_id = await database.create_fixture("111111", 1, games, deadline)
+        other_fixture_id = await database.create_fixture("guild-2", 2, games, deadline)
+        await database.save_scores(
+            current_fixture_id,
+            [
+                {
+                    "user_id": "current-user",
+                    "user_name": "Current Guild",
+                    "points": 3,
+                    "exact_scores": 1,
+                    "correct_results": 0,
+                }
+            ],
+        )
+        await database.save_scores(
+            other_fixture_id,
+            [
+                {
+                    "user_id": "other-user",
+                    "user_name": "Other Guild",
+                    "points": 9,
+                    "exact_scores": 3,
+                    "correct_results": 3,
+                }
+            ],
+        )
+
+        await user_commands.standings.callback(user_commands, mock_interaction)
+
+        content = mock_interaction.response_sent[0]["content"]
+        assert "Current Guild" in content
+        assert "Other Guild" not in content
 
 
 class TestMyPredictionsCommand:

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -165,11 +165,9 @@ class ReviewPendingPartialsButton(discord.ui.Button):
         super().__init__(label="Review Late", style=discord.ButtonStyle.primary, row=4)
 
     async def callback(self, interaction: discord.Interaction):
-        pending_predictions = [
-            pending
-            for pending in await self.parent_view.db.get_pending_partial_predictions()
-            if pending.get("guild_id") == self.parent_view.guild_id
-        ]
+        pending_predictions = await self.parent_view.db.get_pending_partial_predictions(
+            self.parent_view.guild_id
+        )
         if not pending_predictions:
             await interaction.response.send_message(
                 "There are no late predictions awaiting review right now.", ephemeral=True
@@ -448,8 +446,8 @@ class PostResultsButton(discord.ui.Button):
         super().__init__(label="Re-post Results", style=discord.ButtonStyle.secondary, row=3)
 
     async def callback(self, interaction: discord.Interaction):
-        fixture_data = await self.parent_view.db.get_last_fixture_scores()
-        standings = await self.parent_view.db.get_standings()
+        fixture_data = await self.parent_view.db.get_last_fixture_scores(self.parent_view.guild_id)
+        standings = await self.parent_view.db.get_standings(self.parent_view.guild_id)
         if not fixture_data:
             await interaction.response.send_message(
                 "No completed fixtures found with scores!", ephemeral=True
@@ -538,9 +536,8 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
     async def load_fixture_options(self) -> None:
         fixtures = await self.db.get_recent_fixtures(self.guild_id, MAX_SELECT_OPTIONS)
         self.fixture_select.update_options(fixtures)
-        self.has_pending_partials = any(
-            pending.get("guild_id") == self.guild_id
-            for pending in await self.db.get_pending_partial_predictions()
+        self.has_pending_partials = bool(
+            await self.db.get_pending_partial_predictions(self.guild_id)
         )
         self._refresh_items()
 

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -719,8 +719,12 @@ Use these directly in Discord."""
     )
     async def standings(self, interaction: discord.Interaction):
         """Display overall standings."""
-        standings = await self.db.get_standings()
-        last_fixture = await self.db.get_last_fixture_scores()
+        guild_id = await _require_guild_id(interaction)
+        if guild_id is None:
+            return
+
+        standings = await self.db.get_standings(guild_id)
+        last_fixture = await self.db.get_last_fixture_scores(guild_id)
 
         message = format_standings(standings, last_fixture)
 

--- a/typer_bot/database/connection.py
+++ b/typer_bot/database/connection.py
@@ -395,8 +395,8 @@ class Database:
             fixture_id, include_pending=include_pending
         )
 
-    async def get_pending_partial_predictions(self):
-        return await self._predictions.get_pending_partial_predictions()
+    async def get_pending_partial_predictions(self, guild_id):
+        return await self._predictions.get_pending_partial_predictions(guild_id)
 
     async def approve_partial_prediction(self, fixture_id, user_id, admin_user_id):
         return await self._predictions.approve_partial_prediction_with_recalc(
@@ -425,8 +425,8 @@ class Database:
     async def save_scores(self, fixture_id, scores):
         return await self._scores.save_scores(fixture_id, scores)
 
-    async def get_standings(self):
-        return await self._scores.get_standings()
+    async def get_standings(self, guild_id):
+        return await self._scores.get_standings(guild_id)
 
-    async def get_last_fixture_scores(self):
-        return await self._scores.get_last_fixture_scores()
+    async def get_last_fixture_scores(self, guild_id):
+        return await self._scores.get_last_fixture_scores(guild_id)

--- a/typer_bot/database/predictions.py
+++ b/typer_bot/database/predictions.py
@@ -572,8 +572,8 @@ class PredictionRepository:
                 rows = await cursor.fetchall()
                 return [self._prediction_row_to_dict(row) for row in rows]
 
-    async def get_pending_partial_predictions(self) -> list[dict]:
-        """List all pending partial predictions with fixture metadata."""
+    async def get_pending_partial_predictions(self, guild_id: str) -> list[dict]:
+        """List pending partial predictions with fixture metadata for one guild."""
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
@@ -595,9 +595,10 @@ class PredictionRepository:
                     f.status
                 FROM predictions p
                 JOIN fixtures f ON f.id = p.fixture_id
-                WHERE p.pending_partial_approval = TRUE
+                WHERE p.pending_partial_approval = TRUE AND f.guild_id = ?
                 ORDER BY f.week_number ASC, p.user_name COLLATE NOCASE ASC
-                """
+                """,
+                (guild_id,),
             ) as cursor:
                 rows = await cursor.fetchall()
                 return [

--- a/typer_bot/database/scores.py
+++ b/typer_bot/database/scores.py
@@ -224,23 +224,28 @@ class ScoreRepository:
                     )
                 raise
 
-    async def get_standings(self) -> list[dict]:
-        """Get overall standings across all fixtures."""
+    async def get_standings(self, guild_id: str) -> list[dict]:
+        """Get standings for one guild."""
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
                 """SELECT
                           s.user_id,
                           (SELECT user_name FROM scores s2
+                           JOIN fixtures f2 ON f2.id = s2.fixture_id
                            WHERE s2.user_id = s.user_id
+                             AND f2.guild_id = ?
                            ORDER BY fixture_id DESC LIMIT 1) as user_name,
                           SUM(s.points) as total_points,
                           SUM(s.exact_scores) as total_exact,
                           SUM(s.correct_results) as total_correct,
                           COUNT(DISTINCT s.fixture_id) as weeks_played
-                   FROM scores s
-                   GROUP BY s.user_id
-                   ORDER BY total_points DESC, total_exact DESC, total_correct DESC, user_name ASC"""
+                    FROM scores s
+                    JOIN fixtures f ON f.id = s.fixture_id
+                    WHERE f.guild_id = ?
+                    GROUP BY s.user_id
+                    ORDER BY total_points DESC, total_exact DESC, total_correct DESC, user_name ASC""",
+                (guild_id, guild_id),
             ) as cursor:
                 rows = await cursor.fetchall()
                 return [
@@ -255,28 +260,31 @@ class ScoreRepository:
                     for row in rows
                 ]
 
-    async def get_last_fixture_scores(self) -> dict | None:
-        """Get scores from the most recently closed fixture."""
+    async def get_last_fixture_scores(self, guild_id: str) -> dict | None:
+        """Get scores from the most recently closed fixture in one guild."""
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
                 """SELECT s.*, f.week_number
                    FROM scores s
                    JOIN fixtures f ON s.fixture_id = f.id
-                   WHERE f.status = 'closed'
+                   WHERE f.status = 'closed' AND f.guild_id = ?
                    ORDER BY f.id DESC
-                   LIMIT 1"""
+                   LIMIT 1""",
+                (guild_id,),
             ) as cursor:
                 row = await cursor.fetchone()
                 if row:
                     fixture_id = row["fixture_id"]
                     async with db.execute(
                         """
-                        SELECT * FROM scores
-                        WHERE fixture_id = ?
-                        ORDER BY points DESC, exact_scores DESC, correct_results DESC, user_name ASC
-                        """,
-                        (fixture_id,),
+                         SELECT s.*
+                         FROM scores s
+                         JOIN fixtures f ON f.id = s.fixture_id
+                         WHERE s.fixture_id = ? AND f.guild_id = ?
+                         ORDER BY points DESC, exact_scores DESC, correct_results DESC, user_name ASC
+                         """,
+                        (fixture_id, guild_id),
                     ) as cursor2:
                         scores = await cursor2.fetchall()
                         return {

--- a/typer_bot/services/admin_service.py
+++ b/typer_bot/services/admin_service.py
@@ -47,9 +47,10 @@ class AdminService:
         if not predictions:
             raise ValueError("No predictions found for this fixture")
 
+        effective_guild_id = guild_id or fixture["guild_id"]
         scores = await self.db.get_scores_for_fixture(fixture_id)
-        standings = await self.db.get_standings()
-        last_fixture = await self.db.get_last_fixture_scores()
+        standings = await self.db.get_standings(effective_guild_id)
+        last_fixture = await self.db.get_last_fixture_scores(effective_guild_id)
         return FixtureScoreResult(
             fixture=fixture,
             results=results,


### PR DESCRIPTION
## Summary
- scope standings, latest scored fixture lookup, and pending late-review queries by guild
- pass guild context through `/standings`, admin score payloads, and Re-post Results
- add multi-guild regression coverage for same-user standings, latest results, pending review, and UI previews

Closes #197

## Testing
- `uv run pytest --tb=short`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check typer_bot`

## Notes
- Guild config and runtime reminder/channel routing remain #198 and #199 work.