### PR TITLE
refactor: make runtime state guild-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The panel handles:
 - review late partial predictions
 - toggle late waivers
 
-After setup, admins need the configured TyperBot admin role. Only Discord-native server managers/admins can complete or update setup from `/admin panel`.
+After setup, admins need the configured TyperBot admin role. Only Discord-native server admins can complete or update setup from `/admin panel`.
 
 ## Permissions
 - `Send Messages`

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -144,43 +144,8 @@ class TestAdminPanelEntry:
 
         assert isinstance(mock_interaction_admin.response_sent[-1]["view"], GuildSetupStartView)
 
-    @pytest.mark.asyncio
-    async def test_panel_check_prompts_server_manager_to_setup_inline(
-        self,
-        mock_bot,
-        mock_interaction_admin,
-        temp_db_path,
-    ):
-        db = Database(temp_db_path)
-        await db.initialize()
-        mock_bot.db = db
-        admin_cog = AdminCommands(mock_bot)
-        mock_interaction_admin.client = mock_bot
-        member = mock_interaction_admin.guild.get_member(mock_interaction_admin.user.id)
-        member.guild_permissions.manage_guild = True
-
-        can_run = await admin_cog.panel.checks[0](mock_interaction_admin)
-
-        assert can_run is False
-        assert isinstance(mock_interaction_admin.response_sent[-1]["view"], GuildSetupStartView)
-
-    @pytest.mark.asyncio
-    async def test_panel_check_blocks_non_manager_without_setup(
-        self,
-        mock_bot,
-        mock_interaction_admin,
-        temp_db_path,
-    ):
-        db = Database(temp_db_path)
-        await db.initialize()
-        mock_bot.db = db
-        admin_cog = AdminCommands(mock_bot)
-        mock_interaction_admin.client = mock_bot
-
-        can_run = await admin_cog.panel.checks[0](mock_interaction_admin)
-
-        assert can_run is False
-        assert mock_interaction_admin.response_sent[-1].get("view") is None
+    def test_panel_has_no_app_command_check(self, admin_cog):
+        assert admin_cog.panel.checks == []
 
     @pytest.mark.asyncio
     async def test_inline_setup_button_opens_selector_view(
@@ -530,10 +495,12 @@ class TestCooldownLogic:
         import time
 
         user_id = "user123"
+        guild_id = "guild123"
         current_time = time.time()
-        admin_cog.record_calculate_cooldown(user_id, current_time=current_time)
+        admin_cog.record_calculate_cooldown(guild_id, user_id, current_time=current_time)
 
         remaining = admin_cog.get_calculate_cooldown_remaining(
+            guild_id,
             user_id,
             current_time=current_time,
             cooldown_seconds=CALCULATE_COOLDOWN,
@@ -545,18 +512,37 @@ class TestCooldownLogic:
         import time
 
         user_id = "user123"
+        guild_id = "guild123"
         current_time = time.time()
-        admin_cog.record_calculate_cooldown(user_id, current_time=current_time - 31)
+        admin_cog.record_calculate_cooldown(guild_id, user_id, current_time=current_time - 31)
 
         remaining = admin_cog.get_calculate_cooldown_remaining(
+            guild_id,
             user_id,
             current_time=current_time,
             cooldown_seconds=CALCULATE_COOLDOWN,
         )
         assert remaining == 0.0
 
+    def test_cooldown_is_scoped_by_guild(self, admin_cog):
+        import time
+
+        user_id = "user123"
+        current_time = time.time()
+        admin_cog.record_calculate_cooldown("guild-a", user_id, current_time=current_time)
+
+        remaining = admin_cog.get_calculate_cooldown_remaining(
+            "guild-b",
+            user_id,
+            current_time=current_time,
+            cooldown_seconds=CALCULATE_COOLDOWN,
+        )
+
+        assert remaining == 0.0
+
     def test_cleanup_expired_state_removes_stale_entries(self, admin_cog):
         admin_cog.record_calculate_cooldown(
+            "guild123",
             "user123",
             current_time=now().timestamp() - timedelta(hours=2).total_seconds(),
         )

--- a/tests/test_admin_commands.py
+++ b/tests/test_admin_commands.py
@@ -127,7 +127,7 @@ class TestAdminPanelEntry:
         assert "not set up" in mock_interaction_admin.response_sent[-1]["content"]
 
     @pytest.mark.asyncio
-    async def test_panel_prompts_server_manager_to_setup_inline(
+    async def test_panel_prompts_server_admin_to_setup_inline(
         self,
         mock_bot,
         mock_interaction_admin,

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1569,7 +1569,10 @@ class TestFixturePanelFlows:
         calculate_button = _get_button(view, "Calculate Scores")
         await calculate_button.callback(mock_interaction_admin)
 
-        assert admin_cog.get_calculate_cooldown(str(mock_interaction_admin.user.id)) is not None
+        assert (
+            admin_cog.get_calculate_cooldown("111111", str(mock_interaction_admin.user.id))
+            is not None
+        )
         channel.send.assert_awaited_once()
         assert (
             "Week 45 results calculated and posted"
@@ -1588,7 +1591,7 @@ class TestFixturePanelFlows:
             "111111", 47, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         admin_cog.record_calculate_cooldown(
-            str(mock_interaction_admin.user.id), current_time=now().timestamp()
+            "111111", str(mock_interaction_admin.user.id), current_time=now().timestamp()
         )
         admin_cog.service.calculate_fixture_scores = AsyncMock()
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -195,12 +195,13 @@ class TestFixtureAnnouncementSync:
             bot = TyperBot.__new__(TyperBot)
             bot.db = MagicMock()
             bot.get_channel = MagicMock()
+            bot.get_guild = MagicMock()
             bot.fetch_channel = AsyncMock()
             yield bot
 
     @pytest.mark.asyncio
     async def test_sync_fixture_thread_uses_stored_channel_id(self, bot_instance):
-        fixture = {"id": 1, "message_id": "789012", "channel_id": "123456"}
+        fixture = {"id": 1, "guild_id": "111111", "message_id": "789012", "channel_id": "123456"}
         message = MagicMock()
         message.thread = MagicMock(id=789012)
         channel = MagicMock()
@@ -215,12 +216,18 @@ class TestFixtureAnnouncementSync:
         bot_instance.fetch_channel.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_sync_fixture_thread_scans_guild_channels_only_without_channel_id(
+    async def test_sync_fixture_thread_scans_owning_guild_channels_only_without_channel_id(
         self, bot_instance
     ):
-        fixture = {"id": 1, "message_id": "789012", "channel_id": None}
+        fixture = {"id": 1, "guild_id": "111111", "message_id": "789012", "channel_id": None}
         message = MagicMock()
         message.thread = MagicMock(id=789012)
+        other_channel = MagicMock()
+        other_channel.id = 50
+        other_channel.fetch_message = AsyncMock(return_value=message)
+        other_guild = MagicMock()
+        other_guild.id = 222222
+        other_guild.text_channels = [other_channel]
         miss_channel = MagicMock()
         miss_channel.id = 100
         miss_channel.fetch_message = AsyncMock(side_effect=discord.NotFound(MagicMock(), "missing"))
@@ -228,14 +235,17 @@ class TestFixtureAnnouncementSync:
         hit_channel.id = 200
         hit_channel.fetch_message = AsyncMock(return_value=message)
         guild = MagicMock()
+        guild.id = 111111
         guild.text_channels = [miss_channel, hit_channel]
-        bot_instance.guilds = [guild]
+        bot_instance.guilds = [other_guild, guild]
+        bot_instance.get_guild.return_value = guild
         bot_instance.db.get_all_open_fixtures = AsyncMock(return_value=[fixture])
 
         await bot_instance._sync_fixture_thread()
 
         bot_instance.get_channel.assert_not_called()
         bot_instance.fetch_channel.assert_not_called()
+        other_channel.fetch_message.assert_not_called()
         miss_channel.fetch_message.assert_awaited_once_with(789012)
         hit_channel.fetch_message.assert_awaited_once_with(789012)
 
@@ -243,7 +253,7 @@ class TestFixtureAnnouncementSync:
     async def test_sync_fixture_thread_does_not_scan_when_stored_channel_missing(
         self, bot_instance
     ):
-        fixture = {"id": 1, "message_id": "789012", "channel_id": "123456"}
+        fixture = {"id": 1, "guild_id": "111111", "message_id": "789012", "channel_id": "123456"}
         guild = MagicMock()
         guild.text_channels = [MagicMock()]
         bot_instance.guilds = [guild]
@@ -259,7 +269,7 @@ class TestFixtureAnnouncementSync:
     async def test_sync_fixture_thread_does_not_scan_when_stored_channel_message_missing(
         self, bot_instance
     ):
-        fixture = {"id": 1, "message_id": "789012", "channel_id": "123456"}
+        fixture = {"id": 1, "guild_id": "111111", "message_id": "789012", "channel_id": "123456"}
         channel = MagicMock()
         channel.fetch_message = AsyncMock(side_effect=discord.NotFound(MagicMock(), "missing"))
         guild = MagicMock()
@@ -275,7 +285,7 @@ class TestFixtureAnnouncementSync:
 
     @pytest.mark.asyncio
     async def test_sync_fixture_thread_fetches_stored_channel_when_not_cached(self, bot_instance):
-        fixture = {"id": 1, "message_id": "789012", "channel_id": "123456"}
+        fixture = {"id": 1, "guild_id": "111111", "message_id": "789012", "channel_id": "123456"}
         message = MagicMock()
         message.thread = MagicMock(id=789012)
         channel = MagicMock()
@@ -291,7 +301,12 @@ class TestFixtureAnnouncementSync:
 
     @pytest.mark.asyncio
     async def test_sync_fixture_thread_does_not_scan_with_invalid_stored_ids(self, bot_instance):
-        fixture = {"id": 1, "message_id": "not-a-message", "channel_id": "not-a-channel"}
+        fixture = {
+            "id": 1,
+            "guild_id": "111111",
+            "message_id": "not-a-message",
+            "channel_id": "not-a-channel",
+        }
         guild = MagicMock()
         guild.text_channels = [MagicMock()]
         bot_instance.guilds = [guild]

--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -74,7 +74,7 @@ class TestOnMessage:
         assert result is False
         assert len(mock_message.reactions_added) == 0
         assert len(mock_message.author.dm_sent) == 0
-        assert handler.get_thread_prediction_cooldown("123456") is None
+        assert handler.get_thread_prediction_cooldown("111111", "123456") is None
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("fixture_with_thread")
@@ -89,7 +89,7 @@ class TestOnMessage:
         assert "❌" in mock_message.reactions_added
         assert len(mock_message.author.dm_sent) == 1
         assert "Invalid predictions" in mock_message.author.dm_sent[0]
-        assert handler.get_thread_prediction_cooldown("123456") is not None
+        assert handler.get_thread_prediction_cooldown("111111", "123456") is not None
 
     @pytest.mark.asyncio
     async def test_saves_valid_predictions(self, handler, fixture_with_thread, mock_message):
@@ -231,6 +231,25 @@ class TestOnMessage:
         assert second_message.author.dm_sent == []
 
     @pytest.mark.asyncio
+    async def test_thread_prediction_cooldown_is_scoped_by_guild(
+        self, handler, database, mock_message, sample_games
+    ):
+        deadline = datetime.now(UTC) + timedelta(days=1)
+        fixture_id = await database.create_fixture("222222", 1, sample_games, deadline)
+        await database.update_fixture_announcement(
+            fixture_id, message_id="888888", channel_id="456789"
+        )
+        handler.record_thread_prediction_attempt("111111", "123456", datetime.now(UTC))
+        mock_message.guild.id = 222222
+        mock_message.channel.id = 888888
+        mock_message.content = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
+
+        result = await handler.on_message(mock_message)
+
+        assert result is True
+        assert "✅" in mock_message.reactions_added
+
+    @pytest.mark.asyncio
     @pytest.mark.usefixtures("fixture_with_thread")
     async def test_chatty_message_does_not_consume_next_prediction_cooldown(
         self, handler, mock_message
@@ -299,7 +318,9 @@ class TestOnMessage:
         assert retry_message.reactions_added == []
 
     def test_cleanup_expired_state_removes_stale_cooldowns(self, handler):
-        handler.record_thread_prediction_attempt("user-1", datetime.now(UTC) - timedelta(hours=2))
+        handler.record_thread_prediction_attempt(
+            "guild-1", "user-1", datetime.now(UTC) - timedelta(hours=2)
+        )
 
         removed = handler.cleanup_expired_state()
 

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -249,8 +249,8 @@ class TyperBot(commands.Bot):
         """Verify fixture announcement exists on startup.
 
         Checks that each open fixture's announcement message is accessible.
-        Stored channel/message IDs are used directly when available; the slower
-        guild-wide scan only exists for legacy fixtures missing ``channel_id``.
+        Stored channel/message IDs are used directly when available; legacy
+        fixtures missing ``channel_id`` are scanned only inside their owning guild.
         The stored message_id doubles as the thread_id since Discord public
         threads inherit their parent message's snowflake ID.
         """
@@ -302,10 +302,10 @@ class TyperBot(commands.Bot):
             return None
 
         logger.info(
-            "Fixture %s has no channel_id, scanning guild text channels for legacy verification",
+            "Fixture %s has no channel_id, scanning owning guild text channels for legacy verification",
             fixture["id"],
         )
-        return await self._scan_fixture_message_across_guilds(message_id)
+        return await self._scan_fixture_message_in_guild(fixture["guild_id"], message_id)
 
     async def _fetch_fixture_message_from_channel(
         self,
@@ -375,24 +375,31 @@ class TyperBot(commands.Bot):
             )
             return None
 
-    async def _scan_fixture_message_across_guilds(self, message_id: str):
+    async def _scan_fixture_message_in_guild(self, guild_id: str, message_id: str):
         try:
+            discord_guild_id = int(guild_id)
             discord_message_id = int(message_id)
         except (TypeError, ValueError):
             return None
 
-        for guild in self.guilds:
-            for channel in guild.text_channels:
-                try:
-                    return await channel.fetch_message(discord_message_id)
-                except discord.NotFound:
-                    continue
-                except discord.Forbidden:
-                    logger.warning(f"No permission to read channel {channel.id}")
-                    continue
-                except Exception as exc:
-                    logger.warning(f"Could not verify fixture in {channel.id}: {exc}")
-                    continue
+        guild = self.get_guild(discord_guild_id)
+        if guild is None:
+            logger.warning(
+                "Could not resolve owning guild %s for fixture announcement verification", guild_id
+            )
+            return None
+
+        for channel in guild.text_channels:
+            try:
+                return await channel.fetch_message(discord_message_id)
+            except discord.NotFound:
+                continue
+            except discord.Forbidden:
+                logger.warning(f"No permission to read channel {channel.id}")
+                continue
+            except Exception as exc:
+                logger.warning(f"Could not verify fixture in {channel.id}: {exc}")
+                continue
 
         return None
 

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -283,10 +283,11 @@ class AdminCommands(commands.Cog):
         self.bot = bot
         self.db: Database = bot.db  # type: ignore
         self.service = AdminService(self.db)
-        self._calculate_cooldowns: dict[str, float] = {}
+        self._calculate_cooldowns: dict[tuple[str, str], float] = {}
 
     def get_calculate_cooldown_remaining(
         self,
+        guild_id: str,
         user_id: str,
         *,
         current_time: float,
@@ -299,30 +300,32 @@ class AdminCommands(commands.Cog):
         """
         cutoff = current_time - COOLDOWN_ENTRY_EXPIRY.total_seconds()
         expired_users = [
-            stored_user_id
-            for stored_user_id, timestamp in self._calculate_cooldowns.items()
+            stored_key
+            for stored_key, timestamp in self._calculate_cooldowns.items()
             if timestamp < cutoff
         ]
-        for stored_user_id in expired_users:
-            self._calculate_cooldowns.pop(stored_user_id, None)
+        for stored_key in expired_users:
+            self._calculate_cooldowns.pop(stored_key, None)
 
-        last_used = self._calculate_cooldowns.get(user_id)
+        last_used = self._calculate_cooldowns.get((guild_id, user_id))
         if last_used is None:
             return 0.0
 
         return max(0.0, cooldown_seconds - (current_time - last_used))
 
-    def record_calculate_cooldown(self, user_id: str, *, current_time: float) -> None:
-        self._calculate_cooldowns[user_id] = current_time
+    def record_calculate_cooldown(
+        self, guild_id: str, user_id: str, *, current_time: float
+    ) -> None:
+        self._calculate_cooldowns[(guild_id, user_id)] = current_time
 
-    def get_calculate_cooldown(self, user_id: str) -> float | None:
-        return self._calculate_cooldowns.get(user_id)
+    def get_calculate_cooldown(self, guild_id: str, user_id: str) -> float | None:
+        return self._calculate_cooldowns.get((guild_id, user_id))
 
     def cleanup_expired_state(self) -> int:
         cutoff = now().timestamp() - COOLDOWN_ENTRY_EXPIRY.total_seconds()
-        expired = [uid for uid, ts in self._calculate_cooldowns.items() if ts < cutoff]
-        for uid in expired:
-            self._calculate_cooldowns.pop(uid, None)
+        expired = [key for key, ts in self._calculate_cooldowns.items() if ts < cutoff]
+        for key in expired:
+            self._calculate_cooldowns.pop(key, None)
         return len(expired)
 
     async def _create_backup(self) -> None:
@@ -376,7 +379,6 @@ class AdminCommands(commands.Cog):
     )
 
     @admin.command(name="panel", description="Open the admin management panel")
-    @admin_only()
     async def panel(self, interaction: discord.Interaction):
         permission_error = await get_admin_permission_error(interaction, self.db)
         if permission_error is not None:

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -79,7 +79,7 @@ class EveryoneRoleConfirmView(discord.ui.View):
             return False
         if not has_setup_permission(interaction):
             await interaction.response.send_message(
-                "Only a server manager can configure TyperBot for this server.", ephemeral=True
+                "Only a server admin can configure TyperBot for this server.", ephemeral=True
             )
             return False
         return True
@@ -192,7 +192,7 @@ class GuildSetupPromptView(discord.ui.View):
             return False
         if not has_setup_permission(interaction):
             await interaction.response.send_message(
-                "Only a server manager can configure TyperBot for this server.", ephemeral=True
+                "Only a server admin can configure TyperBot for this server.", ephemeral=True
             )
             return False
         return True
@@ -209,7 +209,7 @@ class StartSetupButton(discord.ui.Button):
     async def callback(self, interaction: discord.Interaction):
         if not has_setup_permission(interaction):
             await interaction.response.send_message(
-                "Only a server manager can configure TyperBot for this server.", ephemeral=True
+                "Only a server admin can configure TyperBot for this server.", ephemeral=True
             )
             return
 

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -400,6 +400,7 @@ class CalculateScoresButton(discord.ui.Button):
         user_id = str(interaction.user.id)
         current_time = now().timestamp()
         remaining = admin_commands.get_calculate_cooldown_remaining(
+            self.parent_view.guild_id,
             user_id,
             current_time=current_time,
             cooldown_seconds=30.0,
@@ -418,7 +419,9 @@ class CalculateScoresButton(discord.ui.Button):
             await interaction.response.send_message(str(exc), ephemeral=True)
             return
 
-        admin_commands.record_calculate_cooldown(user_id, current_time=current_time)
+        admin_commands.record_calculate_cooldown(
+            self.parent_view.guild_id, user_id, current_time=current_time
+        )
         await admin_commands._create_backup()
         await admin_commands._post_calculation_to_channel(interaction, score_result)
 

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -43,7 +43,7 @@ class SetupBotButton(discord.ui.Button):
 
         if not has_setup_permission(interaction):
             await interaction.response.send_message(
-                "Only a server manager can configure TyperBot for this server.", ephemeral=True
+                "Only a server admin can configure TyperBot for this server.", ephemeral=True
             )
             return
 

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -30,48 +30,49 @@ class ThreadPredictionHandler:
     def __init__(self, bot: discord.Client, db: Database):
         self.bot = bot
         self.db = db
-        self._thread_prediction_cooldowns: dict[str, datetime] = {}
+        self._thread_prediction_cooldowns: dict[tuple[str, str], datetime] = {}
 
     def record_thread_prediction_attempt(
-        self, user_id: str, current_time: datetime
+        self, guild_id: str, user_id: str, current_time: datetime
     ) -> datetime | None:
         """Record a thread prediction attempt and return the previous timestamp.
 
         Also prunes cooldown entries older than `COOLDOWN_ENTRY_EXPIRY` so the
         rate-limit check does not require a separate cleanup pass.
         """
-        previous_attempt = self._thread_prediction_cooldowns.get(user_id)
-        self._thread_prediction_cooldowns[user_id] = current_time
+        cooldown_key = (guild_id, user_id)
+        previous_attempt = self._thread_prediction_cooldowns.get(cooldown_key)
+        self._thread_prediction_cooldowns[cooldown_key] = current_time
 
         cutoff = current_time - COOLDOWN_ENTRY_EXPIRY
         expired_users = [
-            stored_user_id
-            for stored_user_id, timestamp in self._thread_prediction_cooldowns.items()
+            stored_key
+            for stored_key, timestamp in self._thread_prediction_cooldowns.items()
             if timestamp < cutoff
         ]
-        for stored_user_id in expired_users:
-            self._thread_prediction_cooldowns.pop(stored_user_id, None)
+        for stored_key in expired_users:
+            self._thread_prediction_cooldowns.pop(stored_key, None)
 
         return previous_attempt
 
-    def is_rate_limited(self, user_id: str, current_time: datetime) -> bool:
+    def is_rate_limited(self, guild_id: str, user_id: str, current_time: datetime) -> bool:
         """Return whether a recognized prediction attempt should be rate limited."""
-        last_time = self._thread_prediction_cooldowns.get(user_id)
+        last_time = self._thread_prediction_cooldowns.get((guild_id, user_id))
         if last_time is None:
             return False
         return (current_time - last_time).total_seconds() < PREDICTION_RATE_LIMIT_SECONDS
 
-    def get_thread_prediction_cooldown(self, user_id: str) -> datetime | None:
-        return self._thread_prediction_cooldowns.get(user_id)
+    def get_thread_prediction_cooldown(self, guild_id: str, user_id: str) -> datetime | None:
+        return self._thread_prediction_cooldowns.get((guild_id, user_id))
 
     def clear_thread_prediction_cooldowns(self) -> None:
         self._thread_prediction_cooldowns.clear()
 
     def cleanup_expired_state(self) -> int:
         cutoff = now() - COOLDOWN_ENTRY_EXPIRY
-        expired = [uid for uid, ts in self._thread_prediction_cooldowns.items() if ts < cutoff]
-        for uid in expired:
-            self._thread_prediction_cooldowns.pop(uid, None)
+        expired = [key for key, ts in self._thread_prediction_cooldowns.items() if ts < cutoff]
+        for key in expired:
+            self._thread_prediction_cooldowns.pop(key, None)
         return len(expired)
 
     async def on_message(self, message: discord.Message):
@@ -93,6 +94,7 @@ class ThreadPredictionHandler:
         if not fixture:
             return False
 
+        guild_id = str(message.guild.id)
         user_id = str(message.author.id)
         with LogContextManager(
             user_id=user_id,
@@ -107,11 +109,11 @@ class ThreadPredictionHandler:
             )
 
             if len(message.content) > MAX_MESSAGE_LENGTH or has_score_like_content:
-                if self.is_rate_limited(user_id, current_time):
+                if self.is_rate_limited(guild_id, user_id, current_time):
                     logger.debug(f"Rate limiting prediction from {user_id}")
                     return True
 
-                self.record_thread_prediction_attempt(user_id, current_time)
+                self.record_thread_prediction_attempt(guild_id, user_id, current_time)
 
             if len(message.content) > MAX_MESSAGE_LENGTH:
                 await self._handle_error(

--- a/typer_bot/utils/permissions.py
+++ b/typer_bot/utils/permissions.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from typer_bot.database import Database
 
 SETUP_REQUIRED_MESSAGE = (
-    "TyperBot is not set up for this server. A server manager must run `/admin panel` first."
+    "TyperBot is not set up for this server. A server admin must run `/admin panel` first."
 )
 
 
@@ -97,7 +97,7 @@ def is_admin_member(member: discord.Member | None, admin_role_id: str | None = N
 
 
 def has_setup_permission(interaction: discord.Interaction) -> bool:
-    """Only Discord-native server managers/admins may configure TyperBot."""
+    """Only Discord-native server admins may configure TyperBot."""
     if not interaction.guild:
         return False
 


### PR DESCRIPTION
## Summary
- scope process-local thread prediction and score-calculation cooldowns by guild and user
- keep startup fixture announcement verification inside the fixture-owning guild when legacy rows lack `channel_id`
- let `/admin panel` handle setup/permission responses in-command instead of failing an app-command check

Closes #199

## Testing
- `uv run pytest --tb=short`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check typer_bot`

## Review
- review subagent: no actionable findings