### PR TITLE
refactor: require explicit guild-scoped reads

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,7 +211,7 @@ async def fixture_with_thread(database, sample_games):
     deadline = datetime.now(UTC) + timedelta(days=1)
     fixture_id = await database.create_fixture("111111", 1, sample_games, deadline)
     await database.update_fixture_announcement(fixture_id, message_id="789012", channel_id="123456")
-    fixture = await database.get_fixture_by_id(fixture_id)
+    fixture = await database.get_fixture_by_id(fixture_id, "111111")
     yield fixture
 
 
@@ -220,7 +220,7 @@ async def fixture_with_dm(database, sample_games):
     """Fixture for DM prediction tests (no thread needed)."""
     deadline = datetime.now(UTC) + timedelta(days=1)
     fixture_id = await database.create_fixture("111111", 1, sample_games, deadline)
-    fixture = await database.get_fixture_by_id(fixture_id)
+    fixture = await database.get_fixture_by_id(fixture_id, "111111")
     yield fixture
 
 

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -243,7 +243,7 @@ class TestAdminPanelCommand:
         )
         await confirm_button.callback(mock_interaction_admin)
 
-        fixture = await admin_cog.db.get_fixture_by_id(1)
+        fixture = await admin_cog.db.get_fixture_by_id(1, "111111")
         assert fixture is not None
         assert fixture["message_id"] == "999999"
         assert fixture["channel_id"] == str(mock_interaction_admin.channel.id)
@@ -280,7 +280,7 @@ class TestAdminPanelCommand:
         )
         await confirm_button.callback(mock_interaction_admin)
 
-        fixture = await admin_cog.db.get_fixture_by_id(1)
+        fixture = await admin_cog.db.get_fixture_by_id(1, "111111")
         assert fixture is not None
         assert fixture["message_id"] == "999999"
         assert fixture["channel_id"] == str(mock_interaction_admin.channel.id)
@@ -314,7 +314,7 @@ class TestAdminPanelCommand:
         )
         await confirm_button.callback(mock_interaction_admin)
 
-        assert await admin_cog.db.get_fixture_by_id(1) is not None
+        assert await admin_cog.db.get_fixture_by_id(1, "111111") is not None
         assert (
             "couldn't announce it in the channel"
             in mock_interaction_admin.followup_sent[-1]["content"]
@@ -352,7 +352,7 @@ class TestAdminPanelCommand:
         )
         await confirm_button.callback(mock_interaction_admin)
 
-        fixture = await admin_cog.db.get_fixture_by_id(2)
+        fixture = await admin_cog.db.get_fixture_by_id(2, "111111")
         assert fixture is not None
         assert "Week number changed" in mock_interaction_admin.response_sent[-1]["content"]
 
@@ -1038,7 +1038,7 @@ class TestPredictionPanelFlows:
         )
         await toggle_button.callback(mock_interaction_admin)
 
-        prediction = await admin_cog.db.get_prediction(fixture_id, "user-1")
+        prediction = await admin_cog.db.get_prediction(fixture_id, "user-1", "111111")
         assert prediction is not None
         assert prediction["late_penalty_waived"] == 1
         assert "waiver enabled" in mock_interaction_admin.response_sent[-1]["content"].lower()
@@ -2148,7 +2148,7 @@ class TestResultsPanelFlows:
         view.user_select._values = ["111"]
         await view.user_select.callback(mock_interaction_admin)
 
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
         modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
         modal.results_input._value = "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2"
@@ -2281,7 +2281,7 @@ class TestResultsPanelFlows:
         approve_button = _get_button(view, "Approve Late")
         await approve_button.callback(mock_interaction_admin)
 
-        prediction = await admin_cog.db.get_prediction(fixture_id, "111")
+        prediction = await admin_cog.db.get_prediction(fixture_id, "111", "111111")
         assert prediction is not None
         assert prediction["pending_partial_approval"] is False
         assert prediction["is_late"] == 0
@@ -2326,7 +2326,7 @@ class TestResultsPanelFlows:
         reject_button = _get_button(view, "Reject Late")
         await reject_button.callback(mock_interaction_admin)
 
-        assert await admin_cog.db.get_prediction(fixture_id, "111") is None
+        assert await admin_cog.db.get_prediction(fixture_id, "111", "111111") is None
         assert "rejected" in target_user.dm_sent[-1].lower()
 
     @pytest.mark.asyncio
@@ -2607,7 +2607,7 @@ class TestResultsPanelFlows:
         approve_button = _get_button(view, "Approve Late")
         await approve_button.callback(mock_interaction_admin)
 
-        prediction = await admin_cog.db.get_prediction(fixture_id, "111")
+        prediction = await admin_cog.db.get_prediction(fixture_id, "111", "111111")
         assert prediction is not None
         assert prediction["pending_partial_approval"] is False
         assert "approved" in target_user.dm_sent[-1].lower()
@@ -2630,7 +2630,7 @@ class TestResultsPanelFlows:
             ["2-1", "1-1", "0-2"],
             False,
         )
-        await admin_cog.service.calculate_fixture_scores(fixture_id)
+        await admin_cog.service.calculate_fixture_scores(fixture_id, "111111")
         await admin_cog.db.save_prediction(
             fixture_id,
             "111",
@@ -2681,7 +2681,7 @@ class TestResultsPanelFlows:
             ["2-1", "1-1", "0-2"],
             False,
         )
