### PR TITLE
Refactor fixture score recalculation

### DIFF
--- a/tests/test_admin_service.py
+++ b/tests/test_admin_service.py
@@ -557,6 +557,49 @@ class TestPartialPredictionApproval:
         assert result.scores[0]["points"] == 6
 
     @pytest.mark.asyncio
+    async def test_initial_calculation_and_recalculation_persist_same_scores(
+        self,
+        database,
+        sample_games,
+    ):
+        service = AdminService(database)
+        fixture_id = await database.create_fixture(
+            "111111", 4, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await database.save_results(fixture_id, ["2-1", "1-1", "0-2"])
+        await database.save_prediction(
+            fixture_id,
+            "partial",
+            "Partial User",
+            ["1-1", "0-2"],
+            True,
+            predicted_game_indexes=[1, 2],
+        )
+        await database.set_late_penalty_waiver(fixture_id, "partial", True)
+        await database.save_prediction(
+            fixture_id,
+            "full",
+            "Full User",
+            ["2-1", "1-1", "0-2"],
+            False,
+        )
+
+        await service.calculate_fixture_scores(fixture_id, "111111")
+        initial_scores = await database.get_scores_for_fixture(fixture_id)
+
+        assert await database.save_results_with_recalc(fixture_id, ["2-1", "1-1", "0-2"])
+        recalculated_scores = await database.get_scores_for_fixture(fixture_id)
+
+        score_fields = ("user_id", "points", "exact_scores", "correct_results")
+        assert [tuple(score[field] for field in score_fields) for score in recalculated_scores] == [
+            tuple(score[field] for field in score_fields) for score in initial_scores
+        ]
+        assert [(score["user_id"], score["points"]) for score in recalculated_scores] == [
+            ("full", 9),
+            ("partial", 6),
+        ]
+
+    @pytest.mark.asyncio
     async def test_approve_partial_prediction_recalculates_scored_fixture(
         self,
         database,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -200,6 +200,52 @@ class TestScores:
         assert scores[0]["points"] == 3
 
     @pytest.mark.asyncio
+    async def test_recalculate_fixture_scores_rolls_back_after_partial_write_failure(
+        self, temp_db_path
+    ):
+        db = Database(temp_db_path)
+        await db.initialize()
+        fixture_id = await db.create_fixture(
+            "111111",
+            1,
+            ["Team A - Team B", "Team C - Team D"],
+            datetime.now(UTC),
+        )
+        await db.save_prediction(fixture_id, "user-1", "User One", ["2-1", "1-1"], False)
+        await db.save_results(fixture_id, ["2-1", "1-1"])
+        await db.save_scores(
+            fixture_id,
+            [
+                {
+                    "user_id": "original",
+                    "user_name": "Original User",
+                    "points": 1,
+                    "exact_scores": 0,
+                    "correct_results": 1,
+                }
+            ],
+        )
+
+        async with aiosqlite.connect(temp_db_path) as conn:
+            await conn.execute(
+                """
+                CREATE TRIGGER fail_recalculated_score_insert
+                BEFORE INSERT ON scores
+                WHEN NEW.user_id = 'user-1'
+                BEGIN
+                    SELECT RAISE(FAIL, 'forced score insert failure');
+                END
+                """
+            )
+            await conn.commit()
+
+        with pytest.raises(aiosqlite.IntegrityError, match="forced score insert failure"):
+            await db.recalculate_fixture_scores(fixture_id)
+
+        scores = await db.get_scores_for_fixture(fixture_id)
+        assert [(score["user_id"], score["points"]) for score in scores] == [("original", 1)]
+
+    @pytest.mark.asyncio
     async def test_standings_order_by_points_tiebreakers_and_name(self, temp_db_path):
         db = Database(temp_db_path)
         await db.initialize()

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,6 +1,6 @@
 """Tests for scoring calculation utilities."""
 
-from typer_bot.utils.scoring import calculate_points
+from typer_bot.utils.scoring import build_fixture_scores, calculate_points
 
 
 class TestCalculatePoints:
@@ -136,3 +136,60 @@ class TestCalculatePoints:
         assert result["points"] == 7
         assert result["exact_scores"] == 2
         assert result["correct_results"] == 1
+
+
+class TestBuildFixtureScores:
+    def test_scores_sparse_predictions_and_applies_fixture_ordering(self):
+        scores = build_fixture_scores(
+            [
+                {
+                    "user_id": "partial",
+                    "user_name": "Partial User",
+                    "predictions": ["1-1", "0-2"],
+                    "predicted_game_indexes": [1, 2],
+                    "is_late": False,
+                    "late_penalty_waived": False,
+                },
+                {
+                    "user_id": "full",
+                    "user_name": "Full User",
+                    "predictions": ["2-1", "1-1", "0-2"],
+                    "predicted_game_indexes": [0, 1, 2],
+                    "is_late": False,
+                    "late_penalty_waived": False,
+                },
+            ],
+            ["2-1", "1-1", "0-2"],
+        )
+
+        assert [score["user_id"] for score in scores] == ["full", "partial"]
+        assert scores[0]["points"] == 9
+        assert scores[1]["points"] == 6
+
+    def test_late_penalty_is_applied_once_for_all_score_recalculation_paths(self):
+        scores = build_fixture_scores(
+            [
+                {
+                    "user_id": "late",
+                    "user_name": "Late User",
+                    "predictions": ["2-1"],
+                    "predicted_game_indexes": [0],
+                    "is_late": True,
+                    "late_penalty_waived": False,
+                },
+                {
+                    "user_id": "waived",
+                    "user_name": "Waived User",
+                    "predictions": ["2-1"],
+                    "predicted_game_indexes": [0],
+                    "is_late": True,
+                    "late_penalty_waived": True,
+                },
+            ],
+            ["2-1"],
+        )
+
+        assert [(score["user_id"], score["points"]) for score in scores] == [
+            ("waived", 3),
+            ("late", 0),
+        ]

--- a/typer_bot/database/connection.py
+++ b/typer_bot/database/connection.py
@@ -458,6 +458,9 @@ class Database:
     async def save_scores(self, fixture_id, scores):
         return await self._scores.save_scores(fixture_id, scores)
 
+    async def recalculate_fixture_scores(self, fixture_id):
+        return await self._scores.recalculate_fixture_scores(fixture_id)
+
     async def get_standings(self, guild_id):
         return await self._scores.get_standings(guild_id)
 

--- a/typer_bot/database/scores.py
+++ b/typer_bot/database/scores.py
@@ -4,9 +4,30 @@ import logging
 
 import aiosqlite
 
-from typer_bot.utils import align_predictions_to_fixture, calculate_points
+from typer_bot.utils import build_fixture_scores
 
 logger = logging.getLogger(__name__)
+
+
+def _deserialize_game_indexes(raw: str | None, prediction_count: int) -> list[int]:
+    if not raw:
+        return list(range(prediction_count))
+    return [int(part) for part in raw.split(",") if part != ""]
+
+
+def _prediction_row_to_score_input(row: aiosqlite.Row) -> dict:
+    prediction_values = row["predictions"].split("\n")
+    return {
+        "user_id": row["user_id"],
+        "user_name": row["user_name"],
+        "predictions": prediction_values,
+        "predicted_game_indexes": _deserialize_game_indexes(
+            row["predicted_game_indexes"],
+            len(prediction_values),
+        ),
+        "is_late": bool(row["is_late"]),
+        "late_penalty_waived": bool(row["late_penalty_waived"]),
+    }
 
 
 async def _fixture_has_scores_in_connection(db: aiosqlite.Connection, fixture_id: int) -> bool:
@@ -42,44 +63,8 @@ async def _recalculate_scores_in_connection(db: aiosqlite.Connection, fixture_id
             raise ValueError("No predictions found for this fixture")
 
         results = results_row["results"].split("\n")
-        scores = []
-        for prediction_row in prediction_rows:
-            raw_predictions = prediction_row["predictions"].split("\n")
-            raw_indexes = prediction_row["predicted_game_indexes"]
-            predicted_game_indexes = (
-                [int(part) for part in raw_indexes.split(",") if part != ""]
-                if raw_indexes
-                else list(range(len(raw_predictions)))
-            )
-            aligned_predictions = align_predictions_to_fixture(
-                raw_predictions,
-                predicted_game_indexes,
-                len(results),
-            )
-            score_data = calculate_points(
-                aligned_predictions,
-                results,
-                bool(prediction_row["is_late"]),
-                bool(prediction_row["late_penalty_waived"]),
-            )
-            scores.append(
-                {
-                    "user_id": prediction_row["user_id"],
-                    "user_name": prediction_row["user_name"],
-                    "points": score_data["points"],
-                    "exact_scores": score_data["exact_scores"],
-                    "correct_results": score_data["correct_results"],
-                }
-            )
-
-        scores.sort(
-            key=lambda score: (
-                -score["points"],
-                -score["exact_scores"],
-                -score["correct_results"],
-                score["user_name"].lower(),
-            )
-        )
+        predictions = [_prediction_row_to_score_input(row) for row in prediction_rows]
+        scores = build_fixture_scores(predictions, results)
 
         await db.execute("DELETE FROM scores WHERE fixture_id = ?", (fixture_id,))
         for score in scores:
@@ -222,6 +207,17 @@ class ScoreRepository:
                             "event_type": "transaction.rollback_failed",
                         },
                     )
+                raise
+
+    async def recalculate_fixture_scores(self, fixture_id: int) -> None:
+        """Recalculate one fixture's scores atomically from stored results and predictions."""
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                await _recalculate_scores_in_connection(db, fixture_id)
+                await db.commit()
+            except Exception:
+                await db.rollback()
                 raise
 
     async def get_standings(self, guild_id: str) -> list[dict]:

--- a/typer_bot/services/admin_service.py
+++ b/typer_bot/services/admin_service.py
@@ -11,7 +11,7 @@ from typer_bot.services.errors import (
     PredictionDisappearedError,
     PredictionNotFoundError,
 )
-from typer_bot.utils import align_predictions_to_fixture, calculate_points, parse_line_predictions
+from typer_bot.utils import parse_line_predictions
 
 
 @dataclass(slots=True)
@@ -71,38 +71,7 @@ class AdminService:
         if not predictions:
             raise ValueError("No predictions found for this fixture")
 
-        scores = []
-        for prediction in predictions:
-            aligned_predictions = align_predictions_to_fixture(
-                prediction["predictions"],
-                prediction["predicted_game_indexes"],
-                len(results),
-            )
-            score_data = calculate_points(
-                aligned_predictions,
-                results,
-                prediction["is_late"],
-                prediction["late_penalty_waived"],
-            )
-            scores.append(
-                {
-                    "user_id": prediction["user_id"],
-                    "user_name": prediction["user_name"],
-                    "points": score_data["points"],
-                    "exact_scores": score_data["exact_scores"],
-                    "correct_results": score_data["correct_results"],
-                }
-            )
-
-        scores.sort(
-            key=lambda score: (
-                -score["points"],
-                -score["exact_scores"],
-                -score["correct_results"],
-                score["user_name"].lower(),
-            )
-        )
-        await self.db.save_scores(fixture_id, scores)
+        await self.db.recalculate_fixture_scores(fixture_id)
 
         return await self._build_score_result(fixture_id, guild_id)
 

--- a/typer_bot/utils/__init__.py
+++ b/typer_bot/utils/__init__.py
@@ -19,7 +19,7 @@ from .prediction_parser import (
     parse_prediction_lines,
     parse_predictions,
 )
-from .scoring import align_predictions_to_fixture, calculate_points
+from .scoring import align_predictions_to_fixture, build_fixture_scores, calculate_points
 from .timezone import APP_TZ, format_for_discord, now, parse_deadline, parse_iso
 
 __all__ = [
@@ -39,6 +39,7 @@ __all__ = [
     "format_standings",
     "align_predictions_to_fixture",
     "calculate_points",
+    "build_fixture_scores",
     "now",
     "parse_deadline",
     "format_for_discord",

--- a/typer_bot/utils/scoring.py
+++ b/typer_bot/utils/scoring.py
@@ -77,6 +77,42 @@ def calculate_points(
     }
 
 
+def build_fixture_scores(predictions: Sequence[dict], results: Sequence[str]) -> list[dict]:
+    """Build sorted fixture score rows from stored prediction payloads."""
+    scores = []
+    for prediction in predictions:
+        aligned_predictions = align_predictions_to_fixture(
+            prediction["predictions"],
+            prediction["predicted_game_indexes"],
+            len(results),
+        )
+        score_data = calculate_points(
+            aligned_predictions,
+            results,
+            prediction["is_late"],
+            prediction["late_penalty_waived"],
+        )
+        scores.append(
+            {
+                "user_id": prediction["user_id"],
+                "user_name": prediction["user_name"],
+                "points": score_data["points"],
+                "exact_scores": score_data["exact_scores"],
+                "correct_results": score_data["correct_results"],
+            }
+        )
+
+    scores.sort(
+        key=lambda score: (
+            -score["points"],
+            -score["exact_scores"],
+            -score["correct_results"],
+            score["user_name"].lower(),
+        )
+    )
+    return scores
+
+
 def parse_result(result_str: str) -> tuple[int, int] | None:
     """Parse a result string into home and away scores."""
     try:


### PR DESCRIPTION
## Summary
- Centralizes fixture score row construction in one shared scoring helper.
- Routes initial admin score calculation through the same atomic recalculation path used by result/prediction edits.
- Adds regression coverage for sparse scoring, late waivers, recalculation consistency, and rollback safety.

## Verification
- `uv run pytest --tb=short`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check typer_bot`

Closes #216