### PR TITLE
feat: add minimal guild config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Discord bot for weekly football prediction leagues. Admins create fixtures and e
 - `/standings` - show the leaderboard and latest scored fixture
 
 ### Admin commands
-- `/admin setup admin_role:<role> channel:<text channel>` - configure the TyperBot admin role and league channel for this server
-- `/admin panel` - open the main admin surface
+- `/admin panel` - open the main admin surface, or start first-time setup when the server is not configured yet
 
 The panel handles:
 - create fixtures
@@ -32,7 +31,7 @@ The panel handles:
 - review late partial predictions
 - toggle late waivers
 
-After setup, admins need the configured TyperBot admin role. Only Discord-native server managers/admins can run `/admin setup`.
+After setup, admins need the configured TyperBot admin role. Only Discord-native server managers/admins can complete first-time setup from `/admin panel`.
 
 ## Permissions
 - `Send Messages`
@@ -90,7 +89,7 @@ Team E - Team F 3:2
 - `TZ` - timezone for admin deadline input; default `UTC`
 - `LOG_LEVEL` - logging level; default `INFO`
 
-Run `/admin setup` in each server to store the admin role and league channel. Fixture announcements and deadline reminders both use that league channel.
+Run `/admin panel` in each server to store the admin role and league channel. Fixture announcements and deadline reminders both use that league channel.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The panel handles:
 - review late partial predictions
 - toggle late waivers
 
-After setup, admins need the configured TyperBot admin role. Only Discord-native server managers/admins can complete first-time setup from `/admin panel`.
+After setup, admins need the configured TyperBot admin role. Only Discord-native server managers/admins can complete or update setup from `/admin panel`.
 
 ## Permissions
 - `Send Messages`
@@ -89,7 +89,7 @@ Team E - Team F 3:2
 - `TZ` - timezone for admin deadline input; default `UTC`
 - `LOG_LEVEL` - logging level; default `INFO`
 
-Run `/admin panel` in each server to store the admin role and league channel. Fixture announcements and deadline reminders both use that league channel.
+Run `/admin panel` in each server to store or update the admin role and league channel. Fixture announcements and deadline reminders both use that league channel.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Discord bot for weekly football prediction leagues. Admins create fixtures and e
 - `/standings` - show the leaderboard and latest scored fixture
 
 ### Admin commands
+- `/admin setup admin_role:<role> channel:<text channel>` - configure the TyperBot admin role and league channel for this server
 - `/admin panel` - open the main admin surface
 
 The panel handles:
@@ -31,7 +32,7 @@ The panel handles:
 - review late partial predictions
 - toggle late waivers
 
-Admins need a Discord role named `Admin` or `typer-admin`.
+After setup, admins need the configured TyperBot admin role. Only Discord-native server managers/admins can run `/admin setup`.
 
 ## Permissions
 - `Send Messages`
@@ -87,8 +88,9 @@ Team E - Team F 3:2
 - `DB_PATH` - database path; default `{DATA_DIR}/typer.db`
 - `BACKUP_DIR` - backup directory; default `{DATA_DIR}/backups`
 - `TZ` - timezone for admin deadline input; default `UTC`
-- `REMINDER_CHANNEL_ID` - reminder channel ID
 - `LOG_LEVEL` - logging level; default `INFO`
+
+Run `/admin setup` in each server to store the admin role and league channel. Fixture announcements and deadline reminders both use that league channel.
 
 ## Deployment
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ def mock_bot():
 async def database(temp_db_path):
     db = Database(temp_db_path)
     await db.initialize()
+    await db.upsert_guild_config("111111", str(MockRole("admin").id), "123456")
     yield db
 
 
@@ -108,6 +109,7 @@ class MockGuild:
         mock_member = MagicMock()
         mock_member.id = int(user_id)
         mock_member.roles = [MockRole(role) for role in (roles or [])]
+        mock_member.guild_permissions = MagicMock(administrator=False, manage_guild=False)
         self._members[int(user_id)] = mock_member
         return mock_member
 
@@ -228,9 +230,10 @@ def handler(mock_bot, database):
 
 
 class MockRole:
-    def __init__(self, name: str):
-        self.id = abs(hash(name)) % 1000000 or 1
+    def __init__(self, name: str, role_id: int | None = None):
+        self.id = role_id or abs(hash(name)) % 1000000 or 1
         self.name = name
+        self.mention = f"<@&{self.id}>"
 
 
 class MockAdminUser(MockUser):
@@ -244,6 +247,7 @@ class MockTextChannel:
         self.id = int(channel_id)
         self.name = name
         self._guild = guild
+        self.mention = f"<#{self.id}>"
         self.messages_sent = []
         self.threads_created = []
 
@@ -274,6 +278,7 @@ class MockGuildWithMembers(MockGuild):
         mock_member = MagicMock()
         mock_member.id = int(user_id)
         mock_member.roles = [MockRole(role) for role in (roles or [])]
+        mock_member.guild_permissions = MagicMock(administrator=False, manage_guild=False)
         self._members[int(user_id)] = mock_member
         return mock_member
 

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -174,11 +174,51 @@ class TestAdminPanelEntry:
         assert isinstance(mock_interaction_admin.response_sent[-1]["view"], GuildSetupPromptView)
 
     @pytest.mark.asyncio
+    async def test_panel_check_prompts_server_manager_to_setup_inline(
+        self,
+        mock_bot,
+        mock_interaction_admin,
+        temp_db_path,
+    ):
+        db = Database(temp_db_path)
+        await db.initialize()
+        mock_bot.db = db
+        admin_cog = AdminCommands(mock_bot)
+        mock_interaction_admin.client = mock_bot
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.guild_permissions.manage_guild = True
+
+        can_run = await admin_cog.panel.checks[0](mock_interaction_admin)
+
+        assert can_run is False
+        assert isinstance(mock_interaction_admin.response_sent[-1]["view"], GuildSetupPromptView)
+
+    @pytest.mark.asyncio
+    async def test_panel_check_blocks_non_manager_without_setup(
+        self,
+        mock_bot,
+        mock_interaction_admin,
+        temp_db_path,
+    ):
+        db = Database(temp_db_path)
+        await db.initialize()
+        mock_bot.db = db
+        admin_cog = AdminCommands(mock_bot)
+        mock_interaction_admin.client = mock_bot
+
+        can_run = await admin_cog.panel.checks[0](mock_interaction_admin)
+
+        assert can_run is False
+        assert mock_interaction_admin.response_sent[-1].get("view") is None
+
+    @pytest.mark.asyncio
     async def test_inline_setup_prompt_saves_config(
         self,
-        database,
+        temp_db_path,
         mock_interaction_admin,
     ):
+        database = Database(temp_db_path)
+        await database.initialize()
         member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
         member.guild_permissions.manage_guild = True
         view = GuildSetupPromptView(database, str(mock_interaction_admin.user.id))

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -9,6 +9,7 @@ from tests.conftest import MockRole, MockTextChannel
 from typer_bot.commands.admin_commands import (
     CALCULATE_COOLDOWN,
     AdminCommands,
+    GuildSetupPromptView,
 )
 from typer_bot.commands.admin_panel import PostResultsConfirmView, UnifiedAdminPanelView
 from typer_bot.database import Database
@@ -153,6 +154,43 @@ class TestAdminPanelEntry:
         await admin_cog.panel.callback(admin_cog, mock_interaction_admin)
 
         assert "not set up" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_panel_prompts_server_manager_to_setup_inline(
+        self,
+        mock_bot,
+        mock_interaction_admin,
+        temp_db_path,
+    ):
+        db = Database(temp_db_path)
+        await db.initialize()
+        mock_bot.db = db
+        admin_cog = AdminCommands(mock_bot)
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.guild_permissions.manage_guild = True
+
+        await admin_cog.panel.callback(admin_cog, mock_interaction_admin)
+
+        assert isinstance(mock_interaction_admin.response_sent[-1]["view"], GuildSetupPromptView)
+
+    @pytest.mark.asyncio
+    async def test_inline_setup_prompt_saves_config(
+        self,
+        database,
+        mock_interaction_admin,
+    ):
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.guild_permissions.manage_guild = True
+        view = GuildSetupPromptView(database, str(mock_interaction_admin.user.id))
+        view.admin_role = MockRole("League Admin", role_id=987654)
+        view.league_channel = MockTextChannel("765432", guild=mock_interaction_admin.guild)
+        view.refresh_save_button()
+
+        await view.save_button.callback(mock_interaction_admin)
+
+        config = await database.get_guild_config("111111")
+        assert config["admin_role_id"] == "987654"
+        assert config["league_channel_id"] == "765432"
 
 
 class TestResultsPostFlow:

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -9,6 +9,7 @@ from tests.conftest import MockRole, MockTextChannel
 from typer_bot.commands.admin_commands import (
     CALCULATE_COOLDOWN,
     AdminCommands,
+    EveryoneRoleConfirmView,
     GuildSetupPromptView,
 )
 from typer_bot.commands.admin_panel import PostResultsConfirmView, UnifiedAdminPanelView
@@ -145,6 +146,43 @@ class TestAdminPanelEntry:
         assert "server manager" in mock_interaction_admin.response_sent[-1]["content"]
 
     @pytest.mark.asyncio
