### PR TITLE
refactor: centralize prediction insert semantics

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -9,6 +9,7 @@ import aiosqlite
 import pytest
 
 from typer_bot.database import Database, SaveResult
+from typer_bot.database.predictions import PredictionRepository
 
 
 @pytest.fixture
@@ -762,6 +763,30 @@ class TestSavePredictionGuarded:
         )
         prediction = await prediction_db.get_prediction(open_fixture_id, "u1")
         assert prediction["user_name"] == "NewName"
+
+
+class TestPartialApprovalPending:
+    @pytest.mark.asyncio
+    async def test_clearing_pending_does_not_clear_late_status(
+        self, prediction_db, open_fixture_id
+    ):
+        await prediction_db.save_prediction(
+            open_fixture_id,
+            "u1",
+            "User",
+            ["2-1", "0-0"],
+            is_late=True,
+            pending_partial_approval=True,
+        )
+
+        predictions = PredictionRepository(prediction_db.db_path)
+        updated = await predictions.set_partial_approval_pending(open_fixture_id, "u1", False)
+        prediction = await prediction_db.get_prediction(open_fixture_id, "u1")
+
+        assert updated is True
+        assert prediction is not None
+        assert prediction["pending_partial_approval"] is False
+        assert prediction["is_late"] == 1
 
 
 class TestCreateNextFixtureConcurrency:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -722,6 +722,42 @@ class TestTrySavePrediction:
         assert row[2] in {"2-1\n0-0", "3-0\n1-1"}
 
 
+class TestPredictionSaveMetadata:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "method_name",
+        ["save_prediction", "try_save_prediction", "save_prediction_guarded"],
+    )
+    async def test_save_paths_preserve_non_default_metadata(
+        self, prediction_db, open_fixture_id, method_name
+    ):
+        save = getattr(prediction_db, method_name)
+
+        result = await save(
+            open_fixture_id,
+            "u1",
+            "User",
+            ["1-1"],
+            True,
+            predicted_game_indexes=[1],
+            pending_partial_approval=True,
+            public_message_id="message-1",
+            public_message_kind="bot_post",
+        )
+
+        if method_name != "save_prediction":
+            assert result == SaveResult.SAVED
+        prediction = await prediction_db.get_prediction(open_fixture_id, "u1")
+        assert prediction is not None
+        assert prediction["user_name"] == "User"
+        assert prediction["predictions"] == ["1-1"]
+        assert prediction["is_late"] == 1
+        assert prediction["predicted_game_indexes"] == [1]
+        assert prediction["pending_partial_approval"] is True
+        assert prediction["public_message_id"] == "message-1"
+        assert prediction["public_message_kind"] == "bot_post"
+
+
 class TestSavePredictionGuarded:
     """Upsert with fixture-open guard (DM re-submission path)."""
 
@@ -764,6 +800,36 @@ class TestSavePredictionGuarded:
         prediction = await prediction_db.get_prediction(open_fixture_id, "u1")
         assert prediction["user_name"] == "NewName"
 
+    @pytest.mark.asyncio
+    async def test_resubmission_clears_admin_and_waiver_metadata(
+        self, prediction_db, open_fixture_id
+    ):
+        await prediction_db.save_prediction_guarded(
+            open_fixture_id, "u1", "User", ["2-1", "0-0"], True
+        )
+        await prediction_db.set_late_penalty_waiver(open_fixture_id, "u1", True)
+        await prediction_db.admin_update_prediction(
+            open_fixture_id, "u1", ["2-0", "1-1"], "admin-1"
+        )
+        async with aiosqlite.connect(prediction_db.db_path) as conn:
+            await conn.execute(
+                "UPDATE predictions SET submitted_at = '2000-01-01T00:00:00+00:00' WHERE fixture_id = ? AND user_id = ?",
+                (open_fixture_id, "u1"),
+            )
+            await conn.commit()
+
+        result = await prediction_db.save_prediction_guarded(
+            open_fixture_id, "u1", "User", ["3-0", "1-1"], False
+        )
+
+        assert result == SaveResult.SAVED
+        prediction = await prediction_db.get_prediction(open_fixture_id, "u1")
+        assert prediction is not None
+        assert prediction["late_penalty_waived"] == 0
+        assert prediction["admin_edited_at"] is None
+        assert prediction["admin_edited_by"] is None
+        assert prediction["submitted_at"] > datetime(2000, 1, 1, tzinfo=UTC)
+
 
 class TestPartialApprovalPending:
     @pytest.mark.asyncio