-        await admin_cog.service.calculate_fixture_scores(fixture_id)
+        await admin_cog.service.calculate_fixture_scores(fixture_id, "111111")
         await admin_cog.db.save_prediction(
             fixture_id,
             "111",
@@ -2732,7 +2732,7 @@ class TestAdminPanelModals:
         fixture_id = await admin_cog.db.create_fixture(
             "111111", 24, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = EnterResultsModal(fixture, admin_cog.db)
@@ -2751,7 +2751,7 @@ class TestAdminPanelModals:
         fixture_id = await admin_cog.db.create_fixture(
             "111111", 25, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = EnterResultsModal(fixture, admin_cog.db)
@@ -2771,7 +2771,7 @@ class TestAdminPanelModals:
         fixture_id = await admin_cog.db.create_fixture(
             "111111", 28, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = EnterResultsModal(fixture, admin_cog.db)
@@ -2793,7 +2793,7 @@ class TestAdminPanelModals:
         fixture_id = await admin_cog.db.create_fixture(
             "111111", 26, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = EnterResultsModal(fixture, admin_cog.db)
@@ -2822,7 +2822,7 @@ class TestAdminPanelModals:
         fixture_id = await admin_cog.db.create_fixture(
             "111111", 30, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = EnterResultsModal(fixture, admin_cog.db)
@@ -2850,7 +2850,7 @@ class TestAdminPanelModals:
         fixture_id = await admin_cog.db.create_fixture(
             "111111", 31, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = EnterResultsModal(fixture, admin_cog.db)
@@ -2890,7 +2890,7 @@ class TestAdminPanelModals:
         fixture_id = await admin_cog.db.create_fixture(
             "111111", 27, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = EnterResultsModal(fixture, admin_cog.db)
@@ -2917,7 +2917,7 @@ class TestAdminPanelModals:
         fixture_id = await admin_cog.db.create_fixture(
             "111111", 29, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = EnterResultsModal(fixture, admin_cog.db)
@@ -2964,8 +2964,8 @@ class TestAdminPanelModals:
         await view.fixture_select.callback(mock_interaction_admin)
         view.user_select._values = ["user-1"]
         await view.user_select.callback(mock_interaction_admin)
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
-        prediction = await admin_cog.db.get_prediction(fixture_id, "user-1")
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
+        prediction = await admin_cog.db.get_prediction(fixture_id, "user-1", "111111")
         assert fixture is not None
         assert prediction is not None
 
@@ -3038,8 +3038,8 @@ class TestAdminPanelModals:
         await view.fixture_select.callback(mock_interaction_admin)
         view.user_select._values = ["user-1"]
         await view.user_select.callback(mock_interaction_admin)
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
-        prediction = await admin_cog.db.get_prediction(fixture_id, "user-1")
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
+        prediction = await admin_cog.db.get_prediction(fixture_id, "user-1", "111111")
         assert fixture is not None
         assert prediction is not None
 
@@ -3086,8 +3086,8 @@ class TestAdminPanelModals:
         await view.fixture_select.callback(mock_interaction_admin)
         view.user_select._values = ["111"]
         await view.user_select.callback(mock_interaction_admin)
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
-        prediction = await admin_cog.db.get_prediction(fixture_id, "111")
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
+        prediction = await admin_cog.db.get_prediction(fixture_id, "111", "111111")
         assert fixture is not None
         assert prediction is not None
 
@@ -3132,8 +3132,8 @@ class TestAdminPanelModals:
         await view.fixture_select.callback(mock_interaction_admin)
         view.user_select._values = ["111"]
         await view.user_select.callback(mock_interaction_admin)
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
-        prediction = await admin_cog.db.get_prediction(fixture_id, "111")
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
+        prediction = await admin_cog.db.get_prediction(fixture_id, "111", "111111")
         assert fixture is not None
         assert prediction is not None
 
@@ -3178,8 +3178,8 @@ class TestAdminPanelModals:
         await view.fixture_select.callback(mock_interaction_admin)
         view.user_select._values = ["111"]
         await view.user_select.callback(mock_interaction_admin)
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
-        prediction = await admin_cog.db.get_prediction(fixture_id, "111")
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
+        prediction = await admin_cog.db.get_prediction(fixture_id, "111", "111111")
         assert fixture is not None
         assert prediction is not None
 
@@ -3218,8 +3218,8 @@ class TestAdminPanelModals:
         await view.fixture_select.callback(mock_interaction_admin)
         view.user_select._values = ["user-1"]
         await view.user_select.callback(mock_interaction_admin)
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
-        prediction = await admin_cog.db.get_prediction(fixture_id, "user-1")
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
+        prediction = await admin_cog.db.get_prediction(fixture_id, "user-1", "111111")
         assert fixture is not None
         assert prediction is not None
         await admin_cog.db.delete_prediction(fixture_id, "user-1")
@@ -3254,7 +3254,7 @@ class TestAdminPanelModals:
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
         await view.fixture_select.callback(mock_interaction_admin)
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
@@ -3283,7 +3283,7 @@ class TestAdminPanelModals:
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
         await view.fixture_select.callback(mock_interaction_admin)
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
@@ -3306,7 +3306,7 @@ class TestAdminPanelModals:
         )
         original_results = ["0-0", "1-1", "2-2"]
         await admin_cog.db.save_results(fixture_id, original_results)
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "guild-2")
         assert fixture is not None
         view = ResultsPanelView(
             admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
@@ -3338,7 +3338,7 @@ class TestAdminPanelModals:
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
         await view.fixture_select.callback(mock_interaction_admin)
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
@@ -3364,7 +3364,7 @@ class TestAdminPanelModals:
         await view.load_fixture_options()
         view.fixture_select._values = [str(fixture_id)]
         await view.fixture_select.callback(mock_interaction_admin)
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
@@ -3406,7 +3406,7 @@ class TestAdminPanelModals:
             admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         view.bot = admin_cog.bot
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
@@ -3439,7 +3439,7 @@ class TestAdminPanelModals:
             admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         view.bot = admin_cog.bot
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
@@ -3480,7 +3480,7 @@ class TestAdminPanelModals:
             admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         view.bot = admin_cog.bot
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])
@@ -3517,7 +3517,7 @@ class TestAdminPanelModals:
             admin_cog.db, admin_cog.service, str(mock_interaction_admin.user.id), "111111"
         )
         view.bot = admin_cog.bot
-        fixture = await admin_cog.db.get_fixture_by_id(fixture_id)
+        fixture = await admin_cog.db.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
 
         modal = CorrectResultsModal(view, fixture, ["1-0", "1-1", "0-0"])

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1619,6 +1619,7 @@ class TestFixturePanelFlows:
         await calculate_button.callback(mock_interaction_admin)
 
         assert mock_interaction_admin.response_sent[-1]["content"] == "No results entered"
+        admin_cog.service.calculate_fixture_scores.assert_awaited_once_with(fixture_id, "111111")
         admin_cog._create_backup.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/test_admin_service.py
+++ b/tests/test_admin_service.py
@@ -38,7 +38,7 @@ class TestLatePenaltyWaiver:
             True,
         )
         await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
-        await service.calculate_fixture_scores(fixture_id)
+        await service.calculate_fixture_scores(fixture_id, "111111")
 
         standings = await database.get_standings("111111")
         assert standings[0]["total_points"] == 0
@@ -46,6 +46,7 @@ class TestLatePenaltyWaiver:
         fixture, prediction, recalculation = await service.toggle_late_penalty_waiver(
             fixture_id,
             "late-user",
+            "111111",
         )
 
         assert fixture["week_number"] == 1
@@ -75,7 +76,7 @@ class TestLatePenaltyWaiver:
             True,
         )
         await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
-        await service.calculate_fixture_scores(fixture_id)
+        await service.calculate_fixture_scores(fixture_id, "111111")
 
         async def raise_recalc_error(*_args, **_kwargs):
             raise RuntimeError("boom")
@@ -85,9 +86,9 @@ class TestLatePenaltyWaiver:
         )
 
         with pytest.raises(RuntimeError, match="boom"):
-            await service.toggle_late_penalty_waiver(fixture_id, "late-user")
+            await service.toggle_late_penalty_waiver(fixture_id, "late-user", "111111")
 
-        prediction = await database.get_prediction(fixture_id, "late-user")
+        prediction = await database.get_prediction(fixture_id, "late-user", "111111")
         assert prediction is not None
         assert prediction["late_penalty_waived"] == 0
 
@@ -98,7 +99,7 @@ class TestAdminFlowErrors:
         service = AdminService(database)
 
         with pytest.raises(FixtureNotFoundError):
-            await service.get_fixture_prediction_summary(999)
+            await service.get_fixture_prediction_summary(999, "111111")
 
     @pytest.mark.asyncio
     async def test_wrong_guild_service_actions_raise_fixture_not_found(
@@ -146,7 +147,7 @@ class TestAdminFlowErrors:
                 "111111",
             )
 
-        prediction = await database.get_prediction(fixture_id, "user-1")
+        prediction = await database.get_prediction(fixture_id, "user-1", "guild-2")
         assert prediction is not None
         assert prediction["predictions"] == original_prediction
         assert prediction["pending_partial_approval"] is True
@@ -163,7 +164,7 @@ class TestAdminFlowErrors:
         )
 
         with pytest.raises(NoPredictionsSavedError):
-            await service.get_fixture_prediction_summary(fixture_id)
+            await service.get_fixture_prediction_summary(fixture_id, "111111")
 
     @pytest.mark.asyncio
     async def test_replace_prediction_raises_typed_prediction_not_found(
@@ -180,6 +181,7 @@ class TestAdminFlowErrors:
                 "missing-user",
                 "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2",
                 "admin-1",
+                "111111",
             )
 
     @pytest.mark.asyncio
@@ -200,8 +202,8 @@ class TestAdminFlowErrors:
 
         original_get_prediction = database.get_prediction
 
-        async def disappear_after_toggle(request_fixture_id: int, user_id: str):
-            prediction = await original_get_prediction(request_fixture_id, user_id)
+        async def disappear_after_toggle(request_fixture_id: int, user_id: str, guild_id: str):
+            prediction = await original_get_prediction(request_fixture_id, user_id, guild_id)
             if prediction is not None and prediction["late_penalty_waived"]:
                 return None
             return prediction
@@ -209,7 +211,7 @@ class TestAdminFlowErrors:
         monkeypatch.setattr(database, "get_prediction", disappear_after_toggle)
 
         with pytest.raises(PredictionDisappearedError, match="waiver update"):
-            await service.toggle_late_penalty_waiver(fixture_id, "late-user")
+            await service.toggle_late_penalty_waiver(fixture_id, "late-user", "111111")
 
 
 class TestPredictionReplacement:
@@ -234,7 +236,7 @@ class TestPredictionReplacement:
             True,
         )
 