+    async def test_setup_command_requires_confirmation_for_everyone_role(
+        self,
+        mock_bot,
+        mock_interaction_admin,
+        temp_db_path,
+    ):
+        db = Database(temp_db_path)
+        await db.initialize()
+        mock_bot.db = db
+        admin_cog = AdminCommands(mock_bot)
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.guild_permissions.manage_guild = True
+        everyone_role = MockRole("@everyone", role_id=mock_interaction_admin.guild.id)
+        channel = MockTextChannel("765432", guild=mock_interaction_admin.guild)
+
+        await admin_cog.setup_config.callback(
+            admin_cog,
+            mock_interaction_admin,
+            everyone_role,
+            channel,
+        )
+
+        assert isinstance(mock_interaction_admin.response_sent[-1]["view"], EveryoneRoleConfirmView)
+        assert await db.get_guild_config("111111") is None
+
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        confirm_button = next(
+            child
+            for child in confirm_view.children
+            if getattr(child, "label", None) == "Confirm @everyone"
+        )
+        await confirm_button.callback(mock_interaction_admin)
+
+        config = await db.get_guild_config("111111")
+        assert config["admin_role_id"] == str(mock_interaction_admin.guild.id)
+
+    @pytest.mark.asyncio
     async def test_panel_requires_guild_setup(self, mock_bot, mock_interaction_admin, temp_db_path):
         db = Database(temp_db_path)
         await db.initialize()
@@ -231,6 +269,26 @@ class TestAdminPanelEntry:
         config = await database.get_guild_config("111111")
         assert config["admin_role_id"] == "987654"
         assert config["league_channel_id"] == "765432"
+
+    @pytest.mark.asyncio
+    async def test_inline_setup_prompt_requires_confirmation_for_everyone_role(
+        self,
+        temp_db_path,
+        mock_interaction_admin,
+    ):
+        database = Database(temp_db_path)
+        await database.initialize()
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.guild_permissions.manage_guild = True
+        view = GuildSetupPromptView(database, str(mock_interaction_admin.user.id))
+        view.admin_role = MockRole("@everyone", role_id=mock_interaction_admin.guild.id)
+        view.league_channel = MockTextChannel("765432", guild=mock_interaction_admin.guild)
+        view.refresh_save_button()
+
+        await view.save_button.callback(mock_interaction_admin)
+
+        assert isinstance(mock_interaction_admin.response_sent[-1]["view"], EveryoneRoleConfirmView)
+        assert await database.get_guild_config("111111") is None
 
 
 class TestResultsPostFlow:

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -14,6 +14,7 @@ from typer_bot.commands.admin_commands import (
     GuildSetupStartView,
 )
 from typer_bot.commands.admin_panel import PostResultsConfirmView, UnifiedAdminPanelView
+from typer_bot.commands.admin_panel.unified import SetupBotButton
 from typer_bot.database import Database
 from typer_bot.utils import get_admin_permission_error, has_setup_permission, now
 from typer_bot.utils.permissions import is_admin
@@ -194,6 +195,24 @@ class TestAdminPanelEntry:
             child
             for child in start_view.children
             if getattr(child, "label", None) == "Setup TyperBot"
+        )
+
+        await setup_button.callback(mock_interaction_admin)
+
+        assert isinstance(mock_interaction_admin.response_sent[-1]["view"], GuildSetupPromptView)
+
+    @pytest.mark.asyncio
+    async def test_configured_panel_setup_button_opens_reconfigure_flow(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+    ):
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.guild_permissions.manage_guild = True
+        await admin_cog.panel.callback(admin_cog, mock_interaction_admin)
+        panel_view = mock_interaction_admin.response_sent[-1]["view"]
+        setup_button = next(
+            child for child in panel_view.children if isinstance(child, SetupBotButton)
         )
 
         await setup_button.callback(mock_interaction_admin)

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -5,12 +5,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from tests.conftest import MockRole, MockTextChannel
 from typer_bot.commands.admin_commands import (
     CALCULATE_COOLDOWN,
     AdminCommands,
 )
 from typer_bot.commands.admin_panel import PostResultsConfirmView, UnifiedAdminPanelView
-from typer_bot.utils import now
+from typer_bot.database import Database
+from typer_bot.utils import get_admin_permission_error, has_setup_permission, now
 from typer_bot.utils.permissions import is_admin
 
 
@@ -46,6 +48,50 @@ class TestAdminOnlyDecorator:
         result = is_admin(mock_interaction_admin)
         assert result is True
 
+    @pytest.mark.asyncio
+    async def test_configured_admin_role_grants_access(self, database, mock_interaction_admin):
+        await database.upsert_guild_config("111111", "987654", "123456")
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.roles = [MockRole("League Admin", role_id=987654)]
+
+        assert await get_admin_permission_error(mock_interaction_admin, database) is None
+
+    @pytest.mark.asyncio
+    async def test_configured_admin_role_rejects_name_only_admin(
+        self, database, mock_interaction_admin
+    ):
+        await database.upsert_guild_config("111111", "987654", "123456")
+
+        permission_error = await get_admin_permission_error(mock_interaction_admin, database)
+        assert permission_error is not None
+        assert "permission" in permission_error
+
+    @pytest.mark.asyncio
+    async def test_configured_admin_check_uses_interaction_member_when_cache_misses(
+        self,
+        database,
+        mock_interaction_admin,
+    ):
+        await database.upsert_guild_config("111111", "987654", "123456")
+        mock_interaction_admin.guild._members.clear()
+        mock_interaction_admin.user.roles = [MockRole("League Admin", role_id=987654)]
+
+        assert await get_admin_permission_error(mock_interaction_admin, database) is None
+
+    @pytest.mark.asyncio
+    async def test_setup_permission_uses_interaction_member_when_cache_misses(
+        self,
+        mock_interaction_admin,
+    ):
+        mock_interaction_admin.guild._members.clear()
+        mock_interaction_admin.user.roles = []
+        mock_interaction_admin.user.guild_permissions = MagicMock(
+            administrator=False,
+            manage_guild=True,
+        )
+
+        assert has_setup_permission(mock_interaction_admin) is True
+
 
 class TestAdminPanelEntry:
     @pytest.fixture
@@ -61,6 +107,52 @@ class TestAdminPanelEntry:
 
     def test_admin_group_exposes_panel_command(self, admin_cog):
         assert any(command.name == "panel" for command in admin_cog.admin.commands)