@@ -787,6 +853,26 @@ class TestPartialApprovalPending:
         assert prediction is not None
         assert prediction["pending_partial_approval"] is False
         assert prediction["is_late"] == 1
+
+    @pytest.mark.asyncio
+    async def test_setting_pending_does_not_force_late_status(self, prediction_db, open_fixture_id):
+        await prediction_db.save_prediction(
+            open_fixture_id,
+            "u1",
+            "User",
+            ["2-1", "0-0"],
+            is_late=False,
+            pending_partial_approval=False,
+        )
+
+        predictions = PredictionRepository(prediction_db.db_path)
+        updated = await predictions.set_partial_approval_pending(open_fixture_id, "u1", True)
+        prediction = await prediction_db.get_prediction(open_fixture_id, "u1")
+
+        assert updated is True
+        assert prediction is not None
+        assert prediction["pending_partial_approval"] is True
+        assert prediction["is_late"] == 0
 
 
 class TestCreateNextFixtureConcurrency:

--- a/typer_bot/database/predictions.py
+++ b/typer_bot/database/predictions.py
@@ -12,6 +12,66 @@ from .scores import _fixture_has_scores_in_connection, _recalculate_scores_in_co
 
 logger = logging.getLogger(__name__)
 
+_PREDICTION_INSERT_COLUMNS = (
+    "fixture_id",
+    "user_id",
+    "user_name",
+    "predictions",
+    "is_late",
+    "predicted_game_indexes",
+    "pending_partial_approval",
+    "public_message_id",
+    "public_message_kind",
+)
+
+_PREDICTION_UPSERT_CLAUSE = """
+ON CONFLICT(fixture_id, user_id)
+  DO UPDATE SET predictions = excluded.predictions,
+                 user_name = excluded.user_name,
+                 is_late = excluded.is_late,
+                 predicted_game_indexes = excluded.predicted_game_indexes,
+                 pending_partial_approval = excluded.pending_partial_approval,
+                 public_message_id = excluded.public_message_id,
+                 public_message_kind = excluded.public_message_kind,
+                 late_penalty_waived = FALSE,
+                 admin_edited_at = NULL,
+                 admin_edited_by = NULL,
+                 submitted_at = CURRENT_TIMESTAMP
+"""
+
+
+def _build_prediction_insert_sql(*, upsert: bool) -> str:
+    columns = ", ".join(_PREDICTION_INSERT_COLUMNS)
+    placeholders = ", ".join("?" for _ in _PREDICTION_INSERT_COLUMNS)
+    sql = f"INSERT INTO predictions ({columns}) VALUES ({placeholders})"
+    if upsert:
+        return f"{sql} {_PREDICTION_UPSERT_CLAUSE}"
+    return sql
+
+
+def _prediction_insert_values(
+    fixture_id: int,
+    user_id: str,
+    user_name: str,
+    predictions: list[str],
+    is_late: bool,
+    predicted_game_indexes: list[int] | None,
+    pending_partial_approval: bool,
+    public_message_id: str | None,
+    public_message_kind: str | None,
+) -> tuple[int, str, str, str, bool, str | None, bool, str | None, str | None]:
+    return (
+        fixture_id,
+        user_id,
+        user_name,
+        "\n".join(predictions),
+        is_late,
+        _serialize_game_indexes(predicted_game_indexes, len(predictions)),
+        pending_partial_approval,
+        public_message_id,
+        public_message_kind,
+    )
+
 
 def _serialize_game_indexes(game_indexes: list[int] | None, prediction_count: int) -> str | None:
     if game_indexes is None:
