### PR TITLE
fix: harden score writes and standings query

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -155,6 +155,50 @@ class TestScores:
         assert [score["user_id"] for score in scores] == ["user-1"]
 
     @pytest.mark.asyncio
+    async def test_save_scores_rolls_back_after_partial_write_failure(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        fixture_id = await db.create_fixture("111111", 1, ["Team A - Team B"], datetime.now(UTC))
+        await db.save_scores(
+            fixture_id,
+            [
+                {
+                    "user_id": "user-1",
+                    "user_name": "User One",
+                    "points": 3,
+                    "exact_scores": 1,
+                    "correct_results": 0,
+                }
+            ],
+        )
+
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.save_scores(
+                fixture_id,
+                [
+                    {
+                        "user_id": "user-2",
+                        "user_name": "User Two",
+                        "points": 9,
+                        "exact_scores": 3,
+                        "correct_results": 3,
+                    },
+                    {
+                        "user_id": "user-2",
+                        "user_name": "Duplicate User Two",
+                        "points": 0,
+                        "exact_scores": 0,
+                        "correct_results": 0,
+                    },
+                ],
+            )
+
+        scores = await db.get_scores_for_fixture(fixture_id)
+        assert len(scores) == 1
+        assert scores[0]["user_id"] == "user-1"
+        assert scores[0]["points"] == 3
+
+    @pytest.mark.asyncio
     async def test_standings_order_by_points_tiebreakers_and_name(self, temp_db_path):
         db = Database(temp_db_path)
         await db.initialize()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -9,6 +9,7 @@ import aiosqlite
 import pytest
 
 from typer_bot.database import Database, SaveResult
+from typer_bot.database import scores as scores_module
 
 
 @pytest.fixture
@@ -101,6 +102,114 @@ class TestGuildConfig:
         guild_two = await db.get_guild_config("222222")
         assert guild_one["admin_role_id"] == "role-1"
         assert guild_two["admin_role_id"] == "role-2"
+
+
+class TestScores:
+    @pytest.mark.asyncio
+    async def test_save_scores_does_not_mutate_when_write_lock_is_held(
+        self, temp_db_path, monkeypatch
+    ):
+        db = Database(temp_db_path)
+        await db.initialize()
+        fixture_id = await db.create_fixture("111111", 1, ["Team A - Team B"], datetime.now(UTC))
+        await db.save_scores(
+            fixture_id,
+            [
+                {
+                    "user_id": "user-1",
+                    "user_name": "User One",
+                    "points": 3,
+                    "exact_scores": 1,
+                    "correct_results": 0,
+                }
+            ],
+        )
+
+        real_connect = scores_module.aiosqlite.connect
+
+        def connect_with_short_timeout(*args, **kwargs):
+            kwargs.setdefault("timeout", 0.05)
+            return real_connect(*args, **kwargs)
+
+        monkeypatch.setattr(scores_module.aiosqlite, "connect", connect_with_short_timeout)
+        async with aiosqlite.connect(temp_db_path) as locked_conn:
+            await locked_conn.execute("BEGIN IMMEDIATE")
+
+            with pytest.raises(aiosqlite.OperationalError, match="locked"):
+                await db.save_scores(
+                    fixture_id,
+                    [
+                        {
+                            "user_id": "user-2",
+                            "user_name": "User Two",
+                            "points": 9,
+                            "exact_scores": 3,
+                            "correct_results": 3,
+                        }
+                    ],
+                )
+
+            await locked_conn.rollback()
+
+        scores = await db.get_scores_for_fixture(fixture_id)
+        assert [score["user_id"] for score in scores] == ["user-1"]
+
+    @pytest.mark.asyncio
+    async def test_standings_order_by_points_tiebreakers_and_name(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        fixture_id = await db.create_fixture("111111", 1, ["Team A - Team B"], datetime.now(UTC))
+
+        await db.save_scores(
+            fixture_id,
+            [
+                {
+                    "user_id": "total",
+                    "user_name": "Total",
+                    "points": 10,
+                    "exact_scores": 0,
+                    "correct_results": 0,
+                },
+                {
+                    "user_id": "exact",
+                    "user_name": "Exact",
+                    "points": 9,
+                    "exact_scores": 2,
+                    "correct_results": 0,
+                },
+                {
+                    "user_id": "correct",
+                    "user_name": "Correct",
+                    "points": 9,
+                    "exact_scores": 1,
+                    "correct_results": 3,
+                },
+                {
+                    "user_id": "alpha",
+                    "user_name": "Alpha",
+                    "points": 9,
+                    "exact_scores": 1,
+                    "correct_results": 2,
+                },
+                {
+                    "user_id": "beta",
+                    "user_name": "Beta",
+                    "points": 9,
+                    "exact_scores": 1,
+                    "correct_results": 2,
+                },
+            ],
+        )
+
+        standings = await db.get_standings("111111")
+
+        assert [row["user_id"] for row in standings] == [
+            "total",
+            "exact",
+            "correct",
+            "alpha",
+            "beta",
+        ]
 
 
 class TestOpenFixturesQueries:

--- a/typer_bot/database/scores.py
+++ b/typer_bot/database/scores.py
@@ -165,7 +165,7 @@ class ScoreRepository:
         )
 
         async with aiosqlite.connect(self.db_path) as db:
-            await db.execute("BEGIN")
+            await db.execute("BEGIN IMMEDIATE")
             try:
                 await db.execute("DELETE FROM scores WHERE fixture_id = ?", (fixture_id,))
                 for score in scores:
@@ -229,23 +229,38 @@ class ScoreRepository:
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
-                """SELECT
-                          s.user_id,
-                          (SELECT user_name FROM scores s2
-                           JOIN fixtures f2 ON f2.id = s2.fixture_id
-                           WHERE s2.user_id = s.user_id
-                             AND f2.guild_id = ?
-                           ORDER BY fixture_id DESC LIMIT 1) as user_name,
-                          SUM(s.points) as total_points,
-                          SUM(s.exact_scores) as total_exact,
-                          SUM(s.correct_results) as total_correct,
-                          COUNT(DISTINCT s.fixture_id) as weeks_played
-                    FROM scores s
-                    JOIN fixtures f ON f.id = s.fixture_id
-                    WHERE f.guild_id = ?
-                    GROUP BY s.user_id
-                    ORDER BY total_points DESC, total_exact DESC, total_correct DESC, user_name ASC""",
-                (guild_id, guild_id),
+                """WITH guild_scores AS (
+                           SELECT s.*
+                           FROM scores s
+                           JOIN fixtures f ON f.id = s.fixture_id
+                           WHERE f.guild_id = ?
+                       ),
+                       latest_names AS (
+                           SELECT user_id, user_name
+                           FROM (
+                               SELECT
+                                   user_id,
+                                   user_name,
+                                   ROW_NUMBER() OVER (
+                                       PARTITION BY user_id
+                                       ORDER BY fixture_id DESC
+                                   ) AS row_number
+                               FROM guild_scores
+                           )
+                           WHERE row_number = 1
+                       )
+                    SELECT
+                          gs.user_id,
+                          ln.user_name,
+                          SUM(gs.points) as total_points,
+                          SUM(gs.exact_scores) as total_exact,
+                          SUM(gs.correct_results) as total_correct,
+                          COUNT(DISTINCT gs.fixture_id) as weeks_played
+                    FROM guild_scores gs
+                    JOIN latest_names ln ON ln.user_id = gs.user_id
+                    GROUP BY gs.user_id, ln.user_name
+                    ORDER BY total_points DESC, total_exact DESC, total_correct DESC, ln.user_name ASC""",
+                (guild_id,),
             ) as cursor:
                 rows = await cursor.fetchall()
                 return [


### PR DESCRIPTION
## Summary
- Use `BEGIN IMMEDIATE` for `save_scores` to match other write transactions.
- Replace the per-user correlated standings subquery with CTE/window-function based latest-name selection.

## Tests
- `uv run pytest tests/test_database.py tests/test_integration.py tests/test_admin_service.py --tb=short`
- `uv run ruff check typer_bot/database/scores.py`

Refs #201