-        original = await database.get_prediction(fixture_id, "user-1")
+        original = await database.get_prediction(fixture_id, "user-1", "111111")
         assert original is not None
 
         fixture, updated_prediction, recalculation = await service.replace_prediction(
@@ -242,6 +244,7 @@ class TestPredictionReplacement:
             "user-1",
             "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2",
             "admin-1",
+            "111111",
         )
 
         assert fixture["week_number"] == 1
@@ -272,7 +275,7 @@ class TestPredictionReplacement:
             False,
         )
         await database.save_results(fixture_id, ["1-0", "1-1", "0-0"])
-        await service.calculate_fixture_scores(fixture_id)
+        await service.calculate_fixture_scores(fixture_id, "111111")
 
         async def raise_recalc_error(*_args, **_kwargs):
             raise RuntimeError("boom")
@@ -287,9 +290,10 @@ class TestPredictionReplacement:
                 "user-1",
                 "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2",
                 "admin-1",
+                "111111",
             )
 
-        prediction = await database.get_prediction(fixture_id, "user-1")
+        prediction = await database.get_prediction(fixture_id, "user-1", "111111")
         assert prediction is not None
         assert prediction["predictions"] == ["1-0", "1-1", "0-0"]
         assert prediction["admin_edited_by"] is None
@@ -313,7 +317,7 @@ class TestPredictionReplacement:
             False,
         )
         await database.save_results(fixture_id, ["1-0", "1-1", "0-0"])
-        await service.calculate_fixture_scores(fixture_id)
+        await service.calculate_fixture_scores(fixture_id, "111111")
 
         before = await database.get_standings("111111")
         assert before[0]["total_points"] == 9
@@ -323,6 +327,7 @@ class TestPredictionReplacement:
             "user-1",
             "Team A - Team B 2-1\nTeam C - Team D 2-2\nTeam E - Team F 1-0",
             "admin-1",
+            "111111",
         )
 
         assert updated_prediction["admin_edited_by"] == "admin-1"
@@ -364,7 +369,7 @@ class TestResultCorrection:
             False,
         )
         await database.save_results(fixture1_id, ["1-0", "1-1", "0-2"])
-        await service.calculate_fixture_scores(fixture1_id)
+        await service.calculate_fixture_scores(fixture1_id, "111111")
 
         await database.save_prediction(
             fixture2_id,
@@ -374,7 +379,7 @@ class TestResultCorrection:
             False,
         )
         await database.save_results(fixture2_id, ["2-0", "0-0", "1-1"])
-        await service.calculate_fixture_scores(fixture2_id)
+        await service.calculate_fixture_scores(fixture2_id, "111111")
 
         before = await database.get_standings("111111")
         assert before[0]["user_id"] == "user-1"
@@ -384,6 +389,7 @@ class TestResultCorrection:
         fixture, results, recalculation = await service.correct_results(
             fixture1_id,
             "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2",
+            "111111",
         )
 
         assert fixture["week_number"] == 1
@@ -425,7 +431,7 @@ class TestResultCorrection:
             False,
         )
         await database.save_results(fixture_id, ["1-0", "1-1", "0-0"])
-        await service.calculate_fixture_scores(fixture_id)
+        await service.calculate_fixture_scores(fixture_id, "111111")
 
         async def raise_recalc_error(*_args, **_kwargs):
             raise RuntimeError("boom")
@@ -436,6 +442,7 @@ class TestResultCorrection:
             await service.correct_results(
                 fixture_id,
                 "Team A - Team B 2-1\nTeam C - Team D 2-2\nTeam E - Team F 1-0",
+                "111111",
             )
 
         assert await database.get_results(fixture_id) == ["1-0", "1-1", "0-0"]
@@ -470,7 +477,7 @@ class TestPartialPredictionApproval:
             pending_partial_approval=True,
         )
 
-        result = await service.calculate_fixture_scores(fixture_id)
+        result = await service.calculate_fixture_scores(fixture_id, "111111")
 
         assert [score["user_id"] for score in result.scores] == ["111"]
 
@@ -504,8 +511,8 @@ class TestPartialPredictionApproval:
             False,
         )
 
-        await service.calculate_fixture_scores(other_fixture_id)
-        result = await service.calculate_fixture_scores(current_fixture_id)
+        await service.calculate_fixture_scores(other_fixture_id, "guild-2")
+        result = await service.calculate_fixture_scores(current_fixture_id, "111111")
 
         assert [row["user_id"] for row in result.standings] == ["shared-user"]
         assert result.standings[0]["user_name"] == "Guild One"
@@ -538,12 +545,13 @@ class TestPartialPredictionApproval:
             fixture_id,
             "222",
             "admin-1",
+            "111111",
         )
 
         assert approved_prediction["pending_partial_approval"] is False
         assert recalculation is None
 
-        result = await service.calculate_fixture_scores(fixture_id)
+        result = await service.calculate_fixture_scores(fixture_id, "111111")
 
         assert result.scores[0]["user_id"] == "222"
         assert result.scores[0]["points"] == 6
@@ -566,7 +574,7 @@ class TestPartialPredictionApproval:
             ["2-1", "1-1", "0-2"],
             False,
         )
-        await service.calculate_fixture_scores(fixture_id)
+        await service.calculate_fixture_scores(fixture_id, "111111")
         await database.save_prediction(
             fixture_id,
             "222",
@@ -581,6 +589,7 @@ class TestPartialPredictionApproval:
             fixture_id,
             "222",
             "admin-1",
+            "111111",
         )
 
         assert approved_prediction["pending_partial_approval"] is False
@@ -607,7 +616,7 @@ class TestPartialPredictionApproval:
             ["2-1", "1-1", "0-2"],
             False,
         )
-        await service.calculate_fixture_scores(fixture_id)
+        await service.calculate_fixture_scores(fixture_id, "111111")
         await database.save_prediction(
             fixture_id,
             "222",
@@ -626,9 +635,9 @@ class TestPartialPredictionApproval:
         )
 
         with pytest.raises(RuntimeError, match="boom"):
-            await service.approve_partial_prediction(fixture_id, "222", "admin-1")
+            await service.approve_partial_prediction(fixture_id, "222", "admin-1", "111111")
 
-        prediction = await database.get_prediction(fixture_id, "222")
+        prediction = await database.get_prediction(fixture_id, "222", "111111")
         assert prediction is not None
         assert prediction["pending_partial_approval"] is True
         assert prediction["is_late"] == 1
@@ -652,7 +661,7 @@ class TestPartialPredictionApproval:
             ["2-1", "1-1", "0-2"],
             False,
         )