@@ -79,37 +139,14 @@ class PredictionRepository:
         start_time = time.perf_counter()
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
-                """INSERT INTO predictions (
-                       fixture_id,
-                       user_id,
-                       user_name,
-                       predictions,
-                       is_late,
-                       predicted_game_indexes,
-                       pending_partial_approval,
-                       public_message_id,
-                       public_message_kind
-                   )
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                   ON CONFLICT(fixture_id, user_id)
-                     DO UPDATE SET predictions = excluded.predictions,
-                                    user_name = excluded.user_name,
-                                    is_late = excluded.is_late,
-                                    predicted_game_indexes = excluded.predicted_game_indexes,
-                                    pending_partial_approval = excluded.pending_partial_approval,
-                                    public_message_id = excluded.public_message_id,
-                                    public_message_kind = excluded.public_message_kind,
-                                    late_penalty_waived = FALSE,
-                                    admin_edited_at = NULL,
-                                    admin_edited_by = NULL,
-                                   submitted_at = CURRENT_TIMESTAMP""",
-                (
+                _build_prediction_insert_sql(upsert=True),
+                _prediction_insert_values(
                     fixture_id,
                     user_id,
                     user_name,
-                    "\n".join(predictions),
+                    predictions,
                     is_late,
-                    _serialize_game_indexes(predicted_game_indexes, len(predictions)),
+                    predicted_game_indexes,
                     pending_partial_approval,
                     public_message_id,
                     public_message_kind,
@@ -180,25 +217,14 @@ class PredictionRepository:
                         return SaveResult.DUPLICATE
 
                 await db.execute(
-                    """INSERT INTO predictions (
-                           fixture_id,
-                           user_id,
-                           user_name,
-                           predictions,
-                           is_late,
-                           predicted_game_indexes,
-                           pending_partial_approval,
-                           public_message_id,
-                           public_message_kind
-                       )
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (
+                    _build_prediction_insert_sql(upsert=False),
+                    _prediction_insert_values(
                         fixture_id,
                         user_id,
                         user_name,
-                        "\n".join(predictions),
+                        predictions,
                         is_late,
-                        _serialize_game_indexes(predicted_game_indexes, len(predictions)),
+                        predicted_game_indexes,
                         pending_partial_approval,
                         public_message_id,
                         public_message_kind,
@@ -265,37 +291,14 @@ class PredictionRepository:
                         return SaveResult.FIXTURE_CLOSED
 
                 await db.execute(
-                    """INSERT INTO predictions (
-                           fixture_id,
-                           user_id,
-                           user_name,
-                           predictions,
-                           is_late,
-                           predicted_game_indexes,
-                           pending_partial_approval,
-                           public_message_id,
-                           public_message_kind
-                       )
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                       ON CONFLICT(fixture_id, user_id)
-                        DO UPDATE SET predictions = excluded.predictions,
-                                      user_name = excluded.user_name,
-                                      is_late = excluded.is_late,
-                                      predicted_game_indexes = excluded.predicted_game_indexes,
-                                      pending_partial_approval = excluded.pending_partial_approval,
-                                      public_message_id = excluded.public_message_id,
-                                      public_message_kind = excluded.public_message_kind,
-                                      late_penalty_waived = FALSE,
-                                      admin_edited_at = NULL,
-                                      admin_edited_by = NULL,
-                                      submitted_at = CURRENT_TIMESTAMP""",
-                    (
+                    _build_prediction_insert_sql(upsert=True),
+                    _prediction_insert_values(
                         fixture_id,
                         user_id,
                         user_name,
-                        "\n".join(predictions),
+                        predictions,
                         is_late,
-                        _serialize_game_indexes(predicted_game_indexes, len(predictions)),
+                        predicted_game_indexes,
                         pending_partial_approval,
                         public_message_id,
                         public_message_kind,
@@ -473,10 +476,11 @@ class PredictionRepository:
         user_id: str,
         pending: bool,
     ) -> bool:
+        """Set only the partial-approval pending flag for an existing prediction."""
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
-                "UPDATE predictions SET pending_partial_approval = ?, is_late = ? WHERE fixture_id = ? AND user_id = ?",
-                (pending, pending, fixture_id, user_id),
+                "UPDATE predictions SET pending_partial_approval = ? WHERE fixture_id = ? AND user_id = ?",
+                (pending, fixture_id, user_id),
             )
             await db.commit()
             return cursor.rowcount > 0


### PR DESCRIPTION
## Summary
- Centralize prediction insert columns, upsert SQL, and parameter serialization for the three save paths.
- Make `set_partial_approval_pending` only update the pending flag so clearing pending does not silently clear late status.
- Add regression coverage for preserving `is_late` when pending approval is cleared.

## Tests
- `uv run pytest tests/test_database.py tests/test_user_commands.py tests/test_admin_panel.py tests/test_admin_service.py --tb=short`
- `uv run ruff check typer_bot/database/predictions.py tests/test_database.py`

Refs #201