### PR TITLE
refactor: keep thread cooldown cleanup local

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -95,6 +95,26 @@ class TestSetupHook:
         with pytest.raises(Exception, match="DB Error"):
             await bot_instance.setup_hook()
 
+    @pytest.mark.asyncio
+    async def test_cleanup_sessions_task_cleans_admin_state_only(self):
+        admin_cog = MagicMock()
+        admin_cog.cleanup_expired_state.return_value = 1
+        with patch.object(TyperBot, "cogs", {"AdminCommands": admin_cog}):
+            bot = TyperBot.__new__(TyperBot)
+            bot.thread_handler = MagicMock(spec=[])
+
+            await TyperBot._cleanup_sessions_task.coro(bot)
+
+        admin_cog.cleanup_expired_state.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_sessions_task_ignores_missing_admin_cog(self):
+        with patch.object(TyperBot, "cogs", {}):
+            bot = TyperBot.__new__(TyperBot)
+            bot.thread_handler = MagicMock(spec=[])
+
+            await TyperBot._cleanup_sessions_task.coro(bot)
+
 
 class TestOnReady:
     """Test suite for on_ready event handler."""

--- a/tests/test_thread_prediction_handler.py
+++ b/tests/test_thread_prediction_handler.py
@@ -317,14 +317,15 @@ class TestOnMessage:
         assert second is True
         assert retry_message.reactions_added == []
 
-    def test_cleanup_expired_state_removes_stale_cooldowns(self, handler):
+    def test_record_attempt_prunes_stale_cooldowns(self, handler):
         handler.record_thread_prediction_attempt(
             "guild-1", "user-1", datetime.now(UTC) - timedelta(hours=2)
         )
 
-        removed = handler.cleanup_expired_state()
+        handler.record_thread_prediction_attempt("guild-1", "user-2", datetime.now(UTC))
 
-        assert removed == 1
+        assert handler.get_thread_prediction_cooldown("guild-1", "user-1") is None
+        assert handler.get_thread_prediction_cooldown("guild-1", "user-2") is not None
 
 
 class TestEdgeCases:

--- a/typer_bot/bot.py
+++ b/typer_bot/bot.py
@@ -200,9 +200,10 @@ class TyperBot(commands.Bot):
     @tasks.loop(minutes=5)
     async def _cleanup_sessions_task(self) -> None:
         admin_cog = self.cogs.get("AdminCommands")
-        removed = self.thread_handler.cleanup_expired_state()
-        if admin_cog is not None:
-            removed += admin_cog.cleanup_expired_state()  # type: ignore[attr-defined]
+        if admin_cog is None:
+            return
+
+        removed = admin_cog.cleanup_expired_state()  # type: ignore[attr-defined]
         if removed:
             logger.debug(f"Cooldown cleanup removed {removed} expired entr(y/ies)")
 

--- a/typer_bot/handlers/thread_prediction_handler.py
+++ b/typer_bot/handlers/thread_prediction_handler.py
@@ -68,13 +68,6 @@ class ThreadPredictionHandler:
     def clear_thread_prediction_cooldowns(self) -> None:
         self._thread_prediction_cooldowns.clear()
 
-    def cleanup_expired_state(self) -> int:
-        cutoff = now() - COOLDOWN_ENTRY_EXPIRY
-        expired = [key for key, ts in self._thread_prediction_cooldowns.items() if ts < cutoff]
-        for key in expired:
-            self._thread_prediction_cooldowns.pop(key, None)
-        return len(expired)
-
     async def on_message(self, message: discord.Message):
         """Handle a possible prediction posted inside a fixture thread.
 


### PR DESCRIPTION
## Summary
- Remove the periodic thread cooldown cleanup call from the 5-minute bot task.
- Keep thread cooldown expiry owned by `record_thread_prediction_attempt`, where pruning already happens.
- Leave the periodic cleanup task focused on admin command cooldown state.

## Tests
- `uv run pytest tests/test_thread_prediction_handler.py tests/test_bot.py tests/test_admin_commands.py --tb=short`
- `uv run ruff check typer_bot/bot.py typer_bot/handlers/thread_prediction_handler.py tests/test_thread_prediction_handler.py`

Refs #201