-        await service.calculate_fixture_scores(fixture_id)
+        await service.calculate_fixture_scores(fixture_id, "111111")
         await database.save_prediction(
             fixture_id,
             "222",
@@ -666,11 +675,12 @@ class TestPartialPredictionApproval:
         _fixture, prediction, recalculation = await service.reject_partial_prediction(
             fixture_id,
             "222",
+            "111111",
         )
 
         assert prediction["pending_partial_approval"] is True
         assert recalculation is not None
-        assert await database.get_prediction(fixture_id, "222") is None
+        assert await database.get_prediction(fixture_id, "222", "111111") is None
 
     @pytest.mark.asyncio
     async def test_reject_partial_prediction_rolls_back_if_recalculation_fails(
@@ -691,7 +701,7 @@ class TestPartialPredictionApproval:
             ["2-1", "1-1", "0-2"],
             False,
         )
-        await service.calculate_fixture_scores(fixture_id)
+        await service.calculate_fixture_scores(fixture_id, "111111")
         await database.save_prediction(
             fixture_id,
             "222",
@@ -710,9 +720,9 @@ class TestPartialPredictionApproval:
         )
 
         with pytest.raises(RuntimeError, match="boom"):
-            await service.reject_partial_prediction(fixture_id, "222")
+            await service.reject_partial_prediction(fixture_id, "222", "111111")
 
-        prediction = await database.get_prediction(fixture_id, "222")
+        prediction = await database.get_prediction(fixture_id, "222", "111111")
         assert prediction is not None
         assert prediction["pending_partial_approval"] is True
         assert prediction["is_late"] == 1

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -183,10 +183,10 @@ class TestOpenFixturesQueries:
         fixture_id = await db.create_fixture("guild-2", 1, ["Team A - Team B"], datetime.now(UTC))
 
         assert await db.delete_fixture(fixture_id, "111111") is False
-        assert await db.get_fixture_by_id(fixture_id) is not None
+        assert await db.get_fixture_by_id(fixture_id, "guild-2") is not None
 
         assert await db.delete_fixture(fixture_id, "guild-2") is True
-        assert await db.get_fixture_by_id(fixture_id) is None
+        assert await db.get_fixture_by_id(fixture_id, "111111") is None
 
     @pytest.mark.asyncio
     async def test_pending_partial_predictions_are_guild_scoped(self, temp_db_path):
@@ -241,8 +241,8 @@ class TestOpenFixturesQueries:
             datetime.now(UTC),
         )
 
-        fixture_one = await db.get_fixture_by_id(fixture_one_id)
-        fixture_two = await db.get_fixture_by_id(fixture_two_id)
+        fixture_one = await db.get_fixture_by_id(fixture_one_id, "111111")
+        fixture_two = await db.get_fixture_by_id(fixture_two_id, "111111")
 
         assert week_one == 1
         assert week_two == 2
@@ -263,7 +263,7 @@ class TestOpenFixturesQueries:
             datetime.now(UTC),
         )
 
-        fixture = await db.get_fixture_by_id(fixture_id)
+        fixture = await db.get_fixture_by_id(fixture_id, "guild-2")
         assert fixture is not None
         assert fixture["guild_id"] == "guild-2"
 
@@ -316,7 +316,7 @@ class TestOpenFixturesQueries:
         assert await db.get_max_week_number("111111") == 2
         assert await db.get_max_week_number("guild-2") == 9
 
-        guild_one_second = await db.get_fixture_by_id(guild_one_second_id)
+        guild_one_second = await db.get_fixture_by_id(guild_one_second_id, "111111")
         assert guild_one_second is not None
         assert guild_one_second["guild_id"] == "111111"
 
@@ -433,7 +433,7 @@ class TestSchemaMigration:
 
         fixture = await db.get_fixture_by_id(1, "111111")
         other_guild_fixture = await db.get_fixture_by_id(1, "222222")
-        prediction = await db.get_prediction(1, "user-1")
+        prediction = await db.get_prediction(1, "user-1", "111111")
         results = await db.get_results(1)
         standings = await db.get_standings("111111")
         other_guild_standings = await db.get_standings("222222")
@@ -604,7 +604,7 @@ class TestSchemaMigration:
         db = Database(temp_db_path)
         await db.initialize()
 
-        prediction = await db.get_prediction(1, "user-1")
+        prediction = await db.get_prediction(1, "user-1", "111111")
         assert prediction is not None
         assert prediction["is_late"] == 1
         assert prediction["late_penalty_waived"] == 0
@@ -647,7 +647,7 @@ class TestTrySavePrediction:
             open_fixture_id, "u1", "User", ["2-1", "0-0"]
         )
         assert result == SaveResult.SAVED
-        prediction = await prediction_db.get_prediction(open_fixture_id, "u1")
+        prediction = await prediction_db.get_prediction(open_fixture_id, "u1", "111111")
         assert prediction is not None
         assert prediction["predictions"] == ["2-1", "0-0"]
 
@@ -658,7 +658,7 @@ class TestTrySavePrediction:
             open_fixture_id, "u1", "User", ["3-0", "1-1"]
         )
         assert result == SaveResult.DUPLICATE
-        prediction = await prediction_db.get_prediction(open_fixture_id, "u1")
+        prediction = await prediction_db.get_prediction(open_fixture_id, "u1", "111111")
         assert prediction["predictions"] == ["2-1", "0-0"]
 
     @pytest.mark.asyncio
@@ -671,7 +671,7 @@ class TestTrySavePrediction:
     @pytest.mark.asyncio
     async def test_no_row_written_on_fixture_closed(self, prediction_db, closed_fixture_id):
         await prediction_db.try_save_prediction(closed_fixture_id, "u1", "User", ["2-1", "0-0"])
-        prediction = await prediction_db.get_prediction(closed_fixture_id, "u1")
+        prediction = await prediction_db.get_prediction(closed_fixture_id, "u1", "111111")
         assert prediction is None
 
     @pytest.mark.asyncio
@@ -730,7 +730,7 @@ class TestSavePredictionGuarded:
             open_fixture_id, "u1", "User", ["2-1", "0-0"]
         )
         assert result == SaveResult.SAVED
-        prediction = await prediction_db.get_prediction(open_fixture_id, "u1")
+        prediction = await prediction_db.get_prediction(open_fixture_id, "u1", "111111")
         assert prediction["predictions"] == ["2-1", "0-0"]
 
     @pytest.mark.asyncio
@@ -739,7 +739,7 @@ class TestSavePredictionGuarded:
             closed_fixture_id, "u1", "User", ["2-1", "0-0"]
         )
         assert result == SaveResult.FIXTURE_CLOSED
-        prediction = await prediction_db.get_prediction(closed_fixture_id, "u1")
+        prediction = await prediction_db.get_prediction(closed_fixture_id, "u1", "111111")
         assert prediction is None
 
     @pytest.mark.asyncio
@@ -749,7 +749,7 @@ class TestSavePredictionGuarded:
             open_fixture_id, "u1", "User", ["3-0", "1-1"]
         )
         assert result == SaveResult.SAVED
-        prediction = await prediction_db.get_prediction(open_fixture_id, "u1")
+        prediction = await prediction_db.get_prediction(open_fixture_id, "u1", "111111")
         assert prediction["predictions"] == ["3-0", "1-1"]
 
     @pytest.mark.asyncio
@@ -760,7 +760,7 @@ class TestSavePredictionGuarded:
         await prediction_db.save_prediction_guarded(
             open_fixture_id, "u1", "NewName", ["3-0", "1-1"]
         )
-        prediction = await prediction_db.get_prediction(open_fixture_id, "u1")
+        prediction = await prediction_db.get_prediction(open_fixture_id, "u1", "111111")
         assert prediction["user_name"] == "NewName"
 
 
@@ -780,7 +780,7 @@ class TestCreateNextFixtureConcurrency:
 
         assert weeks == [1, 2]
 