+
+    def test_admin_group_exposes_setup_command(self, admin_cog):
+        assert any(command.name == "setup" for command in admin_cog.admin.commands)
+
+    @pytest.mark.asyncio
+    async def test_setup_command_persists_guild_config(self, admin_cog, mock_interaction_admin):
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.guild_permissions.manage_guild = True
+        role = MockRole("League Admin", role_id=987654)
+        channel = MockTextChannel("765432", guild=mock_interaction_admin.guild)
+
+        await admin_cog.setup_config.callback(
+            admin_cog,
+            mock_interaction_admin,
+            role,
+            channel,
+        )
+
+        config = await admin_cog.db.get_guild_config("111111")
+        assert config["admin_role_id"] == "987654"
+        assert config["league_channel_id"] == "765432"
+
+    @pytest.mark.asyncio
+    async def test_setup_command_requires_server_manager(self, admin_cog, mock_interaction_admin):
+        role = MockRole("League Admin", role_id=987654)
+        channel = MockTextChannel("765432", guild=mock_interaction_admin.guild)
+
+        await admin_cog.setup_config.callback(
+            admin_cog,
+            mock_interaction_admin,
+            role,
+            channel,
+        )
+
+        assert "server manager" in mock_interaction_admin.response_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_panel_requires_guild_setup(self, mock_bot, mock_interaction_admin, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        mock_bot.db = db
+        admin_cog = AdminCommands(mock_bot)
+
+        await admin_cog.panel.callback(admin_cog, mock_interaction_admin)
+
+        assert "not set up" in mock_interaction_admin.response_sent[-1]["content"]
 
 
 class TestResultsPostFlow:

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -11,6 +11,7 @@ from typer_bot.commands.admin_commands import (
     AdminCommands,
     EveryoneRoleConfirmView,
     GuildSetupPromptView,
+    GuildSetupStartView,
 )
 from typer_bot.commands.admin_panel import PostResultsConfirmView, UnifiedAdminPanelView
 from typer_bot.database import Database
@@ -110,77 +111,8 @@ class TestAdminPanelEntry:
     def test_admin_group_exposes_panel_command(self, admin_cog):
         assert any(command.name == "panel" for command in admin_cog.admin.commands)
 
-    def test_admin_group_exposes_setup_command(self, admin_cog):
-        assert any(command.name == "setup" for command in admin_cog.admin.commands)
-
-    @pytest.mark.asyncio
-    async def test_setup_command_persists_guild_config(self, admin_cog, mock_interaction_admin):
-        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
-        member.guild_permissions.manage_guild = True
-        role = MockRole("League Admin", role_id=987654)
-        channel = MockTextChannel("765432", guild=mock_interaction_admin.guild)
-
-        await admin_cog.setup_config.callback(
-            admin_cog,
-            mock_interaction_admin,
-            role,
-            channel,
-        )
-
-        config = await admin_cog.db.get_guild_config("111111")
-        assert config["admin_role_id"] == "987654"
-        assert config["league_channel_id"] == "765432"
-
-    @pytest.mark.asyncio
-    async def test_setup_command_requires_server_manager(self, admin_cog, mock_interaction_admin):
-        role = MockRole("League Admin", role_id=987654)
-        channel = MockTextChannel("765432", guild=mock_interaction_admin.guild)
-
-        await admin_cog.setup_config.callback(
-            admin_cog,
-            mock_interaction_admin,
-            role,
-            channel,
-        )
-
-        assert "server manager" in mock_interaction_admin.response_sent[-1]["content"]
-
-    @pytest.mark.asyncio
-    async def test_setup_command_requires_confirmation_for_everyone_role(
-        self,
-        mock_bot,
-        mock_interaction_admin,
-        temp_db_path,
-    ):
-        db = Database(temp_db_path)
-        await db.initialize()
-        mock_bot.db = db
-        admin_cog = AdminCommands(mock_bot)
-        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
-        member.guild_permissions.manage_guild = True
-        everyone_role = MockRole("@everyone", role_id=mock_interaction_admin.guild.id)
-        channel = MockTextChannel("765432", guild=mock_interaction_admin.guild)
-
-        await admin_cog.setup_config.callback(
-            admin_cog,
-            mock_interaction_admin,
-            everyone_role,
-            channel,
-        )
-
-        assert isinstance(mock_interaction_admin.response_sent[-1]["view"], EveryoneRoleConfirmView)
-        assert await db.get_guild_config("111111") is None
-
-        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
-        confirm_button = next(
-            child
-            for child in confirm_view.children
-            if getattr(child, "label", None) == "Confirm @everyone"
-        )
-        await confirm_button.callback(mock_interaction_admin)
-
-        config = await db.get_guild_config("111111")
-        assert config["admin_role_id"] == str(mock_interaction_admin.guild.id)
+    def test_admin_group_does_not_expose_setup_command(self, admin_cog):
+        assert all(command.name != "setup" for command in admin_cog.admin.commands)
 
     @pytest.mark.asyncio
     async def test_panel_requires_guild_setup(self, mock_bot, mock_interaction_admin, temp_db_path):
@@ -209,7 +141,7 @@ class TestAdminPanelEntry:
 
         await admin_cog.panel.callback(admin_cog, mock_interaction_admin)
 
-        assert isinstance(mock_interaction_admin.response_sent[-1]["view"], GuildSetupPromptView)
+        assert isinstance(mock_interaction_admin.response_sent[-1]["view"], GuildSetupStartView)
 
     @pytest.mark.asyncio
     async def test_panel_check_prompts_server_manager_to_setup_inline(
@@ -229,7 +161,7 @@ class TestAdminPanelEntry:
         can_run = await admin_cog.panel.checks[0](mock_interaction_admin)
 
         assert can_run is False
-        assert isinstance(mock_interaction_admin.response_sent[-1]["view"], GuildSetupPromptView)
+        assert isinstance(mock_interaction_admin.response_sent[-1]["view"], GuildSetupStartView)
 
     @pytest.mark.asyncio
     async def test_panel_check_blocks_non_manager_without_setup(
@@ -248,6 +180,55 @@ class TestAdminPanelEntry:
 
         assert can_run is False
         assert mock_interaction_admin.response_sent[-1].get("view") is None
+
+    @pytest.mark.asyncio
+    async def test_inline_setup_button_opens_selector_view(
+        self,
+        database,
+        mock_interaction_admin,
+    ):
+        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
+        member.guild_permissions.manage_guild = True
+        start_view = GuildSetupStartView(database, str(mock_interaction_admin.user.id))
+        setup_button = next(
+            child
+            for child in start_view.children
+            if getattr(child, "label", None) == "Setup TyperBot"
+        )
+
+        await setup_button.callback(mock_interaction_admin)
+
+        assert isinstance(mock_interaction_admin.response_sent[-1]["view"], GuildSetupPromptView)
+
+    @pytest.mark.asyncio
+    async def test_inline_setup_button_blocks_owner_without_setup_permission(
+        self,
+        database,
+        mock_interaction_admin,
+    ):
+        start_view = GuildSetupStartView(database, str(mock_interaction_admin.user.id))
+        setup_button = next(
+            child
+            for child in start_view.children
+            if getattr(child, "label", None) == "Setup TyperBot"
+        )
+
+        await setup_button.callback(mock_interaction_admin)
+
+        assert mock_interaction_admin.response_sent[-1].get("view") is None
+
+    @pytest.mark.asyncio
+    async def test_inline_setup_selector_rechecks_setup_permission(
+        self,
+        temp_db_path,
+        mock_interaction_admin,
+    ):
+        database = Database(temp_db_path)
+        await database.initialize()
+        view = GuildSetupPromptView(database, str(mock_interaction_admin.user.id))
+
+        assert await view.interaction_check(mock_interaction_admin) is False
+        assert await database.get_guild_config("111111") is None
 
     @pytest.mark.asyncio
     async def test_inline_setup_prompt_saves_config(
@@ -289,6 +270,17 @@ class TestAdminPanelEntry:
 
         assert isinstance(mock_interaction_admin.response_sent[-1]["view"], EveryoneRoleConfirmView)
         assert await database.get_guild_config("111111") is None
+
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        confirm_button = next(
+            child
+            for child in confirm_view.children
+            if getattr(child, "label", None) == "Confirm @everyone"
+        )
+        await confirm_button.callback(mock_interaction_admin)
+
+        config = await database.get_guild_config("111111")
+        assert config["admin_role_id"] == str(mock_interaction_admin.guild.id)
 
 
 class TestResultsPostFlow:

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -501,6 +501,7 @@ class TestAdminPanelCommand:
         assert "Admin Panel" in response["content"]
         assert response["ephemeral"] is True
         assert response["view"] is not None
+        assert _has_button(response["view"], "Setup TyperBot") is True
 
 
 class TestPredictionPanelFlows:

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -357,6 +357,90 @@ class TestAdminPanelCommand:
         assert "Week number changed" in mock_interaction_admin.response_sent[-1]["content"]
 
     @pytest.mark.asyncio
+    async def test_create_fixture_confirm_posts_to_configured_league_channel(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        await admin_cog.db.upsert_guild_config(
+            "111111",
+            str(
+                mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id).roles[0].id
+            ),
+            "654321",
+        )
+        announcement = MagicMock()
+        announcement.id = 999999
+        announcement.create_thread = AsyncMock(return_value=AsyncMock())
+        configured_channel = MagicMock()
+        configured_channel.id = 654321
+        configured_channel.send = AsyncMock(return_value=announcement)
+        admin_cog.bot.get_channel.return_value = configured_channel
+        mock_interaction_admin.channel.send = AsyncMock()
+
+        modal = CreateFixtureModal(
+            admin_cog.db,
+            mock_interaction_admin.channel,
+            str(mock_interaction_admin.user.id),
+            admin_cog.bot,
+        )
+        modal.games_input._value = "\n".join(sample_games)
+        modal.deadline_input._value = "2026-04-20 18:00"
+
+        await modal.on_submit(mock_interaction_admin)
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        confirm_button = next(
+            child
+            for child in confirm_view.children
+            if getattr(child, "label", None) == "Create Fixture"
+        )
+        await confirm_button.callback(mock_interaction_admin)
+
+        configured_channel.send.assert_awaited_once()
+        mock_interaction_admin.channel.send.assert_not_awaited()
+        fixture = await admin_cog.db.get_current_fixture("111111")
+        assert fixture["channel_id"] == "654321"
+
+    @pytest.mark.asyncio
+    async def test_create_fixture_confirm_rejects_unavailable_configured_channel(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+    ):
+        await admin_cog.db.upsert_guild_config(
+            "111111",
+            str(
+                mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id).roles[0].id
+            ),
+            "654321",
+        )
+        admin_cog.bot.get_channel.return_value = None
+        admin_cog.bot.fetch_channel.side_effect = discord.NotFound(MagicMock(), "missing")
+
+        modal = CreateFixtureModal(
+            admin_cog.db,
+            mock_interaction_admin.channel,
+            str(mock_interaction_admin.user.id),
+            admin_cog.bot,
+        )
+        modal.games_input._value = "\n".join(sample_games)
+        modal.deadline_input._value = "2026-04-20 18:00"
+
+        await modal.on_submit(mock_interaction_admin)
+        confirm_view = mock_interaction_admin.response_sent[-1]["view"]
+        confirm_button = next(
+            child
+            for child in confirm_view.children
+            if getattr(child, "label", None) == "Create Fixture"
+        )
+        await confirm_button.callback(mock_interaction_admin)
+
+        assert "league channel" in mock_interaction_admin.response_sent[-1]["content"]
+        assert await admin_cog.db.get_current_fixture("111111") is None
+
+    @pytest.mark.asyncio
     async def test_create_fixture_confirm_cancel_leaves_database_unchanged(
         self,
         admin_cog,
@@ -1813,6 +1897,12 @@ class TestFixturePanelFlows:
         )
 
         db_mock = AsyncMock(spec=Database)
+        db_mock.get_guild_config.return_value = {
+            "admin_role_id": str(
+                mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id).roles[0].id
+            ),
+            "league_channel_id": "123456",
+        }
         db_mock.delete_fixture.side_effect = RuntimeError("DB locked")
 
         confirm_view = DeleteConfirmView(

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -325,6 +325,7 @@ class TestReminderSystem:
 
         fixture = {
             "id": 1,
+            "guild_id": "111111",
             "deadline": deadline,
             "week_number": 1,
         }
@@ -344,6 +345,7 @@ class TestReminderSystem:
 
         fixture = {
             "id": 1,
+            "guild_id": "111111",
             "deadline": deadline,
             "week_number": 1,
         }
@@ -363,6 +365,7 @@ class TestReminderSystem:
 
         fixture = {
             "id": 1,
+            "guild_id": "111111",
             "deadline": deadline,
             "week_number": 1,
         }
@@ -394,8 +397,8 @@ class TestReminderSystem:
         deadline = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
         mock_now.return_value = deadline - timedelta(hours=24)
 
-        fixture_a = {"id": 1, "deadline": deadline, "week_number": 1}
-        fixture_b = {"id": 2, "deadline": deadline, "week_number": 2}
+        fixture_a = {"id": 1, "guild_id": "111111", "deadline": deadline, "week_number": 1}
+        fixture_b = {"id": 2, "guild_id": "222222", "deadline": deadline, "week_number": 2}
         bot_instance.db.get_all_open_fixtures = AsyncMock(return_value=[fixture_a, fixture_b])
 
         await bot_instance.reminder_task()
@@ -410,18 +413,22 @@ class TestSendReminder:
     def bot_instance(self):
         with patch("typer_bot.bot.commands.Bot.__init__", return_value=None):
             bot = TyperBot.__new__(TyperBot)
+            bot.db = MagicMock()
             bot.get_channel = MagicMock()
+            bot.fetch_channel = AsyncMock()
             yield bot
 
     @pytest.mark.asyncio
-    @patch.dict(os.environ, {"REMINDER_CHANNEL_ID": "123456"})
     async def test_send_reminder_to_configured_channel(self, bot_instance):
         """Reminders route to the configured channel."""
         mock_channel = MagicMock()
         mock_channel.send = AsyncMock()
         bot_instance.get_channel.return_value = mock_channel
+        bot_instance.db.get_guild_config = AsyncMock(return_value={"league_channel_id": "123456"})
 
         fixture = {
+            "id": 1,
+            "guild_id": "111111",
             "deadline": datetime.now(UTC) + timedelta(days=1),
             "week_number": 1,
         }
@@ -434,11 +441,11 @@ class TestSendReminder:
         assert "/predict" in call_args
 
     @pytest.mark.asyncio
-    async def test_send_reminder_missing_channel_id(self, bot_instance):
+    async def test_send_reminder_missing_guild_config(self, bot_instance):
         """Missing channel configuration skips delivery."""
-        with patch.dict(os.environ, {}, clear=True):
-            fixture = {"deadline": datetime.now(UTC), "week_number": 1}
-            await bot_instance.send_reminder(fixture, "24 hours remaining")
+        bot_instance.db.get_guild_config = AsyncMock(return_value=None)
+        fixture = {"id": 1, "guild_id": "111111", "deadline": datetime.now(UTC), "week_number": 1}
+        await bot_instance.send_reminder(fixture, "24 hours remaining")
 
         bot_instance.get_channel.assert_not_called()
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -71,6 +71,38 @@ class TestGetMaxWeekNumber:
         assert result == 10
 
 
+class TestGuildConfig:
+    @pytest.mark.asyncio
+    async def test_guild_config_persists_and_updates(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+
+        assert await db.get_guild_config("111111") is None
+
+        await db.upsert_guild_config("111111", "role-1", "channel-1")
+        config = await db.get_guild_config("111111")
+        assert config["admin_role_id"] == "role-1"
+        assert config["league_channel_id"] == "channel-1"
+
+        await db.upsert_guild_config("111111", "role-2", "channel-2")
+        updated = await db.get_guild_config("111111")
+        assert updated["admin_role_id"] == "role-2"
+        assert updated["league_channel_id"] == "channel-2"
+
+    @pytest.mark.asyncio
+    async def test_guild_config_is_per_guild(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+
+        await db.upsert_guild_config("111111", "role-1", "channel-1")
+        await db.upsert_guild_config("222222", "role-2", "channel-2")
+
+        guild_one = await db.get_guild_config("111111")
+        guild_two = await db.get_guild_config("222222")
+        assert guild_one["admin_role_id"] == "role-1"
+        assert guild_two["admin_role_id"] == "role-2"
+
+
 class TestOpenFixturesQueries:
     """Test suite for multi-open fixture query helpers."""
 

--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -157,10 +157,7 @@ class TestOnMessage:
         await database.update_fixture_announcement(
             fixture_id, message_id="789012", channel_id="123456"
         )
-        admin_role = MagicMock()
-        admin_role.name = "typer-admin"
-        admin_role.id = 4242
-        mock_message.guild.roles = [admin_role]
+        await database.upsert_guild_config("111111", "4242", "123456")
         mock_message.content = "Team C - Team D 1-1\nTeam E - Team F 0-2"
         mock_message.channel.id = 789012
 

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -12,7 +12,7 @@ from typer_bot.commands.user_commands import (
     PredictModal,
     UserCommands,
 )
-from typer_bot.database import SaveResult
+from typer_bot.database import Database, SaveResult
 
 
 @pytest.fixture
@@ -315,8 +315,8 @@ class TestPredictCommand:
         self, user_commands, mock_interaction, database
     ):
         await _attach_prediction_threads(user_commands, database, [1], mock_interaction.guild)
-        admin_role = MockRole("typer-admin")
-        mock_interaction.guild.roles = [admin_role]
+        admin_role = MockRole("League Admin", role_id=4242)
+        await database.upsert_guild_config("111111", str(admin_role.id), "123456")
         fixture = await database.get_fixture_by_id(1)
         assert fixture is not None
         fixture["deadline"] = datetime.now(UTC) - timedelta(minutes=1)
@@ -340,6 +340,39 @@ class TestPredictCommand:
         assert "0 points" not in mock_interaction.response_sent[-1]["content"]
         thread = user_commands.bot.get_channel(700001)
         assert f"<@&{admin_role.id}>" in thread.messages_sent[-1]["content"]
+
+    @pytest.mark.asyncio
+    async def test_predict_modal_without_setup_does_not_ping_legacy_admin_role(
+        self,
+        mock_bot,
+        mock_interaction,
+        temp_db_path,
+        sample_games,
+    ):
+        database = Database(temp_db_path)
+        await database.initialize()
+        mock_bot.db = database
+        user_commands = UserCommands(mock_bot)
+        deadline = datetime.now(UTC) - timedelta(minutes=1)
+        fixture_id = await database.create_fixture("111111", 1, sample_games, deadline)
+        await _attach_prediction_threads(
+            user_commands, database, [fixture_id], mock_interaction.guild
+        )
+        mock_interaction.guild.roles = [MockRole("typer-admin", role_id=4242)]
+
+        fixture = await database.get_fixture_by_id(fixture_id)
+        assert fixture is not None
+        user_commands.db.get_open_fixtures = AsyncMock(return_value=[fixture])
+        user_commands.db.get_fixture_by_id = AsyncMock(return_value=fixture)
+
+        await user_commands.predict.callback(user_commands, mock_interaction)
+        modal = mock_interaction.modal_sent["modal"]
+        modal.predictions_input._value = "Team C - Team D 1-1\nTeam E - Team F 0-2"
+        await modal.on_submit(mock_interaction)
+
+        thread = user_commands.bot.get_channel(700001)
+        assert "awaiting admin review" in thread.messages_sent[-1]["content"]
+        assert "<@&4242>" not in thread.messages_sent[-1]["content"]
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("fixture_with_dm")

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -212,16 +212,21 @@ class TyperBot(commands.Bot):
 
     async def send_reminder(self, fixture: dict, time_description: str):
         """Send prediction reminder to configured channel."""
-        channel_id = os.getenv("REMINDER_CHANNEL_ID")
-        if not channel_id:
-            logger.warning("REMINDER_CHANNEL_ID not set, skipping reminder")
+        config = await self.db.get_guild_config(fixture["guild_id"])
+        if config is None:
+            logger.warning(
+                "Guild %s is missing TyperBot setup, skipping reminder for fixture %s",
+                fixture["guild_id"],
+                fixture["id"],
+            )
             return
+
+        channel_id = config["league_channel_id"]
 
         try:
             channel = self.get_channel(int(channel_id))
             if channel is None:
-                logger.error(f"Could not find channel {channel_id}")
-                return
+                channel = await self.fetch_channel(int(channel_id))
 
             send = getattr(channel, "send", None)
             if send is None:

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -201,6 +201,40 @@ class GuildSetupPromptView(discord.ui.View):
         self.save_button.disabled = self.admin_role is None or self.league_channel is None
 
 
+class StartSetupButton(discord.ui.Button):
+    def __init__(self, parent_view: GuildSetupStartView):
+        self.parent_view = parent_view
+        super().__init__(label="Setup TyperBot", style=discord.ButtonStyle.primary)
+
+    async def callback(self, interaction: discord.Interaction):
+        if not has_setup_permission(interaction):
+            await interaction.response.send_message(
+                "Only a server manager can configure TyperBot for this server.", ephemeral=True
+            )
+            return
+
+        await interaction.response.edit_message(
+            content="Choose the TyperBot admin role and league channel below.",
+            view=GuildSetupPromptView(self.parent_view.db, str(interaction.user.id)),
+        )
+
+
+class GuildSetupStartView(discord.ui.View):
+    def __init__(self, db: Database, owner_user_id: str):
+        super().__init__(timeout=180)
+        self.db = db
+        self.owner_user_id = owner_user_id
+        self.add_item(StartSetupButton(self))
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if str(interaction.user.id) != self.owner_user_id:
+            await interaction.response.send_message(
+                "You don't have permission to do this!", ephemeral=True
+            )
+            return False
+        return True
+
+
 async def send_setup_prompt_if_allowed(interaction: discord.Interaction, db: Database) -> None:
     if not interaction.guild or interaction.guild_id is None:
         await interaction.response.send_message(
@@ -212,8 +246,8 @@ async def send_setup_prompt_if_allowed(interaction: discord.Interaction, db: Dat
         return
 
     await interaction.response.send_message(
-        "TyperBot needs setup before league admin commands can be used. Choose the admin role and league channel below.",
-        view=GuildSetupPromptView(db, str(interaction.user.id)),
+        "TyperBot needs setup before league admin commands can be used.",
+        view=GuildSetupStartView(db, str(interaction.user.id)),
         ephemeral=True,
     )
 
@@ -364,49 +398,6 @@ class AdminCommands(commands.Cog):
         await interaction.response.send_message(
             view.render_content(),
             view=view,
-            ephemeral=True,
-        )
-
-    @admin.command(name="setup", description="Configure TyperBot for this server")
-    @app_commands.describe(
-        admin_role="Role allowed to use TyperBot admin actions",
-        channel="League channel for fixture announcements and reminders",
-    )
-    async def setup_config(
-        self,
-        interaction: discord.Interaction,
-        admin_role: discord.Role,
-        channel: discord.TextChannel,
-    ):
-        if not interaction.guild or interaction.guild_id is None:
-            await interaction.response.send_message(
-                "This command can only be used in a server.", ephemeral=True
-            )
-            return
-
-        if not has_setup_permission(interaction):
-            await interaction.response.send_message(
-                "Only a server manager can configure TyperBot for this server.", ephemeral=True
-            )
-            return
-
-        if channel.guild.id != interaction.guild_id:
-            await interaction.response.send_message(
-                "Setup channel must belong to this server.", ephemeral=True
-            )
-            return
-
-        if _is_everyone_role(admin_role, interaction.guild_id):
-            await interaction.response.send_message(
-                "You selected @everyone as the TyperBot admin role. This gives every server member access to admin actions. Confirm this intentionally?",
-                view=_everyone_warning_view(self.db, interaction, admin_role, channel),
-                ephemeral=True,
-            )
-            return
-
-        await _save_guild_config(self.db, interaction, admin_role, channel)
-        await interaction.response.send_message(
-            _setup_saved_message(admin_role, channel),
             ephemeral=True,
         )
 

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
+from typing import cast
 
 import discord
 from discord import app_commands
@@ -16,6 +17,7 @@ from typer_bot.database import Database
 from typer_bot.services import AdminService
 from typer_bot.services.admin_service import FixtureScoreResult
 from typer_bot.utils import (
+    SETUP_REQUIRED_MESSAGE,
     format_fixture_results,
     format_standings,
     get_admin_permission_error,
@@ -31,6 +33,111 @@ COOLDOWN_ENTRY_EXPIRY = timedelta(hours=1)
 logger = logging.getLogger(__name__)
 
 
+class SetupRoleSelect(discord.ui.RoleSelect):
+    def __init__(self, parent_view: GuildSetupPromptView):
+        self.parent_view = parent_view
+        super().__init__(placeholder="Choose TyperBot admin role", min_values=1, max_values=1)
+
+    async def callback(self, interaction: discord.Interaction):
+        self.parent_view.admin_role = self.values[0]
+        self.parent_view.refresh_save_button()
+        await interaction.response.edit_message(view=self.parent_view)
+
+
+class SetupChannelSelect(discord.ui.ChannelSelect):
+    def __init__(self, parent_view: GuildSetupPromptView):
+        self.parent_view = parent_view
+        super().__init__(
+            placeholder="Choose league channel",
+            channel_types=[discord.ChannelType.text],
+            min_values=1,
+            max_values=1,
+        )
+
+    async def callback(self, interaction: discord.Interaction):
+        self.parent_view.league_channel = cast(discord.TextChannel, self.values[0])
+        self.parent_view.refresh_save_button()
+        await interaction.response.edit_message(view=self.parent_view)
+
+
+class SaveSetupButton(discord.ui.Button):
+    def __init__(self, parent_view: GuildSetupPromptView):
+        self.parent_view = parent_view
+        super().__init__(label="Save Setup", style=discord.ButtonStyle.success, disabled=True)
+
+    async def callback(self, interaction: discord.Interaction):
+        admin_role = self.parent_view.admin_role
+        league_channel = self.parent_view.league_channel
+        if admin_role is None or league_channel is None:
+            await interaction.response.send_message(
+                "Choose an admin role and league channel first.", ephemeral=True
+            )
+            return
+        if interaction.guild_id is None or league_channel.guild.id != interaction.guild_id:
+            await interaction.response.send_message(
+                "Setup channel must belong to this server.", ephemeral=True
+            )
+            return
+
+        await self.parent_view.db.upsert_guild_config(
+            str(interaction.guild_id),
+            str(admin_role.id),
+            str(league_channel.id),
+        )
+        await interaction.response.edit_message(
+            content=f"TyperBot setup saved. Admin role: {admin_role.mention}. League channel: {league_channel.mention}.",
+            view=None,
+        )
+
+
+class GuildSetupPromptView(discord.ui.View):
+    def __init__(self, db: Database, owner_user_id: str):
+        super().__init__(timeout=180)
+        self.db = db
+        self.owner_user_id = owner_user_id
+        self.admin_role: discord.Role | None = None
+        self.league_channel: discord.TextChannel | None = None
+        self.role_select = SetupRoleSelect(self)
+        self.channel_select = SetupChannelSelect(self)
+        self.save_button = SaveSetupButton(self)
+        self.add_item(self.role_select)
+        self.add_item(self.channel_select)
+        self.add_item(self.save_button)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if str(interaction.user.id) != self.owner_user_id:
+            await interaction.response.send_message(
+                "You don't have permission to do this!", ephemeral=True
+            )
+            return False
+        if not has_setup_permission(interaction):
+            await interaction.response.send_message(
+                "Only a server manager can configure TyperBot for this server.", ephemeral=True
+            )
+            return False
+        return True
+
+    def refresh_save_button(self) -> None:
+        self.save_button.disabled = self.admin_role is None or self.league_channel is None
+
+
+async def send_setup_prompt_if_allowed(interaction: discord.Interaction, db: Database) -> None:
+    if not interaction.guild or interaction.guild_id is None:
+        await interaction.response.send_message(
+            "This command can only be used in a server.", ephemeral=True
+        )
+        return
+    if not has_setup_permission(interaction):
+        await interaction.response.send_message(SETUP_REQUIRED_MESSAGE, ephemeral=True)
+        return
+
+    await interaction.response.send_message(
+        "TyperBot needs setup before league admin commands can be used. Choose the admin role and league channel below.",
+        view=GuildSetupPromptView(db, str(interaction.user.id)),
+        ephemeral=True,
+    )
+
+
 def admin_only():
     """Decorator to check if user has admin permissions."""
 
@@ -39,6 +146,13 @@ def admin_only():
         if db is None:
             await interaction.response.send_message("Bot database is not ready.", ephemeral=True)
             return False
+        if (
+            interaction.guild_id is not None
+            and await db.get_guild_config(str(interaction.guild_id)) is None
+        ):
+            await send_setup_prompt_if_allowed(interaction, db)
+            return False
+
         permission_error = await get_admin_permission_error(interaction, db)
         if permission_error is not None:
             await interaction.response.send_message(permission_error, ephemeral=True)
@@ -152,7 +266,10 @@ class AdminCommands(commands.Cog):
     async def panel(self, interaction: discord.Interaction):
         permission_error = await get_admin_permission_error(interaction, self.db)
         if permission_error is not None:
-            await interaction.response.send_message(permission_error, ephemeral=True)
+            if await self.db.get_guild_config(str(interaction.guild_id)) is None:
+                await send_setup_prompt_if_allowed(interaction, self.db)
+            else:
+                await interaction.response.send_message(permission_error, ephemeral=True)
             return
 
         view = UnifiedAdminPanelView(

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -15,7 +15,13 @@ from typer_bot.commands.admin_panel import (
 from typer_bot.database import Database
 from typer_bot.services import AdminService
 from typer_bot.services.admin_service import FixtureScoreResult
-from typer_bot.utils import format_fixture_results, format_standings, is_admin, now
+from typer_bot.utils import (
+    format_fixture_results,
+    format_standings,
+    get_admin_permission_error,
+    has_setup_permission,
+    now,
+)
 from typer_bot.utils.config import BACKUP_DIR
 from typer_bot.utils.db_backup import cleanup_old_backups, create_backup
 
@@ -29,15 +35,13 @@ def admin_only():
     """Decorator to check if user has admin permissions."""
 
     async def predicate(interaction: discord.Interaction) -> bool:
-        if not interaction.guild:
-            await interaction.response.send_message(
-                "This command can only be used in a server.", ephemeral=True
-            )
+        db = getattr(interaction.client, "db", None)
+        if db is None:
+            await interaction.response.send_message("Bot database is not ready.", ephemeral=True)
             return False
-        if not is_admin(interaction):
-            await interaction.response.send_message(
-                "You don't have permission to use admin commands.", ephemeral=True
-            )
+        permission_error = await get_admin_permission_error(interaction, db)
+        if permission_error is not None:
+            await interaction.response.send_message(permission_error, ephemeral=True)
             return False
         return True
 
@@ -146,6 +150,11 @@ class AdminCommands(commands.Cog):
     @admin.command(name="panel", description="Open the admin management panel")
     @admin_only()
     async def panel(self, interaction: discord.Interaction):
+        permission_error = await get_admin_permission_error(interaction, self.db)
+        if permission_error is not None:
+            await interaction.response.send_message(permission_error, ephemeral=True)
+            return
+
         view = UnifiedAdminPanelView(
             self.db,
             self.service,
@@ -158,6 +167,45 @@ class AdminCommands(commands.Cog):
         await interaction.response.send_message(
             view.render_content(),
             view=view,
+            ephemeral=True,
+        )
+
+    @admin.command(name="setup", description="Configure TyperBot for this server")
+    @app_commands.describe(
+        admin_role="Role allowed to use TyperBot admin actions",
+        channel="League channel for fixture announcements and reminders",
+    )
+    async def setup_config(
+        self,
+        interaction: discord.Interaction,
+        admin_role: discord.Role,
+        channel: discord.TextChannel,
+    ):
+        if not interaction.guild or interaction.guild_id is None:
+            await interaction.response.send_message(
+                "This command can only be used in a server.", ephemeral=True
+            )
+            return
+
+        if not has_setup_permission(interaction):
+            await interaction.response.send_message(
+                "Only a server manager can configure TyperBot for this server.", ephemeral=True
+            )
+            return
+
+        if channel.guild.id != interaction.guild_id:
+            await interaction.response.send_message(
+                "Setup channel must belong to this server.", ephemeral=True
+            )
+            return
+
+        await self.db.upsert_guild_config(
+            str(interaction.guild_id),
+            str(admin_role.id),
+            str(channel.id),
+        )
+        await interaction.response.send_message(
+            f"TyperBot setup saved. Admin role: {admin_role.mention}. League channel: {channel.mention}.",
             ephemeral=True,
         )
 

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -33,6 +33,81 @@ COOLDOWN_ENTRY_EXPIRY = timedelta(hours=1)
 logger = logging.getLogger(__name__)
 
 
+def _is_everyone_role(role: discord.Role, guild_id: int | None) -> bool:
+    is_default = getattr(role, "is_default", None)
+    if callable(is_default) and is_default():
+        return True
+    return guild_id is not None and role.id == guild_id
+
+
+async def _save_guild_config(
+    db: Database,
+    interaction: discord.Interaction,
+    admin_role: discord.Role,
+    league_channel: discord.TextChannel,
+) -> None:
+    await db.upsert_guild_config(
+        str(interaction.guild_id),
+        str(admin_role.id),
+        str(league_channel.id),
+    )
+
+
+def _setup_saved_message(admin_role: discord.Role, league_channel: discord.TextChannel) -> str:
+    return f"TyperBot setup saved. Admin role: {admin_role.mention}. League channel: {league_channel.mention}."
+
+
+class EveryoneRoleConfirmView(discord.ui.View):
+    def __init__(
+        self,
+        db: Database,
+        owner_user_id: str,
+        admin_role: discord.Role,
+        league_channel: discord.TextChannel,
+    ):
+        super().__init__(timeout=60)
+        self.db = db
+        self.owner_user_id = owner_user_id
+        self.admin_role = admin_role
+        self.league_channel = league_channel
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if str(interaction.user.id) != self.owner_user_id:
+            await interaction.response.send_message(
+                "You don't have permission to do this!", ephemeral=True
+            )
+            return False
+        if not has_setup_permission(interaction):
+            await interaction.response.send_message(
+                "Only a server manager can configure TyperBot for this server.", ephemeral=True
+            )
+            return False
+        return True
+
+    @discord.ui.button(label="Confirm @everyone", style=discord.ButtonStyle.danger)
+    async def confirm(self, interaction: discord.Interaction, _button: discord.ui.Button):
+        if interaction.guild_id is None or self.league_channel.guild.id != interaction.guild_id:
+            await interaction.response.send_message(
+                "Setup channel must belong to this server.", ephemeral=True
+            )
+            return
+
+        await _save_guild_config(self.db, interaction, self.admin_role, self.league_channel)
+        await interaction.response.edit_message(
+            content=_setup_saved_message(self.admin_role, self.league_channel),
+            view=None,
+        )
+
+
+def _everyone_warning_view(
+    db: Database,
+    interaction: discord.Interaction,
+    admin_role: discord.Role,
+    league_channel: discord.TextChannel,
+) -> EveryoneRoleConfirmView:
+    return EveryoneRoleConfirmView(db, str(interaction.user.id), admin_role, league_channel)
+
+
 class SetupRoleSelect(discord.ui.RoleSelect):
     def __init__(self, parent_view: GuildSetupPromptView):
         self.parent_view = parent_view
@@ -79,13 +154,18 @@ class SaveSetupButton(discord.ui.Button):
             )
             return
 
-        await self.parent_view.db.upsert_guild_config(
-            str(interaction.guild_id),
-            str(admin_role.id),
-            str(league_channel.id),
-        )
+        if _is_everyone_role(admin_role, interaction.guild_id):
+            await interaction.response.edit_message(
+                content="You selected @everyone as the TyperBot admin role. This gives every server member access to admin actions. Confirm this intentionally?",
+                view=_everyone_warning_view(
+                    self.parent_view.db, interaction, admin_role, league_channel
+                ),
+            )
+            return
+
+        await _save_guild_config(self.parent_view.db, interaction, admin_role, league_channel)
         await interaction.response.edit_message(
-            content=f"TyperBot setup saved. Admin role: {admin_role.mention}. League channel: {league_channel.mention}.",
+            content=_setup_saved_message(admin_role, league_channel),
             view=None,
         )
 
@@ -316,13 +396,17 @@ class AdminCommands(commands.Cog):
             )
             return
 
-        await self.db.upsert_guild_config(
-            str(interaction.guild_id),
-            str(admin_role.id),
-            str(channel.id),
-        )
+        if _is_everyone_role(admin_role, interaction.guild_id):
+            await interaction.response.send_message(
+                "You selected @everyone as the TyperBot admin role. This gives every server member access to admin actions. Confirm this intentionally?",
+                view=_everyone_warning_view(self.db, interaction, admin_role, channel),
+                ephemeral=True,
+            )
+            return
+
+        await _save_guild_config(self.db, interaction, admin_role, channel)
         await interaction.response.send_message(
-            f"TyperBot setup saved. Admin role: {admin_role.mention}. League channel: {channel.mention}.",
+            _setup_saved_message(admin_role, channel),
             ephemeral=True,
         )
 

--- a/typer_bot/commands/admin_panel/base.py
+++ b/typer_bot/commands/admin_panel/base.py
@@ -11,7 +11,7 @@ import discord
 
 from typer_bot.database import Database
 from typer_bot.services import AdminService
-from typer_bot.utils import is_admin
+from typer_bot.utils import get_admin_permission_error
 
 if TYPE_CHECKING:
     from .fixtures import FixturesPanelView
@@ -150,10 +150,9 @@ class OwnerRestrictedView(discord.ui.View):
                 "You don't have permission to do this!", ephemeral=True
             )
             return False
-        if not is_admin(interaction):
-            await interaction.response.send_message(
-                "You no longer have permission to use admin commands.", ephemeral=True
-            )
+        permission_error = await get_admin_permission_error(interaction, self.db)
+        if permission_error is not None:
+            await interaction.response.send_message(permission_error, ephemeral=True)
             return False
         return True
 

--- a/typer_bot/commands/admin_panel/fixtures.py
+++ b/typer_bot/commands/admin_panel/fixtures.py
@@ -9,7 +9,7 @@ import discord
 
 from typer_bot.database import Database
 from typer_bot.services import AdminService
-from typer_bot.utils import is_admin
+from typer_bot.utils import get_admin_permission_error
 
 from .base import (
     FixtureSelect,
@@ -176,10 +176,9 @@ class DeleteConfirmView(discord.ui.View):
                 "You don't have permission to do this!", ephemeral=True
             )
             return
-        if not is_admin(interaction):
-            await interaction.response.send_message(
-                "You no longer have permission to use admin commands.", ephemeral=True
-            )
+        permission_error = await get_admin_permission_error(interaction, self.db)
+        if permission_error is not None:
+            await interaction.response.send_message(permission_error, ephemeral=True)
             return
 
         try:
@@ -217,10 +216,9 @@ class DeleteConfirmView(discord.ui.View):
                 "You don't have permission to do this!", ephemeral=True
             )
             return
-        if not is_admin(interaction):
-            await interaction.response.send_message(
-                "You no longer have permission to use admin commands.", ephemeral=True
-            )
+        permission_error = await get_admin_permission_error(interaction, self.db)
+        if permission_error is not None:
+            await interaction.response.send_message(permission_error, ephemeral=True)
             return
 
         await interaction.response.edit_message(

--- a/typer_bot/commands/admin_panel/modals.py
+++ b/typer_bot/commands/admin_panel/modals.py
@@ -149,7 +149,7 @@ class CreateFixtureConfirmView(discord.ui.View):
         league_channel = await self._get_league_channel(str(interaction.guild_id))
         if league_channel is None:
             await interaction.response.send_message(
-                "Configured league channel is unavailable. Run `/admin setup` again.",
+                "Configured league channel is unavailable. Run `/admin panel` again to update setup.",
                 ephemeral=True,
             )
             return

--- a/typer_bot/commands/admin_panel/modals.py
+++ b/typer_bot/commands/admin_panel/modals.py
@@ -13,7 +13,13 @@ from typer_bot.services import (
     PredictionDisappearedError,
     PredictionNotFoundError,
 )
-from typer_bot.utils import APP_TZ, format_for_discord, is_admin, now, parse_line_predictions
+from typer_bot.utils import (
+    APP_TZ,
+    format_for_discord,
+    get_admin_permission_error,
+    now,
+    parse_line_predictions,
+)
 
 from .base import (
     _build_detail_lines,
@@ -95,6 +101,7 @@ class CreateFixtureConfirmView(discord.ui.View):
         preview_week_number: int,
         games: list[str],
         deadline: datetime,
+        bot: discord.Client | None = None,
     ):
         super().__init__(timeout=120)
         self.db = db
@@ -103,6 +110,29 @@ class CreateFixtureConfirmView(discord.ui.View):
         self.preview_week_number = preview_week_number
         self.games = games
         self.deadline = deadline
+        self.bot = bot
+
+    async def _get_league_channel(self, guild_id: str):
+        config = await self.db.get_guild_config(guild_id)
+        if config is None:
+            return None
+
+        league_channel_id = int(config["league_channel_id"])
+        if getattr(self.channel, "id", None) == league_channel_id:
+            return self.channel
+
+        if self.bot is None:
+            return None
+
+        channel = self.bot.get_channel(league_channel_id)
+        if channel is None:
+            fetch_channel = getattr(self.bot, "fetch_channel", None)
+            if fetch_channel is not None:
+                try:
+                    channel = await fetch_channel(league_channel_id)
+                except discord.HTTPException:
+                    return None
+        return channel if getattr(channel, "send", None) is not None else None
 
     @discord.ui.button(label="Create Fixture", style=discord.ButtonStyle.green)
     async def confirm(self, interaction: discord.Interaction, _button: discord.ui.Button):
@@ -111,9 +141,16 @@ class CreateFixtureConfirmView(discord.ui.View):
                 "You don't have permission to do this!", ephemeral=True
             )
             return
-        if not is_admin(interaction):
+        permission_error = await get_admin_permission_error(interaction, self.db)
+        if permission_error is not None:
+            await interaction.response.send_message(permission_error, ephemeral=True)
+            return
+
+        league_channel = await self._get_league_channel(str(interaction.guild_id))
+        if league_channel is None:
             await interaction.response.send_message(
-                "You no longer have permission to use admin commands.", ephemeral=True
+                "Configured league channel is unavailable. Run `/admin setup` again.",
+                ephemeral=True,
             )
             return
 
@@ -135,7 +172,7 @@ class CreateFixtureConfirmView(discord.ui.View):
         await interaction.response.edit_message(content=created_text, view=None)
 
         try:
-            announcement = await self.channel.send(
+            announcement = await league_channel.send(
                 f"**Week {allocated_week} Fixture is now open!**\n\n"
                 f"{final_preview}\n\n"
                 f"💬 **How to predict:**\n"
@@ -146,7 +183,7 @@ class CreateFixtureConfirmView(discord.ui.View):
             await self.db.update_fixture_announcement(
                 fixture_id,
                 message_id=str(announcement.id),
-                channel_id=str(self.channel.id),
+                channel_id=str(league_channel.id),
             )
 
             try:
@@ -193,11 +230,14 @@ class CreateFixtureModal(discord.ui.Modal):
     block creation. Nothing is persisted until the confirm view succeeds.
     """
 
-    def __init__(self, db: Database, channel, owner_user_id: str):
+    def __init__(
+        self, db: Database, channel, owner_user_id: str, bot: discord.Client | None = None
+    ):
         super().__init__(title="Create Fixture")
         self.db = db
         self.channel = channel
         self.owner_user_id = owner_user_id
+        self.bot = bot
         self.games_input = discord.ui.TextInput(
             label="Games",
             style=discord.TextStyle.paragraph,
@@ -216,10 +256,9 @@ class CreateFixtureModal(discord.ui.Modal):
         self.add_item(self.deadline_input)
 
     async def on_submit(self, interaction: discord.Interaction):
-        if not is_admin(interaction):
-            await interaction.response.send_message(
-                "You no longer have permission to use admin commands.", ephemeral=True
-            )
+        permission_error = await get_admin_permission_error(interaction, self.db)
+        if permission_error is not None:
+            await interaction.response.send_message(permission_error, ephemeral=True)
             return
 
         try:
@@ -246,6 +285,7 @@ class CreateFixtureModal(discord.ui.Modal):
             preview_week_number,
             games,
             deadline,
+            self.bot,
         )
         await interaction.response.send_message(
             f"{preview}\n\nCreate this fixture?",
@@ -292,10 +332,9 @@ class EnterResultsConfirmView(discord.ui.View):
                 "You don't have permission to do this!", ephemeral=True
             )
             return
-        if not is_admin(interaction):
-            await interaction.response.send_message(
-                "You no longer have permission to use admin commands.", ephemeral=True
-            )
+        permission_error = await get_admin_permission_error(interaction, self.db)
+        if permission_error is not None:
+            await interaction.response.send_message(permission_error, ephemeral=True)
             return
 
         try:
@@ -347,10 +386,9 @@ class EnterResultsModal(discord.ui.Modal):
         self.add_item(self.results_input)
 
     async def on_submit(self, interaction: discord.Interaction):
-        if not is_admin(interaction):
-            await interaction.response.send_message(
-                "You no longer have permission to use admin commands.", ephemeral=True
-            )
+        permission_error = await get_admin_permission_error(interaction, self.db)
+        if permission_error is not None:
+            await interaction.response.send_message(permission_error, ephemeral=True)
             return
 
         results, errors = parse_line_predictions(self.results_input.value, self.fixture["games"])
@@ -408,10 +446,9 @@ class ReplacePredictionModal(discord.ui.Modal):
         self.add_item(self.predictions_input)
 
     async def on_submit(self, interaction: discord.Interaction):
-        if not is_admin(interaction):
-            await interaction.response.send_message(
-                "You no longer have permission to use admin commands.", ephemeral=True
-            )
+        permission_error = await get_admin_permission_error(interaction, self.parent_view.db)
+        if permission_error is not None:
+            await interaction.response.send_message(permission_error, ephemeral=True)
             return
 
         try:
@@ -520,10 +557,9 @@ class CorrectResultsModal(discord.ui.Modal):
         self.add_item(self.results_input)
 
     async def on_submit(self, interaction: discord.Interaction):
-        if not is_admin(interaction):
-            await interaction.response.send_message(
-                "You no longer have permission to use admin commands.", ephemeral=True
-            )
+        permission_error = await get_admin_permission_error(interaction, self.parent_view.db)
+        if permission_error is not None:
+            await interaction.response.send_message(permission_error, ephemeral=True)
             return
 
         try:

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -8,7 +8,7 @@ import discord
 
 from typer_bot.database import Database
 from typer_bot.services import AdminService
-from typer_bot.utils import format_standings, now
+from typer_bot.utils import format_standings, has_setup_permission, now
 
 from .base import (
     MAX_SELECT_OPTIONS,
@@ -31,6 +31,27 @@ from .predictions import (
     _prediction_status_text,
 )
 from .results import CorrectResultsButton
+
+
+class SetupBotButton(discord.ui.Button):
+    def __init__(self, parent_view: UnifiedAdminPanelView):
+        self.parent_view = parent_view
+        super().__init__(label="Setup TyperBot", style=discord.ButtonStyle.secondary, row=2)
+
+    async def callback(self, interaction: discord.Interaction):
+        from typer_bot.commands.admin_commands import GuildSetupPromptView
+
+        if not has_setup_permission(interaction):
+            await interaction.response.send_message(
+                "Only a server manager can configure TyperBot for this server.", ephemeral=True
+            )
+            return
+
+        await interaction.response.send_message(
+            "Update TyperBot setup for this server.",
+            view=GuildSetupPromptView(self.parent_view.db, str(interaction.user.id)),
+            ephemeral=True,
+        )
 
 
 class ApprovePartialButton(discord.ui.Button):
@@ -507,6 +528,7 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
         self.add_item(self.fixture_select)
         self.add_item(self.user_select)
         self.add_item(CreateFixtureButton(self))
+        self.add_item(SetupBotButton(self))
         self.add_item(FixturesDeleteButton(self, disabled=self.selection.fixture_id is None, row=2))
         self.add_item(JumpToWeekButton(self))
         if self.has_pending_partials:

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -528,8 +528,8 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
         self.add_item(self.fixture_select)
         self.add_item(self.user_select)
         self.add_item(CreateFixtureButton(self))
-        self.add_item(SetupBotButton(self))
         self.add_item(FixturesDeleteButton(self, disabled=self.selection.fixture_id is None, row=2))
+        self.add_item(SetupBotButton(self))
         self.add_item(JumpToWeekButton(self))
         if self.has_pending_partials:
             self.add_item(ReviewPendingPartialsButton(self))

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -245,7 +245,12 @@ class CreateFixtureButton(discord.ui.Button):
             )
             return
 
-        modal = CreateFixtureModal(self.parent_view.db, channel, str(interaction.user.id))
+        modal = CreateFixtureModal(
+            self.parent_view.db,
+            channel,
+            str(interaction.user.id),
+            self.parent_view.bot,
+        )
         await interaction.response.send_modal(modal)
 
 

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -14,8 +14,8 @@ from typer_bot.utils import (
     format_for_discord,
     format_predictions_preview,
     format_standings,
-    get_admin_role_mention,
-    is_admin,
+    get_configured_admin_role_mention,
+    is_configured_admin,
     now,
     parse_prediction_lines,
 )
@@ -46,7 +46,6 @@ def _remaining_open_fixtures(
 
 def _format_thread_prediction_message(
     fixture: dict,
-    guild: discord.Guild | None,
     user_id: int,
     predictions: list[str],
     predicted_game_indexes: list[int],
@@ -54,6 +53,7 @@ def _format_thread_prediction_message(
     is_update: bool,
     is_late: bool,
     pending_partial_approval: bool,
+    admin_role_mention: str | None = None,
 ) -> str:
     heading = "Updated prediction" if is_update else "Prediction"
     content = [f"**{heading} from <@{user_id}> · Week {fixture['week_number']}**", ""]
@@ -63,7 +63,6 @@ def _format_thread_prediction_message(
 
     status: str | None = None
     if pending_partial_approval:
-        admin_role_mention = get_admin_role_mention(guild)
         status = "⏳ Late prediction awaiting admin review."
         if admin_role_mention:
             status += f" {admin_role_mention}"
@@ -405,18 +404,23 @@ class PredictModal(discord.ui.Modal):
         existing_prediction = await self.db.get_prediction(fixture["id"], str(interaction.user.id))
         is_partial = len(predicted_game_indexes) < len(fixture["games"])
         pending_partial_approval = is_late and is_partial
+        admin_role_mention = (
+            await get_configured_admin_role_mention(str(interaction.guild_id), self.db)
+            if pending_partial_approval
+            else None
+        )
         public_message = None
         try:
             public_message = await thread.send(
                 _format_thread_prediction_message(
                     fixture,
-                    interaction.guild,
                     interaction.user.id,
                     predictions,
                     predicted_game_indexes,
                     is_update=existing_prediction is not None,
                     is_late=is_late,
                     pending_partial_approval=pending_partial_approval,
+                    admin_role_mention=admin_role_mention,
                 )
             )
         except discord.HTTPException:
@@ -608,7 +612,7 @@ class UserCommands(commands.Cog):
     @app_commands.command(name="help", description="Show help information")
     async def help(self, interaction: discord.Interaction):
         """Display help for users and admins."""
-        is_admin_user = is_admin(interaction)
+        is_admin_user = await is_configured_admin(interaction, self.db)
 
         user_help = """## 📖 User Commands
 

--- a/typer_bot/database/connection.py
+++ b/typer_bot/database/connection.py
@@ -8,6 +8,7 @@ import aiosqlite
 from typer_bot.utils.config import DB_PATH
 
 from .fixtures import FixtureRepository
+from .guild_config import GuildConfigRepository
 from .predictions import PredictionRepository, SaveResult
 from .results import ResultsRepository
 from .scores import ScoreRepository
@@ -146,6 +147,7 @@ class Database:
             db_dir.mkdir(parents=True, exist_ok=True)
 
         self._fixtures = FixtureRepository(self.db_path)
+        self._guild_config = GuildConfigRepository(self.db_path)
         self._predictions = PredictionRepository(self.db_path)
         self._results = ResultsRepository(self.db_path)
         self._scores = ScoreRepository(self.db_path)
@@ -221,6 +223,16 @@ class Database:
                 )
             """)
 
+            await db.execute("""
+                CREATE TABLE IF NOT EXISTS guild_config (
+                    guild_id TEXT PRIMARY KEY,
+                    admin_role_id TEXT NOT NULL,
+                    league_channel_id TEXT NOT NULL,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+
             column_names = await _table_columns(db, "fixtures")
 
             if "message_id" not in column_names:
@@ -248,6 +260,14 @@ class Database:
             )
 
             await db.commit()
+
+    async def upsert_guild_config(self, guild_id, admin_role_id, league_channel_id):
+        return await self._guild_config.upsert_guild_config(
+            guild_id, admin_role_id, league_channel_id
+        )
+
+    async def get_guild_config(self, guild_id):
+        return await self._guild_config.get_guild_config(guild_id)
 
     async def create_fixture(self, guild_id, week_number, games, deadline):
         return await self._fixtures.create_fixture(guild_id, week_number, games, deadline)

--- a/typer_bot/database/guild_config.py
+++ b/typer_bot/database/guild_config.py
@@ -1,0 +1,47 @@
+"""Guild configuration repository."""
+
+import aiosqlite
+
+
+class GuildConfigRepository:
+    """CRUD for per-guild bot configuration."""
+
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+
+    async def upsert_guild_config(
+        self,
+        guild_id: str,
+        admin_role_id: str,
+        league_channel_id: str,
+    ) -> None:
+        """Create or replace the minimal config for one guild."""
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                """
+                INSERT INTO guild_config (guild_id, admin_role_id, league_channel_id)
+                VALUES (?, ?, ?)
+                ON CONFLICT(guild_id) DO UPDATE SET
+                    admin_role_id = excluded.admin_role_id,
+                    league_channel_id = excluded.league_channel_id,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                (guild_id, admin_role_id, league_channel_id),
+            )
+            await db.commit()
+
+    async def get_guild_config(self, guild_id: str) -> dict | None:
+        """Return stored config for one guild, if setup has been completed."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(
+                """
+                SELECT guild_id, admin_role_id, league_channel_id, created_at, updated_at
+                FROM guild_config
+                WHERE guild_id = ?
+                """,
+                (guild_id,),
+            ) as cursor:
+                row = await cursor.fetchone()
+
+        return dict(row) if row else None

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 import discord
 
 from typer_bot.database import Database, SaveResult
-from typer_bot.utils import get_admin_role_mention, now, parse_prediction_lines
+from typer_bot.utils import get_configured_admin_role_mention, now, parse_prediction_lines
 from typer_bot.utils.logger import LogContextManager, log_event
 
 logger = logging.getLogger(__name__)
@@ -239,7 +239,11 @@ class ThreadPredictionHandler:
             if is_late:
                 with suppress(discord.Forbidden):
                     if pending_partial_approval:
-                        admin_role_mention = get_admin_role_mention(message.guild)
+                        admin_role_mention = (
+                            await get_configured_admin_role_mention(str(message.guild.id), self.db)
+                            if message.guild
+                            else None
+                        )
                         await message.author.send(
                             "⏳ **Late prediction received.** It was saved and is now awaiting admin review because it arrived late with missing games."
                         )

--- a/typer_bot/utils/__init__.py
+++ b/typer_bot/utils/__init__.py
@@ -1,6 +1,7 @@
 """Utility functions and helpers."""
 
 from .permissions import (
+    SETUP_REQUIRED_MESSAGE,
     get_admin_permission_error,
     get_admin_role_mention,
     get_configured_admin_role_mention,
@@ -43,4 +44,5 @@ __all__ = [
     "format_for_discord",
     "parse_iso",
     "APP_TZ",
+    "SETUP_REQUIRED_MESSAGE",
 ]

--- a/typer_bot/utils/__init__.py
+++ b/typer_bot/utils/__init__.py
@@ -1,6 +1,14 @@
 """Utility functions and helpers."""
 
-from .permissions import get_admin_role_mention, is_admin, is_admin_member
+from .permissions import (
+    get_admin_permission_error,
+    get_admin_role_mention,
+    get_configured_admin_role_mention,
+    has_setup_permission,
+    is_admin,
+    is_admin_member,
+    is_configured_admin,
+)
 from .prediction_parser import (
     ascii_username,
     format_fixture_results,
@@ -16,8 +24,12 @@ from .timezone import APP_TZ, format_for_discord, now, parse_deadline, parse_iso
 __all__ = [
     "ascii_username",
     "get_admin_role_mention",
+    "get_configured_admin_role_mention",
+    "get_admin_permission_error",
+    "has_setup_permission",
     "is_admin",
     "is_admin_member",
+    "is_configured_admin",
     "parse_predictions",
     "parse_prediction_lines",
     "parse_line_predictions",

--- a/typer_bot/utils/permissions.py
+++ b/typer_bot/utils/permissions.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from typer_bot.database import Database
 
 SETUP_REQUIRED_MESSAGE = (
-    "TyperBot is not set up for this server. A server manager must run `/admin setup` first."
+    "TyperBot is not set up for this server. A server manager must run `/admin panel` first."
 )
 
 

--- a/typer_bot/utils/permissions.py
+++ b/typer_bot/utils/permissions.py
@@ -1,10 +1,36 @@
 """Permission checking utilities."""
 
+from typing import TYPE_CHECKING, cast
+
 import discord
 
+if TYPE_CHECKING:
+    from typer_bot.database import Database
 
-def _has_admin_role(member: discord.Member) -> bool:
+SETUP_REQUIRED_MESSAGE = (
+    "TyperBot is not set up for this server. A server manager must run `/admin setup` first."
+)
+
+
+def _interaction_member(interaction: discord.Interaction) -> discord.Member | None:
+    if not interaction.guild:
+        return None
+
+    cached_member = interaction.guild.get_member(interaction.user.id)
+    if cached_member is not None:
+        return cached_member
+
+    if isinstance(interaction.user, discord.Member) or hasattr(interaction.user, "roles"):
+        return cast(discord.Member, interaction.user)
+
+    return None
+
+
+def _has_admin_role(member: discord.Member, admin_role_id: str | None = None) -> bool:
     """Check if member has an admin role."""
+    if admin_role_id is not None:
+        return any(str(role.id) == admin_role_id for role in member.roles)
+
     admin_roles = {"admin", "typer-admin"}
     return any(role.name.lower() in admin_roles for role in member.roles)
 
@@ -21,13 +47,72 @@ def is_admin(interaction: discord.Interaction) -> bool:
     """
     if not interaction.guild:
         return False
-    member = interaction.guild.get_member(interaction.user.id)
+    member = _interaction_member(interaction)
     return _has_admin_role(member) if member else False
 
 
-def is_admin_member(member: discord.Member | None) -> bool:
+async def is_configured_admin(interaction: discord.Interaction, db: "Database") -> bool:
+    """Check whether the user has the configured TyperBot admin role."""
+    if not interaction.guild or interaction.guild_id is None:
+        return False
+
+    config = await db.get_guild_config(str(interaction.guild_id))
+    if config is None:
+        return False
+
+    member = _interaction_member(interaction)
+    return _has_admin_role(member, config["admin_role_id"]) if member else False
+
+
+async def get_configured_admin_role_mention(guild_id: str, db: "Database") -> str | None:
+    """Return the configured TyperBot admin role mention for one guild."""
+    config = await db.get_guild_config(guild_id)
+    if config is None:
+        return None
+    return f"<@&{config['admin_role_id']}>"
+
+
+async def get_admin_permission_error(
+    interaction: discord.Interaction,
+    db: "Database",
+) -> str | None:
+    """Return the user-visible reason an admin action should be blocked."""
+    if not interaction.guild or interaction.guild_id is None:
+        return "This command can only be used in a server."
+
+    config = await db.get_guild_config(str(interaction.guild_id))
+    if config is None:
+        return SETUP_REQUIRED_MESSAGE
+
+    member = _interaction_member(interaction)
+    if member is None or not _has_admin_role(member, config["admin_role_id"]):
+        return "You no longer have permission to use admin commands."
+
+    return None
+
+
+def is_admin_member(member: discord.Member | None, admin_role_id: str | None = None) -> bool:
     """Check if a guild member currently has an admin role."""
-    return _has_admin_role(member) if member else False
+    return _has_admin_role(member, admin_role_id) if member else False
+
+
+def has_setup_permission(interaction: discord.Interaction) -> bool:
+    """Only Discord-native server managers/admins may configure TyperBot."""
+    if not interaction.guild:
+        return False
+
+    member = _interaction_member(interaction)
+    if member is None:
+        return False
+
+    permissions = getattr(member, "guild_permissions", None)
+    return bool(
+        permissions
+        and (
+            getattr(permissions, "administrator", False)
+            or getattr(permissions, "manage_guild", False)
+        )
+    )
 
 
 def get_admin_role_mention(guild: discord.Guild | None) -> str | None:


### PR DESCRIPTION
## Summary
- add minimal per-guild config for TyperBot admin role and league channel
- make `/admin panel` the setup and reconfiguration entrypoint for guild config
- route fixture announcements, reminders, admin checks, and late-review pings through configured guild values
- require explicit confirmation before using `@everyone` as the TyperBot admin role
- document setup/reconfiguration and remove the old reminder-channel env var from README

Closes #198

## Testing
- `uv run pytest --tb=short`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check typer_bot`

## Notes
- The `guild_config` table is created automatically, but rows are not backfilled automatically.
- Existing production guilds must complete setup from `/admin panel` once after deploy, or be configured manually with a deliberate SQL insert.
- Runtime cooldown scoping and remaining background-task cleanup stay in #199.