-        fixtures = [await db.get_fixture_by_id(fixture_id) for fixture_id in fixture_ids]
+        fixtures = [await db.get_fixture_by_id(fixture_id, "111111") for fixture_id in fixture_ids]
         assert all(fixture is not None for fixture in fixtures)
         assert sorted(fixture["week_number"] for fixture in fixtures if fixture is not None) == [
             1,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -186,7 +186,17 @@ class TestOpenFixturesQueries:
         assert await db.get_fixture_by_id(fixture_id, "guild-2") is not None
 
         assert await db.delete_fixture(fixture_id, "guild-2") is True
-        assert await db.get_fixture_by_id(fixture_id, "111111") is None
+        assert await db.get_fixture_by_id(fixture_id, "guild-2") is None
+
+    @pytest.mark.asyncio
+    async def test_get_prediction_requires_fixture_guild_ownership(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        fixture_id = await db.create_fixture("guild-2", 1, ["Team A - Team B"], datetime.now(UTC))
+        await db.save_prediction(fixture_id, "user-1", "User One", ["2-1"], False)
+
+        assert await db.get_prediction(fixture_id, "user-1", "111111") is None
+        assert await db.get_prediction(fixture_id, "user-1", "guild-2") is not None
 
     @pytest.mark.asyncio
     async def test_pending_partial_predictions_are_guild_scoped(self, temp_db_path):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,7 +18,7 @@ class TestFullWorkflow:
             fixture_id, message_id="789012", channel_id="123456"
         )
 
-        fixture = await database.get_fixture_by_id(fixture_id)
+        fixture = await database.get_fixture_by_id(fixture_id, "111111")
         assert fixture["week_number"] == 1
         assert len(fixture["games"]) == 3
 
@@ -119,7 +119,7 @@ class TestEdgeCases:
 
         await database.delete_fixture(fixture_id)
 
-        assert await database.get_fixture_by_id(fixture_id) is None
+        assert await database.get_fixture_by_id(fixture_id, "111111") is None
         assert len(await database.get_all_predictions(fixture_id)) == 0
 
     @pytest.mark.asyncio
@@ -285,8 +285,8 @@ class TestEdgeCases:
             ],
         )
 
-        fixture_one = await database.get_fixture_by_id(fixture_one_id)
-        fixture_two = await database.get_fixture_by_id(fixture_two_id)
+        fixture_one = await database.get_fixture_by_id(fixture_one_id, "111111")
+        fixture_two = await database.get_fixture_by_id(fixture_two_id, "111111")
         open_fixtures = await database.get_open_fixtures("111111")
 
         assert fixture_one is not None

--- a/tests/test_seed_test_data.py
+++ b/tests/test_seed_test_data.py
@@ -80,9 +80,15 @@ async def test_seed_mixed_data_includes_real_tester_when_user_id_provided(temp_d
     assert week_one is not None
     assert week_two is not None
 
-    tester_scored_prediction = await db.get_prediction(week_one["id"], tester_user_id)
-    tester_prediction = await db.get_prediction(week_two["id"], tester_user_id)
-    synthetic_prediction = await db.get_prediction(week_two["id"], "seed-user-1")
+    tester_scored_prediction = await db.get_prediction(
+        week_one["id"], tester_user_id, DEFAULT_MANUAL_GUILD_ID
+    )
+    tester_prediction = await db.get_prediction(
+        week_two["id"], tester_user_id, DEFAULT_MANUAL_GUILD_ID
+    )
+    synthetic_prediction = await db.get_prediction(
+        week_two["id"], "seed-user-1", DEFAULT_MANUAL_GUILD_ID
+    )
 
     assert tester_scored_prediction is None
     assert tester_prediction is not None

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -274,7 +274,11 @@ class TestPredictCommand:
         assert fixture is not None
         fixture["deadline"] = datetime.now(UTC) - timedelta(minutes=1)
         user_commands.db.get_open_fixtures = AsyncMock(return_value=[fixture])
-        user_commands.db.get_fixture_by_id = AsyncMock(return_value=fixture)
+        user_commands.db.get_fixture_by_id = AsyncMock(
+            side_effect=lambda fixture_id, guild_id: (
+                fixture if (fixture_id, guild_id) == (1, "111111") else None
+            )
+        )
 
         await user_commands.predict.callback(user_commands, mock_interaction)
 
@@ -321,7 +325,11 @@ class TestPredictCommand:
         assert fixture is not None
         fixture["deadline"] = datetime.now(UTC) - timedelta(minutes=1)
         user_commands.db.get_open_fixtures = AsyncMock(return_value=[fixture])
-        user_commands.db.get_fixture_by_id = AsyncMock(return_value=fixture)
+        user_commands.db.get_fixture_by_id = AsyncMock(
+            side_effect=lambda fixture_id, guild_id: (
+                fixture if (fixture_id, guild_id) == (1, "111111") else None
+            )
+        )
 
         await user_commands.predict.callback(user_commands, mock_interaction)
         modal = mock_interaction.modal_sent["modal"]
@@ -363,7 +371,11 @@ class TestPredictCommand:
         fixture = await database.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
         user_commands.db.get_open_fixtures = AsyncMock(return_value=[fixture])
-        user_commands.db.get_fixture_by_id = AsyncMock(return_value=fixture)
+        user_commands.db.get_fixture_by_id = AsyncMock(
+            side_effect=lambda request_fixture_id, guild_id: (
+                fixture if (request_fixture_id, guild_id) == (fixture_id, "111111") else None
+            )
+        )
 
         await user_commands.predict.callback(user_commands, mock_interaction)
         modal = mock_interaction.modal_sent["modal"]
@@ -384,7 +396,11 @@ class TestPredictCommand:
         assert fixture is not None
         fixture["deadline"] = datetime.now(UTC) - timedelta(minutes=1)
         user_commands.db.get_open_fixtures = AsyncMock(return_value=[fixture])
-        user_commands.db.get_fixture_by_id = AsyncMock(return_value=fixture)
+        user_commands.db.get_fixture_by_id = AsyncMock(
+            side_effect=lambda fixture_id, guild_id: (
+                fixture if (fixture_id, guild_id) == (1, "111111") else None
+            )
+        )
 
         await user_commands.predict.callback(user_commands, mock_interaction)
         first_modal = mock_interaction.modal_sent["modal"]

--- a/tests/test_user_commands.py
+++ b/tests/test_user_commands.py
@@ -82,7 +82,7 @@ class TestPredictCommand:
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
         fixture_id = await database.create_fixture("guild-2", 1, sample_games, deadline)
-        fixture = await database.get_fixture_by_id(fixture_id)
+        fixture = await database.get_fixture_by_id(fixture_id, "guild-2")
 
         view = FixtureSelectView(
             database,
@@ -104,7 +104,7 @@ class TestPredictCommand:
     ):
         deadline = datetime.now(UTC) + timedelta(days=1)
         fixture_id = await database.create_fixture("guild-2", 1, sample_games, deadline)
-        fixture = await database.get_fixture_by_id(fixture_id)
+        fixture = await database.get_fixture_by_id(fixture_id, "guild-2")
 
         view = ContinuePredictView(
             database,
@@ -217,7 +217,7 @@ class TestPredictCommand:
         )
         await modal.on_submit(mock_interaction)
 
-        assert await database.get_prediction(1, str(mock_interaction.user.id)) is not None
+        assert await database.get_prediction(1, str(mock_interaction.user.id), "111111") is not None
         assert isinstance(mock_interaction.response_sent[-1]["view"], ContinuePredictView)
 
     @pytest.mark.asyncio
@@ -234,7 +234,7 @@ class TestPredictCommand:
         )
         await modal.on_submit(mock_interaction)
 
-        assert await database.get_prediction(1, str(mock_interaction.user.id)) is not None
+        assert await database.get_prediction(1, str(mock_interaction.user.id), "111111") is not None
         assert "You're done for now." in mock_interaction.response_sent[-1]["content"]
         assert "view" not in mock_interaction.response_sent[-1]
 
@@ -260,7 +260,7 @@ class TestPredictCommand:
         )
         await modal.on_submit(mock_interaction)
 
-        prediction = await database.get_prediction(1, str(mock_interaction.user.id))
+        prediction = await database.get_prediction(1, str(mock_interaction.user.id), "111111")
         assert prediction is not None
         assert prediction["predictions"] == ["3-0", "0-0", "1-1"]
 
@@ -270,7 +270,7 @@ class TestPredictCommand:
         self, user_commands, mock_interaction, database
     ):
         await _attach_prediction_threads(user_commands, database, [1], mock_interaction.guild)
-        fixture = await database.get_fixture_by_id(1)
+        fixture = await database.get_fixture_by_id(1, "111111")
         assert fixture is not None
         fixture["deadline"] = datetime.now(UTC) - timedelta(minutes=1)
         user_commands.db.get_open_fixtures = AsyncMock(return_value=[fixture])
@@ -284,7 +284,7 @@ class TestPredictCommand:
         )
         await modal.on_submit(mock_interaction)
 
-        prediction = await database.get_prediction(1, str(mock_interaction.user.id))
+        prediction = await database.get_prediction(1, str(mock_interaction.user.id), "111111")
         assert prediction is not None
         assert prediction["is_late"] == 1
         assert "Late prediction" in mock_interaction.response_sent[-1]["content"]
@@ -301,7 +301,7 @@ class TestPredictCommand:
         modal.predictions_input._value = "Team C - Team D 1-1\nTeam E - Team F 0-2"
         await modal.on_submit(mock_interaction)
 
-        prediction = await database.get_prediction(1, str(mock_interaction.user.id))
+        prediction = await database.get_prediction(1, str(mock_interaction.user.id), "111111")
         assert prediction is not None
         assert prediction["predictions"] == ["1-1", "0-2"]
         assert prediction["predicted_game_indexes"] == [1, 2]
@@ -317,7 +317,7 @@ class TestPredictCommand:
         await _attach_prediction_threads(user_commands, database, [1], mock_interaction.guild)
         admin_role = MockRole("League Admin", role_id=4242)
         await database.upsert_guild_config("111111", str(admin_role.id), "123456")
-        fixture = await database.get_fixture_by_id(1)
+        fixture = await database.get_fixture_by_id(1, "111111")
         assert fixture is not None
         fixture["deadline"] = datetime.now(UTC) - timedelta(minutes=1)
         user_commands.db.get_open_fixtures = AsyncMock(return_value=[fixture])
@@ -328,7 +328,7 @@ class TestPredictCommand:
         modal.predictions_input._value = "Team C - Team D 1-1\nTeam E - Team F 0-2"
         await modal.on_submit(mock_interaction)
 
-        prediction = await database.get_prediction(1, str(mock_interaction.user.id))
+        prediction = await database.get_prediction(1, str(mock_interaction.user.id), "111111")
         assert prediction is not None
         assert prediction["pending_partial_approval"] is True
         assert prediction["predicted_game_indexes"] == [1, 2]
@@ -360,7 +360,7 @@ class TestPredictCommand:
         )
         mock_interaction.guild.roles = [MockRole("typer-admin", role_id=4242)]
 
-        fixture = await database.get_fixture_by_id(fixture_id)
+        fixture = await database.get_fixture_by_id(fixture_id, "111111")
         assert fixture is not None
         user_commands.db.get_open_fixtures = AsyncMock(return_value=[fixture])
         user_commands.db.get_fixture_by_id = AsyncMock(return_value=fixture)
@@ -380,7 +380,7 @@ class TestPredictCommand:
         self, user_commands, mock_interaction, database
     ):
         await _attach_prediction_threads(user_commands, database, [1], mock_interaction.guild)
-        fixture = await database.get_fixture_by_id(1)
+        fixture = await database.get_fixture_by_id(1, "111111")
         assert fixture is not None
         fixture["deadline"] = datetime.now(UTC) - timedelta(minutes=1)
         user_commands.db.get_open_fixtures = AsyncMock(return_value=[fixture])
@@ -399,7 +399,7 @@ class TestPredictCommand:
         second_modal.predictions_input._value = "Team A - Team B 2-0\nTeam C - Team D 1-1"
         await second_modal.on_submit(mock_interaction)
 
-        prediction = await database.get_prediction(1, str(mock_interaction.user.id))
+        prediction = await database.get_prediction(1, str(mock_interaction.user.id), "111111")
         assert prediction is not None
         assert prediction["public_message_id"] == "2"
         first_public_message.delete.assert_awaited_once()
@@ -498,7 +498,10 @@ class TestPredictCommand:
             "does not have a usable prediction thread"
             in mock_interaction.response_sent[-1]["content"]
         )
-        assert await user_commands.db.get_prediction(1, str(mock_interaction.user.id)) is None
+        assert (
+            await user_commands.db.get_prediction(1, str(mock_interaction.user.id), "111111")
+            is None
+        )
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("fixture_with_dm")
@@ -518,7 +521,7 @@ class TestPredictCommand:
         )
         await modal.on_submit(mock_interaction)
 
-        assert await database.get_prediction(1, str(mock_interaction.user.id)) is not None
+        assert await database.get_prediction(1, str(mock_interaction.user.id), "111111") is not None
         user_commands.bot.fetch_channel.assert_awaited_once_with(700001)
 
     @pytest.mark.asyncio
@@ -547,7 +550,7 @@ class TestPredictCommand:
             "does not have a usable prediction thread"
             in mock_interaction.response_sent[-1]["content"]
         )
-        assert await database.get_prediction(1, str(mock_interaction.user.id)) is None
+        assert await database.get_prediction(1, str(mock_interaction.user.id), "111111") is None
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("fixture_with_dm")
@@ -594,7 +597,7 @@ class TestPredictCommand:
             "Please enter at least one prediction before submitting."
             in mock_interaction.response_sent[-1]["content"]
         )
-        assert await database.get_prediction(1, str(mock_interaction.user.id)) is None
+        assert await database.get_prediction(1, str(mock_interaction.user.id), "111111") is None
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("fixture_with_dm")
@@ -658,8 +661,8 @@ class TestPredictCommand:
         )
         await second_modal.on_submit(mock_interaction)
 
-        assert await database.get_prediction(1, str(mock_interaction.user.id)) is not None
-        assert await database.get_prediction(2, str(mock_interaction.user.id)) is not None
+        assert await database.get_prediction(1, str(mock_interaction.user.id), "111111") is not None
+        assert await database.get_prediction(2, str(mock_interaction.user.id), "111111") is not None
         assert "You're done for now." in mock_interaction.response_sent[-1]["content"]
         assert "view" not in mock_interaction.response_sent[-1]
 

--- a/typer_bot/commands/admin_panel/predictions.py
+++ b/typer_bot/commands/admin_panel/predictions.py
@@ -178,7 +178,9 @@ class PredictionUserSelect(discord.ui.Select):
             )
             return
 
-        prediction = await self.parent_view.db.get_prediction(fixture_id, selected_user_id)
+        prediction = await self.parent_view.db.get_prediction(
+            fixture_id, selected_user_id, self.parent_view.guild_id
+        )
         if prediction is None:
             self.parent_view.selection.user_id = None
             self.parent_view.selection.user_label = ""
@@ -236,7 +238,9 @@ class ReplacePredictionButton(discord.ui.Button):
             return
 
         fixture = await self.parent_view.db.get_fixture_by_id(fixture_id, self.parent_view.guild_id)
-        prediction = await self.parent_view.db.get_prediction(fixture_id, user_id)
+        prediction = await self.parent_view.db.get_prediction(
+            fixture_id, user_id, self.parent_view.guild_id
+        )
         if fixture is None:
             self.parent_view.selection.fixture_id = None
             self.parent_view.selection.fixture_label = ""
@@ -377,7 +381,9 @@ class ToggleWaiverButton(discord.ui.Button):
             )
             return
 
-        prediction = await self.parent_view.db.get_prediction(fixture_id, user_id)
+        prediction = await self.parent_view.db.get_prediction(
+            fixture_id, user_id, self.parent_view.guild_id
+        )
         if prediction is None:
             self.parent_view.selection.user_id = None
             self.parent_view.selection.user_label = ""

--- a/typer_bot/commands/admin_panel/unified.py
+++ b/typer_bot/commands/admin_panel/unified.py
@@ -591,7 +591,7 @@ class UnifiedAdminPanelView(OwnerRestrictedView):
         if fixture is None:
             return
         self.current_prediction = await self.db.get_prediction(
-            self.selection.fixture_id, self.selection.user_id
+            self.selection.fixture_id, self.selection.user_id, self.guild_id
         )
 
     async def populate_fixture_details(self, fixture: dict | None) -> None:

--- a/typer_bot/commands/user_commands.py
+++ b/typer_bot/commands/user_commands.py
@@ -213,7 +213,9 @@ class ContinuePredictButton(discord.ui.Button):
             )
             return
 
-        existing_prediction = await view.db.get_prediction(self.fixture["id"], view.owner_user_id)
+        existing_prediction = await view.db.get_prediction(
+            self.fixture["id"], view.owner_user_id, view.guild_id
+        )
         modal = PredictModal(
             view.bot,
             view.db,
@@ -285,7 +287,9 @@ class FixtureSelect(discord.ui.Select):
             )
             return
 
-        existing_prediction = await view.db.get_prediction(fixture_id, view.owner_user_id)
+        existing_prediction = await view.db.get_prediction(
+            fixture_id, view.owner_user_id, view.guild_id
+        )
         modal = PredictModal(
             view.bot,
             view.db,
@@ -401,7 +405,9 @@ class PredictModal(discord.ui.Modal):
             return
 
         is_late = now() > fixture["deadline"]
-        existing_prediction = await self.db.get_prediction(fixture["id"], str(interaction.user.id))
+        existing_prediction = await self.db.get_prediction(
+            fixture["id"], str(interaction.user.id), fixture["guild_id"]
+        )
         is_partial = len(predicted_game_indexes) < len(fixture["games"])
         pending_partial_approval = is_late and is_partial
         admin_role_mention = (
@@ -588,7 +594,7 @@ class UserCommands(commands.Cog):
         if len(open_fixtures) == 1:
             fixture = open_fixtures[0]
             existing_prediction = await self.db.get_prediction(
-                fixture["id"], str(interaction.user.id)
+                fixture["id"], str(interaction.user.id), guild_id
             )
             modal = PredictModal(
                 self.bot,
@@ -751,7 +757,9 @@ Use these directly in Discord."""
 
         if len(open_fixtures) == 1:
             fixture = open_fixtures[0]
-            prediction = await self.db.get_prediction(fixture["id"], str(interaction.user.id))
+            prediction = await self.db.get_prediction(
+                fixture["id"], str(interaction.user.id), guild_id
+            )
 
             if not prediction:
                 await interaction.response.send_message(
@@ -794,7 +802,7 @@ Use these directly in Discord."""
         has_any_prediction = False
 
         for fixture in open_fixtures:
-            prediction = await self.db.get_prediction(fixture["id"], user_id)
+            prediction = await self.db.get_prediction(fixture["id"], user_id, guild_id)
             deadline_str = format_for_discord(fixture["deadline"], "F")
             relative_str = format_for_discord(fixture["deadline"], "R")
 

--- a/typer_bot/database/connection.py
+++ b/typer_bot/database/connection.py
@@ -293,8 +293,11 @@ class Database:
     async def get_open_fixture_by_week(self, guild_id, week_number):
         return await self._fixtures.get_open_fixture_by_week(guild_id, week_number)
 
-    async def get_fixture_by_id(self, fixture_id, guild_id=None):
+    async def get_fixture_by_id(self, fixture_id, guild_id):
         return await self._fixtures.get_fixture_by_id(fixture_id, guild_id)
+
+    async def _get_fixture_by_id_unchecked(self, fixture_id):
+        return await self._fixtures._get_fixture_by_id_unchecked(fixture_id)
 
     async def get_fixture_by_week(self, guild_id, week_number):
         return await self._fixtures.get_fixture_by_week(guild_id, week_number)
@@ -391,8 +394,8 @@ class Database:
             public_message_kind=public_message_kind,
         )
 
-    async def get_prediction(self, fixture_id, user_id):
-        return await self._predictions.get_prediction(fixture_id, user_id)
+    async def get_prediction(self, fixture_id, user_id, guild_id):
+        return await self._predictions.get_prediction(fixture_id, user_id, guild_id)
 
     async def admin_update_prediction(self, fixture_id, user_id, predictions, admin_user_id):
         return await self._predictions.admin_update_prediction(

--- a/typer_bot/database/fixtures.py
+++ b/typer_bot/database/fixtures.py
@@ -171,18 +171,23 @@ class FixtureRepository:
                 row = await cursor.fetchone()
                 return self._row_to_fixture(row) if row else None
 
-    async def get_fixture_by_id(self, fixture_id: int, guild_id: str | None = None) -> dict | None:
-        """Get a fixture by ID, optionally requiring guild ownership."""
+    async def get_fixture_by_id(self, fixture_id: int, guild_id: str) -> dict | None:
+        """Get a fixture by ID, requiring guild ownership."""
+        _validate_guild_id(guild_id)
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
-            if guild_id is None:
-                query = "SELECT * FROM fixtures WHERE id = ?"
-                params = (fixture_id,)
-            else:
-                _validate_guild_id(guild_id)
-                query = "SELECT * FROM fixtures WHERE id = ? AND guild_id = ?"
-                params = (fixture_id, guild_id)
-            async with db.execute(query, params) as cursor:
+            async with db.execute(
+                "SELECT * FROM fixtures WHERE id = ? AND guild_id = ?",
+                (fixture_id, guild_id),
+            ) as cursor:
+                row = await cursor.fetchone()
+                return self._row_to_fixture(row) if row else None
+
+    async def _get_fixture_by_id_unchecked(self, fixture_id: int) -> dict | None:
+        """Get a fixture by ID for process-level/internal paths that have no guild context."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute("SELECT * FROM fixtures WHERE id = ?", (fixture_id,)) as cursor:
                 row = await cursor.fetchone()
                 return self._row_to_fixture(row) if row else None
 

--- a/typer_bot/database/predictions.py
+++ b/typer_bot/database/predictions.py
@@ -8,6 +8,7 @@ import aiosqlite
 
 from typer_bot.utils import parse_iso
 
+from .fixtures import _validate_guild_id
 from .scores import _fixture_has_scores_in_connection, _recalculate_scores_in_connection
 
 logger = logging.getLogger(__name__)
@@ -319,13 +320,19 @@ class PredictionRepository:
         )
         return SaveResult.SAVED
 
-    async def get_prediction(self, fixture_id: int, user_id: str) -> dict | None:
+    async def get_prediction(self, fixture_id: int, user_id: str, guild_id: str) -> dict | None:
         """Get a user's predictions for a fixture."""
+        _validate_guild_id(guild_id)
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
-                "SELECT * FROM predictions WHERE fixture_id = ? AND user_id = ?",
-                (fixture_id, user_id),
+                """
+                SELECT p.*
+                FROM predictions p
+                JOIN fixtures f ON f.id = p.fixture_id
+                WHERE p.fixture_id = ? AND p.user_id = ? AND f.guild_id = ?
+                """,
+                (fixture_id, user_id, guild_id),
             ) as cursor:
                 row = await cursor.fetchone()
                 if row:

--- a/typer_bot/services/admin_service.py
+++ b/typer_bot/services/admin_service.py
@@ -32,9 +32,7 @@ class AdminService:
     def __init__(self, db: Database):
         self.db = db
 
-    async def _build_score_result(
-        self, fixture_id: int, guild_id: str | None = None
-    ) -> FixtureScoreResult:
+    async def _build_score_result(self, fixture_id: int, guild_id: str) -> FixtureScoreResult:
         fixture = await self.db.get_fixture_by_id(fixture_id, guild_id)
         if fixture is None:
             raise FixtureNotFoundError
@@ -47,10 +45,9 @@ class AdminService:
         if not predictions:
             raise ValueError("No predictions found for this fixture")
 
-        effective_guild_id = guild_id or fixture["guild_id"]
         scores = await self.db.get_scores_for_fixture(fixture_id)
-        standings = await self.db.get_standings(effective_guild_id)
-        last_fixture = await self.db.get_last_fixture_scores(effective_guild_id)
+        standings = await self.db.get_standings(guild_id)
+        last_fixture = await self.db.get_last_fixture_scores(guild_id)
         return FixtureScoreResult(
             fixture=fixture,
             results=results,
@@ -60,9 +57,7 @@ class AdminService:
             last_fixture=last_fixture,
         )
 
-    async def calculate_fixture_scores(
-        self, fixture_id: int, guild_id: str | None = None
-    ) -> FixtureScoreResult:
+    async def calculate_fixture_scores(self, fixture_id: int, guild_id: str) -> FixtureScoreResult:
         """Recalculate one fixture and refresh standings."""
         fixture = await self.db.get_fixture_by_id(fixture_id, guild_id)
         if fixture is None:
@@ -112,7 +107,7 @@ class AdminService:
         return await self._build_score_result(fixture_id, guild_id)
 
     async def maybe_recalculate_fixture(
-        self, fixture_id: int, guild_id: str | None = None
+        self, fixture_id: int, guild_id: str
     ) -> FixtureScoreResult | None:
         """Recalculate a fixture only when it has already been scored."""
         if not await self.db.fixture_has_scores(fixture_id):
@@ -120,7 +115,7 @@ class AdminService:
         return await self.calculate_fixture_scores(fixture_id, guild_id)
 
     async def get_fixture_prediction_summary(
-        self, fixture_id: int, guild_id: str | None = None
+        self, fixture_id: int, guild_id: str
     ) -> tuple[dict, list[dict]]:
         """Return fixture and its predictions for panel display.
 
@@ -144,13 +139,13 @@ class AdminService:
         fixture_id: int,
         user_id: str,
         admin_user_id: str,
-        guild_id: str | None = None,
+        guild_id: str,
     ) -> tuple[dict, dict, FixtureScoreResult | None]:
         fixture = await self.db.get_fixture_by_id(fixture_id, guild_id)
         if fixture is None:
             raise FixtureNotFoundError
 
-        prediction = await self.db.get_prediction(fixture_id, user_id)
+        prediction = await self.db.get_prediction(fixture_id, user_id, guild_id)
         if prediction is None or not prediction["pending_partial_approval"]:
             raise ValueError("No late prediction awaiting review for that user")
 
@@ -158,7 +153,7 @@ class AdminService:
         if not approved:
             raise ValueError("Partial approval failed")
 
-        refreshed_prediction = await self.db.get_prediction(fixture_id, user_id)
+        refreshed_prediction = await self.db.get_prediction(fixture_id, user_id, guild_id)
         if refreshed_prediction is None:
             raise ValueError("Prediction disappeared after approval")
 
@@ -171,13 +166,13 @@ class AdminService:
         self,
         fixture_id: int,
         user_id: str,
-        guild_id: str | None = None,
+        guild_id: str,
     ) -> tuple[dict, dict, FixtureScoreResult | None]:
         fixture = await self.db.get_fixture_by_id(fixture_id, guild_id)
         if fixture is None:
             raise FixtureNotFoundError
 
-        prediction = await self.db.get_prediction(fixture_id, user_id)
+        prediction = await self.db.get_prediction(fixture_id, user_id, guild_id)
         if prediction is None or not prediction["pending_partial_approval"]:
             raise ValueError("No late prediction awaiting review for that user")
 
@@ -196,7 +191,7 @@ class AdminService:
         user_id: str,
         prediction_lines: str,
         admin_user_id: str,
-        guild_id: str | None = None,
+        guild_id: str,
     ) -> tuple[dict, dict, FixtureScoreResult | None]:
         """Replace a stored prediction through an explicit admin action.
 
@@ -210,7 +205,7 @@ class AdminService:
         if fixture is None:
             raise FixtureNotFoundError
 
-        existing_prediction = await self.db.get_prediction(fixture_id, user_id)
+        existing_prediction = await self.db.get_prediction(fixture_id, user_id, guild_id)
         if existing_prediction is None:
             raise PredictionNotFoundError
 
@@ -227,7 +222,7 @@ class AdminService:
         if not updated:
             raise ValueError("Prediction update failed")
 
-        refreshed_prediction = await self.db.get_prediction(fixture_id, user_id)
+        refreshed_prediction = await self.db.get_prediction(fixture_id, user_id, guild_id)
         if refreshed_prediction is None:
             raise PredictionDisappearedError("update")
 
@@ -240,7 +235,7 @@ class AdminService:
         self,
         fixture_id: int,
         user_id: str,
-        guild_id: str | None = None,
+        guild_id: str,
     ) -> tuple[dict, dict, FixtureScoreResult | None]:
         """Toggle the waiver flag for a stored late prediction.
 
@@ -254,7 +249,7 @@ class AdminService:
         if fixture is None:
             raise FixtureNotFoundError
 
-        prediction = await self.db.get_prediction(fixture_id, user_id)
+        prediction = await self.db.get_prediction(fixture_id, user_id, guild_id)
         if prediction is None:
             raise PredictionNotFoundError
         if not prediction["is_late"]:
@@ -264,7 +259,7 @@ class AdminService:
         if waived is None:
             raise ValueError("Late waiver update failed")
 
-        refreshed_prediction = await self.db.get_prediction(fixture_id, user_id)
+        refreshed_prediction = await self.db.get_prediction(fixture_id, user_id, guild_id)
         if refreshed_prediction is None:
             raise PredictionDisappearedError("waiver update")
 
@@ -277,7 +272,7 @@ class AdminService:
         self,
         fixture_id: int,
         results_lines: str,
-        guild_id: str | None = None,
+        guild_id: str,
     ) -> tuple[dict, list[str], FixtureScoreResult | None]:
         """Replace stored results and recalculate scored fixtures."""
         fixture = await self.db.get_fixture_by_id(fixture_id, guild_id)


### PR DESCRIPTION
## Summary
- Require `guild_id` for fixture and prediction reads that cross trust boundaries.
- Add explicit `_get_fixture_by_id_unchecked` naming for intentionally guildless fixture lookups.
- Thread guild scope through user commands, admin panel workflows, admin service methods, and tests.

## Tests
- `uv run pytest --tb=short`
- `uv run ruff check typer_bot tests`
- `uv run ty check typer_bot`

Refs #201