### PR TITLE
Scope workflows to active season

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -22,6 +22,26 @@ def temp_db_path():
     Path(path).unlink(missing_ok=True)
 
 
+async def _start_new_active_season(db_path: str, guild_id: str, name: str = "Next Season") -> int:
+    async with aiosqlite.connect(db_path) as conn:
+        await conn.execute(
+            "UPDATE seasons SET status = 'archived' WHERE guild_id = ? AND status = 'active'",
+            (guild_id,),
+        )
+        cursor = await conn.execute(
+            "INSERT INTO seasons (guild_id, name, status) VALUES (?, ?, 'active')",
+            (guild_id, name),
+        )
+        if cursor.lastrowid is None:
+            raise RuntimeError("Failed to create test season")
+        await conn.execute(
+            "UPDATE guild_config SET active_season_id = ? WHERE guild_id = ?",
+            (cursor.lastrowid, guild_id),
+        )
+        await conn.commit()
+        return cursor.lastrowid
+
+
 class TestGetMaxWeekNumber:
     """Test suite for get_max_week_number method."""
 
@@ -71,6 +91,19 @@ class TestGetMaxWeekNumber:
 
         result = await db.get_max_week_number("111111")
         assert result == 10
+
+    @pytest.mark.asyncio
+    async def test_get_max_week_number_is_active_season_scoped(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        await db.create_fixture("111111", 10, ["Team A - Team B"], datetime.now(UTC))
+        await _start_new_active_season(temp_db_path, "111111")
+
+        assert await db.get_max_week_number("111111") == 0
+
+        await db.create_fixture("111111", 1, ["Team C - Team D"], datetime.now(UTC))
+
+        assert await db.get_max_week_number("111111") == 1
 
 
 class TestGuildConfig:
@@ -181,6 +214,203 @@ class TestSeasons:
         assert active_season["id"] == fixture["season_id"]
         assert config["active_season_id"] == active_season["id"]
 
+    @pytest.mark.asyncio
+    async def test_create_next_fixture_restarts_week_numbers_per_active_season(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        _old_fixture_id, old_week = await db.create_next_fixture(
+            "111111", ["Team A - Team B"], datetime.now(UTC)
+        )
+        await _start_new_active_season(temp_db_path, "111111")
+
+        new_fixture_id, new_week = await db.create_next_fixture(
+            "111111", ["Team C - Team D"], datetime.now(UTC)
+        )
+        new_fixture = await db.get_fixture_by_id(new_fixture_id, "111111")
+        active_season = await db.get_active_season("111111")
+
+        assert old_week == 1
+        assert new_week == 1
+        assert new_fixture["season_id"] == active_season["id"]
+
+    @pytest.mark.asyncio
+    async def test_fixture_queries_default_to_active_season(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        old_fixture_id = await db.create_fixture(
+            "111111", 1, ["Old Team A - Old Team B"], datetime.now(UTC)
+        )
+        await db.update_fixture_announcement(old_fixture_id, "old-message", "channel-1")
+        await _start_new_active_season(temp_db_path, "111111")
+        active_fixture_id = await db.create_fixture(
+            "111111", 1, ["New Team A - New Team B"], datetime.now(UTC)
+        )
+        await db.update_fixture_announcement(active_fixture_id, "new-message", "channel-1")
+
+        current_fixture = await db.get_current_fixture("111111")
+        open_fixtures = await db.get_open_fixtures("111111")
+        recent_fixtures = await db.get_recent_fixtures("111111")
+        week_fixture = await db.get_open_fixture_by_week("111111", 1)
+        any_status_week_fixture = await db.get_fixture_by_week("111111", 1)
+        message_fixture = await db.get_fixture_by_message_id("new-message", "111111")
+        global_message_fixture = await db.get_fixture_by_message_id("new-message")
+
+        assert await db.get_fixture_by_id(old_fixture_id, "111111") is None
+        assert current_fixture["id"] == active_fixture_id
+        assert [fixture["id"] for fixture in open_fixtures] == [active_fixture_id]
+        assert [fixture["id"] for fixture in recent_fixtures] == [active_fixture_id]
+        assert week_fixture["id"] == active_fixture_id
+        assert any_status_week_fixture["id"] == active_fixture_id
+        assert message_fixture["id"] == active_fixture_id
+        assert global_message_fixture["id"] == active_fixture_id
+        assert await db.get_fixture_by_message_id("old-message", "111111") is None
+        assert await db.get_fixture_by_message_id("old-message") is None
+
+    @pytest.mark.asyncio
+    async def test_all_open_fixtures_only_returns_active_season_fixtures(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        await db.create_fixture("111111", 1, ["Old Team A - Old Team B"], datetime.now(UTC))
+        await _start_new_active_season(temp_db_path, "111111")
+        active_fixture_id = await db.create_fixture(
+            "111111", 1, ["New Team A - New Team B"], datetime.now(UTC)
+        )
+        other_guild_fixture_id = await db.create_fixture(
+            "222222", 1, ["Other Team A - Other Team B"], datetime.now(UTC)
+        )
+
+        open_fixture_ids = [fixture["id"] for fixture in await db.get_all_open_fixtures()]
+
+        assert set(open_fixture_ids) == {active_fixture_id, other_guild_fixture_id}
+
+    @pytest.mark.asyncio
+    async def test_archived_fixture_prediction_writes_are_rejected(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        old_fixture_id = await db.create_fixture(
+            "111111", 1, ["Old Team A - Old Team B"], datetime.now(UTC)
+        )
+        await db.save_prediction(old_fixture_id, "user-1", "User One", ["1-0"], False)
+        await _start_new_active_season(temp_db_path, "111111")
+
+        first_write = await db.try_save_prediction(old_fixture_id, "user-2", "User Two", ["2-0"])
+        guarded_write = await db.save_prediction_guarded(
+            old_fixture_id, "user-1", "User One", ["9-9"]
+        )
+        admin_write = await db.admin_update_prediction_with_recalc(
+            old_fixture_id, "user-1", ["8-8"], "admin-1"
+        )
+
+        assert first_write == SaveResult.FIXTURE_CLOSED
+        assert guarded_write == SaveResult.FIXTURE_CLOSED
+        assert admin_write is False
+        assert await db.get_prediction(old_fixture_id, "user-1", "111111") is None
+        async with (
+            aiosqlite.connect(temp_db_path) as conn,
+            conn.execute(
+                "SELECT predictions FROM predictions WHERE fixture_id = ? AND user_id = ?",
+                (old_fixture_id, "user-1"),
+            ) as cursor,
+        ):
+            row = await cursor.fetchone()
+        assert row == ("1-0",)
+
+    @pytest.mark.asyncio
+    async def test_archived_pending_partials_are_hidden_and_not_mutated(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        old_fixture_id = await db.create_fixture(
+            "111111", 1, ["Old Team A - Old Team B"], datetime.now(UTC)
+        )
+        await db.save_prediction(
+            old_fixture_id,
+            "user-1",
+            "User One",
+            ["1-0"],
+            True,
+            pending_partial_approval=True,
+        )
+        await _start_new_active_season(temp_db_path, "111111")
+
+        approved = await db.approve_partial_prediction(old_fixture_id, "user-1", "admin-1")
+        rejected = await db.reject_partial_prediction(old_fixture_id, "user-1")
+        pending = await db.get_pending_partial_predictions("111111")
+
+        assert approved is False
+        assert rejected is False
+        assert pending == []
+        async with (
+            aiosqlite.connect(temp_db_path) as conn,
+            conn.execute(
+                "SELECT pending_partial_approval FROM predictions WHERE fixture_id = ? AND user_id = ?",
+                (old_fixture_id, "user-1"),
+            ) as cursor,
+        ):
+            row = await cursor.fetchone()
+        assert row == (1,)
+
+    @pytest.mark.asyncio
+    async def test_archived_fixture_result_and_score_writes_are_rejected(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        old_fixture_id = await db.create_fixture(
+            "111111", 1, ["Old Team A - Old Team B"], datetime.now(UTC)
+        )
+        await db.save_results(old_fixture_id, ["0-0"])
+        await db.save_scores(
+            old_fixture_id,
+            [
+                {
+                    "user_id": "old-user",
+                    "user_name": "Old User",
+                    "points": 30,
+                    "exact_scores": 10,
+                    "correct_results": 0,
+                }
+            ],
+        )
+        await _start_new_active_season(temp_db_path, "111111")
+
+        with pytest.raises(ValueError):
+            await db.save_results(old_fixture_id, ["1-0"])
+        with pytest.raises(ValueError):
+            await db.save_results_with_recalc(old_fixture_id, ["1-0"])
+        with pytest.raises(ValueError):
+            await db.recalculate_fixture_scores(old_fixture_id)
+        with pytest.raises(ValueError):
+            await db.save_scores(
+                old_fixture_id,
+                [
+                    {
+                        "user_id": "new-user",
+                        "user_name": "New User",
+                        "points": 1,
+                        "exact_scores": 0,
+                        "correct_results": 1,
+                    }
+                ],
+            )
+
+        assert await db.get_results(old_fixture_id) == ["0-0"]
+        scores = await db.get_scores_for_fixture(old_fixture_id)
+        assert [(score["user_id"], score["points"]) for score in scores] == [("old-user", 30)]
+
+    @pytest.mark.asyncio
+    async def test_archived_fixture_delete_requires_active_season(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        old_fixture_id = await db.create_fixture(
+            "111111", 1, ["Old Team A - Old Team B"], datetime.now(UTC)
+        )
+        await _start_new_active_season(temp_db_path, "111111")
+
+        assert await db.delete_fixture(old_fixture_id, "111111") is False
+        async with (
+            aiosqlite.connect(temp_db_path) as conn,
+            conn.execute("SELECT 1 FROM fixtures WHERE id = ?", (old_fixture_id,)) as cursor,
+        ):
+            assert await cursor.fetchone() == (1,)
+
 
 class TestScores:
     @pytest.mark.asyncio
@@ -250,7 +480,20 @@ class TestScores:
             ],
         )
 
-        with pytest.raises(aiosqlite.IntegrityError):
+        async with aiosqlite.connect(temp_db_path) as conn:
+            await conn.execute(
+                """
+                CREATE TRIGGER fail_second_score_insert
+                BEFORE INSERT ON scores
+                WHEN NEW.user_id = 'user-3'
+                BEGIN
+                    SELECT RAISE(FAIL, 'forced score insert failure');
+                END
+                """
+            )
+            await conn.commit()
+
+        with pytest.raises(aiosqlite.IntegrityError, match="forced score insert failure"):
             await db.save_scores(
                 fixture_id,
                 [
@@ -262,8 +505,8 @@ class TestScores:
                         "correct_results": 3,
                     },
                     {
-                        "user_id": "user-2",
-                        "user_name": "Duplicate User Two",
+                        "user_id": "user-3",
+                        "user_name": "User Three",
                         "points": 0,
                         "exact_scores": 0,
                         "correct_results": 0,
@@ -272,9 +515,17 @@ class TestScores:
             )
 
         scores = await db.get_scores_for_fixture(fixture_id)
-        assert len(scores) == 1
-        assert scores[0]["user_id"] == "user-1"
-        assert scores[0]["points"] == 3
+        fixture = await db.get_fixture_by_id(fixture_id, "111111")
+        assert scores == [
+            {
+                "user_id": "user-1",
+                "user_name": "User One",
+                "points": 3,
+                "exact_scores": 1,
+                "correct_results": 0,
+            }
+        ]
+        assert fixture["status"] == "closed"
 
     @pytest.mark.asyncio
     async def test_recalculate_fixture_scores_rolls_back_after_partial_write_failure(
@@ -378,6 +629,100 @@ class TestScores:
             "alpha",
             "beta",
         ]
+
+    @pytest.mark.asyncio
+    async def test_standings_are_active_season_scoped(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        old_fixture_id = await db.create_fixture(
+            "111111", 1, ["Old Team A - Old Team B"], datetime.now(UTC)
+        )
+        await db.save_scores(
+            old_fixture_id,
+            [
+                {
+                    "user_id": "shared-user",
+                    "user_name": "Old Shared User",
+                    "points": 30,
+                    "exact_scores": 10,
+                    "correct_results": 0,
+                }
+            ],
+        )
+        await _start_new_active_season(temp_db_path, "111111")
+        active_fixture_id = await db.create_fixture(
+            "111111", 1, ["New Team A - New Team B"], datetime.now(UTC)
+        )
+        await db.save_scores(
+            active_fixture_id,
+            [
+                {
+                    "user_id": "shared-user",
+                    "user_name": "Active Shared User",
+                    "points": 3,
+                    "exact_scores": 1,
+                    "correct_results": 0,
+                }
+            ],
+        )
+
+        standings = await db.get_standings("111111")
+
+        assert [row["user_id"] for row in standings] == ["shared-user"]
+        assert standings[0]["user_name"] == "Active Shared User"
+        assert standings[0]["total_points"] == 3
+
+    @pytest.mark.asyncio
+    async def test_last_fixture_scores_are_active_season_scoped(self, temp_db_path):
+        db = Database(temp_db_path)
+        await db.initialize()
+        await _start_new_active_season(temp_db_path, "111111")
+        active_fixture_id = await db.create_fixture(
+            "111111", 1, ["New Team A - New Team B"], datetime.now(UTC)
+        )
+        await db.save_scores(
+            active_fixture_id,
+            [
+                {
+                    "user_id": "active-user",
+                    "user_name": "Active User",
+                    "points": 3,
+                    "exact_scores": 1,
+                    "correct_results": 0,
+                }
+            ],
+        )
+        await _start_new_active_season(temp_db_path, "111111", "Archived Later Season")
+        later_archived_fixture_id = await db.create_fixture(
+            "111111", 1, ["Archived Team A - Archived Team B"], datetime.now(UTC)
+        )
+        await db.save_scores(
+            later_archived_fixture_id,
+            [
+                {
+                    "user_id": "archived-user",
+                    "user_name": "Archived User",
+                    "points": 30,
+                    "exact_scores": 10,
+                    "correct_results": 0,
+                }
+            ],
+        )
+        async with aiosqlite.connect(temp_db_path) as conn:
+            await conn.execute(
+                "UPDATE seasons SET status = 'archived' WHERE id = (SELECT season_id FROM fixtures WHERE id = ?)",
+                (later_archived_fixture_id,),
+            )
+            await conn.execute(
+                "UPDATE seasons SET status = 'active' WHERE id = (SELECT season_id FROM fixtures WHERE id = ?)",
+                (active_fixture_id,),
+            )
+            await conn.commit()
+
+        last_fixture = await db.get_last_fixture_scores("111111")
+
+        assert last_fixture["fixture_id"] == active_fixture_id
+        assert [score["user_id"] for score in last_fixture["scores"]] == ["active-user"]
 
 
 class TestOpenFixturesQueries:
@@ -1254,11 +1599,12 @@ class TestRowToFixture:
         """Empty games column must deserialize to [] not [''] (split artefact)."""
         db = Database(temp_db_path)
         await db.initialize()
+        season = await db.get_or_create_active_season("111111")
 
         async with aiosqlite.connect(temp_db_path) as conn:
             await conn.execute(
-                "INSERT INTO fixtures (guild_id, week_number, games, deadline, status) VALUES (?, ?, ?, ?, ?)",
-                ("111111", 99, "", "2030-01-01T00:00:00+00:00", "open"),
+                "INSERT INTO fixtures (guild_id, season_id, week_number, games, deadline, status) VALUES (?, ?, ?, ?, ?, ?)",
+                ("111111", season["id"], 99, "", "2030-01-01T00:00:00+00:00", "open"),
             )
             await conn.commit()
 

--- a/typer_bot/database/fixtures.py
+++ b/typer_bot/database/fixtures.py
@@ -8,7 +8,7 @@ import aiosqlite
 from typer_bot.utils import parse_iso
 from typer_bot.utils.config import DB_PATH
 
-from .seasons import _get_or_create_active_season_in_connection
+from .seasons import _get_active_season_in_connection, _get_or_create_active_season_in_connection
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +27,10 @@ class FixtureRepository:
 
     def __init__(self, db_path: str | None = None) -> None:
         self.db_path = db_path or DB_PATH
+
+    async def _active_season_id(self, db: aiosqlite.Connection, guild_id: str) -> int | None:
+        season = await _get_active_season_in_connection(db, guild_id)
+        return season["id"] if season else None
 
     def _row_to_fixture(self, row: aiosqlite.Row) -> dict:
         row_dict = dict(row)
@@ -112,14 +116,14 @@ class FixtureRepository:
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute("BEGIN IMMEDIATE")
             try:
+                season = await _get_or_create_active_season_in_connection(db, guild_id)
                 async with db.execute(
-                    "SELECT COALESCE(MAX(week_number), 0) FROM fixtures WHERE guild_id = ?",
-                    (guild_id,),
+                    "SELECT COALESCE(MAX(week_number), 0) FROM fixtures WHERE guild_id = ? AND season_id = ?",
+                    (guild_id, season["id"]),
                 ) as cursor:
                     row = await cursor.fetchone()
                     next_week = int(row[0]) + 1 if row else 1
 
-                season = await _get_or_create_active_season_in_connection(db, guild_id)
                 insert_cursor = await db.execute(
                     "INSERT INTO fixtures (guild_id, season_id, week_number, games, deadline) VALUES (?, ?, ?, ?, ?)",
                     (guild_id, season["id"], next_week, "\n".join(games), deadline.isoformat()),
@@ -149,9 +153,12 @@ class FixtureRepository:
         _validate_guild_id(guild_id)
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
+            season_id = await self._active_season_id(db, guild_id)
+            if season_id is None:
+                return None
             async with db.execute(
-                "SELECT * FROM fixtures WHERE guild_id = ? AND status = 'open' ORDER BY id DESC LIMIT 1",
-                (guild_id,),
+                "SELECT * FROM fixtures WHERE guild_id = ? AND season_id = ? AND status = 'open' ORDER BY id DESC LIMIT 1",
+                (guild_id, season_id),
             ) as cursor:
                 row = await cursor.fetchone()
                 return self._row_to_fixture(row) if row else None
@@ -160,9 +167,12 @@ class FixtureRepository:
         _validate_guild_id(guild_id)
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
+            season_id = await self._active_season_id(db, guild_id)
+            if season_id is None:
+                return []
             async with db.execute(
-                "SELECT * FROM fixtures WHERE guild_id = ? AND status = 'open' ORDER BY week_number ASC, id ASC",
-                (guild_id,),
+                "SELECT * FROM fixtures WHERE guild_id = ? AND season_id = ? AND status = 'open' ORDER BY week_number ASC, id ASC",
+                (guild_id, season_id),
             ) as cursor:
                 rows = await cursor.fetchall()
                 return [self._row_to_fixture(row) for row in rows]
@@ -172,7 +182,13 @@ class FixtureRepository:
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             async with db.execute(
-                "SELECT * FROM fixtures WHERE status = 'open' ORDER BY guild_id ASC, week_number ASC, id ASC"
+                """
+                SELECT f.*
+                FROM fixtures f
+                JOIN seasons s ON s.id = f.season_id AND s.guild_id = f.guild_id
+                WHERE f.status = 'open' AND s.status = 'active'
+                ORDER BY f.guild_id ASC, f.week_number ASC, f.id ASC
+                """
             ) as cursor:
                 rows = await cursor.fetchall()
                 return [self._row_to_fixture(row) for row in rows]
@@ -181,9 +197,12 @@ class FixtureRepository:
         _validate_guild_id(guild_id)
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
+            season_id = await self._active_season_id(db, guild_id)
+            if season_id is None:
+                return None
             async with db.execute(
-                "SELECT * FROM fixtures WHERE guild_id = ? AND status = 'open' AND week_number = ? ORDER BY id DESC LIMIT 1",
-                (guild_id, week_number),
+                "SELECT * FROM fixtures WHERE guild_id = ? AND season_id = ? AND status = 'open' AND week_number = ? ORDER BY id DESC LIMIT 1",
+                (guild_id, season_id, week_number),
             ) as cursor:
                 row = await cursor.fetchone()
                 return self._row_to_fixture(row) if row else None
@@ -192,9 +211,12 @@ class FixtureRepository:
         _validate_guild_id(guild_id)
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
+            season_id = await self._active_season_id(db, guild_id)
+            if season_id is None:
+                return None
             async with db.execute(
-                "SELECT * FROM fixtures WHERE id = ? AND guild_id = ?",
-                (fixture_id, guild_id),
+                "SELECT * FROM fixtures WHERE id = ? AND guild_id = ? AND season_id = ?",
+                (fixture_id, guild_id, season_id),
             ) as cursor:
                 row = await cursor.fetchone()
                 return self._row_to_fixture(row) if row else None
@@ -211,9 +233,12 @@ class FixtureRepository:
         _validate_guild_id(guild_id)
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
+            season_id = await self._active_season_id(db, guild_id)
+            if season_id is None:
+                return None
             async with db.execute(
-                "SELECT * FROM fixtures WHERE guild_id = ? AND week_number = ? ORDER BY id DESC LIMIT 1",
-                (guild_id, week_number),
+                "SELECT * FROM fixtures WHERE guild_id = ? AND season_id = ? AND week_number = ? ORDER BY id DESC LIMIT 1",
+                (guild_id, season_id, week_number),
             ) as cursor:
                 row = await cursor.fetchone()
                 return self._row_to_fixture(row) if row else None
@@ -222,9 +247,12 @@ class FixtureRepository:
         _validate_guild_id(guild_id)
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
+            season_id = await self._active_season_id(db, guild_id)
+            if season_id is None:
+                return []
             async with db.execute(
-                "SELECT * FROM fixtures WHERE guild_id = ? ORDER BY id DESC LIMIT ?",
-                (guild_id, limit),
+                "SELECT * FROM fixtures WHERE guild_id = ? AND season_id = ? ORDER BY id DESC LIMIT ?",
+                (guild_id, season_id, limit),
             ) as cursor:
                 rows = await cursor.fetchall()
                 return [self._row_to_fixture(row) for row in rows]
@@ -241,45 +269,82 @@ class FixtureRepository:
         async with aiosqlite.connect(self.db_path) as db:
             db.row_factory = aiosqlite.Row
             if guild_id is None:
-                query = "SELECT * FROM fixtures WHERE message_id = ? AND status = 'open'"
+                query = """
+                    SELECT f.*
+                    FROM fixtures f
+                    JOIN seasons s ON s.id = f.season_id AND s.guild_id = f.guild_id
+                    WHERE f.message_id = ? AND f.status = 'open' AND s.status = 'active'
+                """
                 params = (message_id,)
             else:
                 _validate_guild_id(guild_id)
-                query = "SELECT * FROM fixtures WHERE guild_id = ? AND message_id = ? AND status = 'open'"
-                params = (guild_id, message_id)
+                season_id = await self._active_season_id(db, guild_id)
+                if season_id is None:
+                    return None
+                query = "SELECT * FROM fixtures WHERE guild_id = ? AND season_id = ? AND message_id = ? AND status = 'open'"
+                params = (guild_id, season_id, message_id)
             async with db.execute(query, params) as cursor:
                 row = await cursor.fetchone()
                 return self._row_to_fixture(row) if row else None
 
     async def get_max_week_number(self, guild_id: str) -> int:
         _validate_guild_id(guild_id)
-        async with (
-            aiosqlite.connect(self.db_path) as db,
-            db.execute(
-                "SELECT MAX(week_number) FROM fixtures WHERE guild_id = ?",
-                (guild_id,),
-            ) as cursor,
-        ):
-            row = await cursor.fetchone()
-            return row[0] if row and row[0] is not None else 0
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            season_id = await self._active_season_id(db, guild_id)
+            if season_id is None:
+                return 0
+            async with db.execute(
+                "SELECT MAX(week_number) FROM fixtures WHERE guild_id = ? AND season_id = ?",
+                (guild_id, season_id),
+            ) as cursor:
+                row = await cursor.fetchone()
+                return row[0] if row and row[0] is not None else 0
 
     async def delete_fixture(self, fixture_id: int, guild_id: str | None = None) -> bool:
         """Delete a fixture and all associated data, optionally requiring guild ownership."""
         async with aiosqlite.connect(self.db_path) as db:
-            if guild_id is not None:
-                _validate_guild_id(guild_id)
-                async with db.execute(
-                    "SELECT 1 FROM fixtures WHERE id = ? AND guild_id = ?",
-                    (fixture_id, guild_id),
-                ) as cursor:
-                    if await cursor.fetchone() is None:
-                        return False
-            await db.execute("DELETE FROM scores WHERE fixture_id = ?", (fixture_id,))
-            await db.execute("DELETE FROM results WHERE fixture_id = ?", (fixture_id,))
-            await db.execute("DELETE FROM predictions WHERE fixture_id = ?", (fixture_id,))
-            cursor = await db.execute("DELETE FROM fixtures WHERE id = ?", (fixture_id,))
-            await db.commit()
-            return cursor.rowcount > 0
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                if guild_id is not None:
+                    _validate_guild_id(guild_id)
+                    async with db.execute(
+                        """
+                        SELECT 1
+                        FROM fixtures f
+                        JOIN seasons s ON s.id = f.season_id AND s.guild_id = f.guild_id
+                        WHERE f.id = ? AND f.guild_id = ? AND s.status = 'active'
+                        """,
+                        (fixture_id, guild_id),
+                    ) as cursor:
+                        if await cursor.fetchone() is None:
+                            await db.rollback()
+                            return False
+                await db.execute("DELETE FROM scores WHERE fixture_id = ?", (fixture_id,))
+                await db.execute("DELETE FROM results WHERE fixture_id = ?", (fixture_id,))
+                await db.execute("DELETE FROM predictions WHERE fixture_id = ?", (fixture_id,))
+                if guild_id is None:
+                    cursor = await db.execute("DELETE FROM fixtures WHERE id = ?", (fixture_id,))
+                else:
+                    cursor = await db.execute(
+                        """
+                        DELETE FROM fixtures
+                        WHERE id = ? AND guild_id = ?
+                          AND EXISTS (
+                              SELECT 1
+                              FROM seasons s
+                              WHERE s.id = fixtures.season_id
+                                AND s.guild_id = fixtures.guild_id
+                                AND s.status = 'active'
+                          )
+                        """,
+                        (fixture_id, guild_id),
+                    )
+                await db.commit()
+                return cursor.rowcount > 0
+            except Exception:
+                await db.rollback()
+                raise
 
     async def update_fixture_announcement(
         self,

--- a/typer_bot/database/predictions.py
+++ b/typer_bot/database/predictions.py
@@ -87,6 +87,17 @@ def _deserialize_game_indexes(raw: str | None, prediction_count: int) -> list[in
     return [int(part) for part in raw.split(",") if part != ""]
 
 
+_ACTIVE_FIXTURE_EXISTS_SQL = """
+EXISTS (
+    SELECT 1
+    FROM fixtures f
+    JOIN seasons s ON s.id = f.season_id AND s.guild_id = f.guild_id
+    WHERE f.id = predictions.fixture_id
+      AND s.status = 'active'
+)
+"""
+
+
 class SaveResult(StrEnum):
     """Result of an atomic prediction save attempt."""
 
@@ -204,7 +215,13 @@ class PredictionRepository:
             await db.execute("BEGIN IMMEDIATE")
             try:
                 async with db.execute(
-                    "SELECT 1 FROM fixtures WHERE id = ? AND status = 'open'", (fixture_id,)
+                    """
+                    SELECT 1
+                    FROM fixtures f
+                    JOIN seasons s ON s.id = f.season_id AND s.guild_id = f.guild_id
+                    WHERE f.id = ? AND f.status = 'open' AND s.status = 'active'
+                    """,
+                    (fixture_id,),
                 ) as cursor:
                     if await cursor.fetchone() is None:
                         await db.rollback()
@@ -286,7 +303,13 @@ class PredictionRepository:
             await db.execute("BEGIN IMMEDIATE")
             try:
                 async with db.execute(
-                    "SELECT 1 FROM fixtures WHERE id = ? AND status = 'open'", (fixture_id,)
+                    """
+                    SELECT 1
+                    FROM fixtures f
+                    JOIN seasons s ON s.id = f.season_id AND s.guild_id = f.guild_id
+                    WHERE f.id = ? AND f.status = 'open' AND s.status = 'active'
+                    """,
+                    (fixture_id,),
                 ) as cursor:
                     if await cursor.fetchone() is None:
                         await db.rollback()
@@ -334,7 +357,8 @@ class PredictionRepository:
                 SELECT p.*
                 FROM predictions p
                 JOIN fixtures f ON f.id = p.fixture_id
-                WHERE p.fixture_id = ? AND p.user_id = ? AND f.guild_id = ?
+                JOIN seasons s ON s.id = f.season_id AND s.guild_id = f.guild_id
+                WHERE p.fixture_id = ? AND p.user_id = ? AND f.guild_id = ? AND s.status = 'active'
                 """,
                 (fixture_id, user_id, guild_id),
             ) as cursor:
@@ -353,12 +377,13 @@ class PredictionRepository:
         """Replace a stored prediction without changing original submission timing."""
         async with aiosqlite.connect(self.db_path) as db:
             cursor = await db.execute(
-                """
+                f"""
                 UPDATE predictions
                 SET predictions = ?,
                     admin_edited_at = CURRENT_TIMESTAMP,
                     admin_edited_by = ?
                 WHERE fixture_id = ? AND user_id = ?
+                  AND {_ACTIVE_FIXTURE_EXISTS_SQL}
                 """,
                 ("\n".join(predictions), admin_user_id, fixture_id, user_id),
             )
@@ -377,7 +402,7 @@ class PredictionRepository:
             await db.execute("BEGIN IMMEDIATE")
             try:
                 cursor = await db.execute(
-                    """
+                    f"""
                     UPDATE predictions
                     SET predictions = ?,
                         predicted_game_indexes = ?,
@@ -385,6 +410,7 @@ class PredictionRepository:
                         admin_edited_at = CURRENT_TIMESTAMP,
                         admin_edited_by = ?
                     WHERE fixture_id = ? AND user_id = ?
+                      AND {_ACTIVE_FIXTURE_EXISTS_SQL}
                     """,
                     (
                         "\n".join(predictions),
@@ -437,7 +463,12 @@ class PredictionRepository:
             await db.execute("BEGIN IMMEDIATE")
             try:
                 async with db.execute(
-                    "SELECT late_penalty_waived FROM predictions WHERE fixture_id = ? AND user_id = ?",
+                    f"""
+                    SELECT late_penalty_waived
+                    FROM predictions
+                    WHERE fixture_id = ? AND user_id = ?
+                      AND {_ACTIVE_FIXTURE_EXISTS_SQL}
+                    """,
                     (fixture_id, user_id),
                 ) as cursor:
                     row = await cursor.fetchone()
@@ -448,10 +479,11 @@ class PredictionRepository:
 
                 waived = not bool(row["late_penalty_waived"])
                 cursor = await db.execute(
-                    """
+                    f"""
                     UPDATE predictions
                     SET late_penalty_waived = ?
                     WHERE fixture_id = ? AND user_id = ?
+                      AND {_ACTIVE_FIXTURE_EXISTS_SQL}
                     """,
                     (waived, fixture_id, user_id),
                 )
@@ -509,7 +541,7 @@ class PredictionRepository:
             await db.execute("BEGIN IMMEDIATE")
             try:
                 cursor = await db.execute(
-                    """
+                    f"""
                     UPDATE predictions
                     SET pending_partial_approval = FALSE,
                         is_late = FALSE,
@@ -517,6 +549,7 @@ class PredictionRepository:
                         admin_edited_at = CURRENT_TIMESTAMP,
                         admin_edited_by = ?
                     WHERE fixture_id = ? AND user_id = ? AND pending_partial_approval = TRUE
+                      AND {_ACTIVE_FIXTURE_EXISTS_SQL}
                     """,
                     (admin_user_id, fixture_id, user_id),
                 )
@@ -547,7 +580,11 @@ class PredictionRepository:
             await db.execute("BEGIN IMMEDIATE")
             try:
                 cursor = await db.execute(
-                    "DELETE FROM predictions WHERE fixture_id = ? AND user_id = ? AND pending_partial_approval = TRUE",
+                    f"""
+                    DELETE FROM predictions
+                    WHERE fixture_id = ? AND user_id = ? AND pending_partial_approval = TRUE
+                      AND {_ACTIVE_FIXTURE_EXISTS_SQL}
+                    """,
                     (fixture_id, user_id),
                 )
                 if cursor.rowcount <= 0:
@@ -607,7 +644,8 @@ class PredictionRepository:
                     f.status
                 FROM predictions p
                 JOIN fixtures f ON f.id = p.fixture_id
-                WHERE p.pending_partial_approval = TRUE AND f.guild_id = ?
+                JOIN seasons s ON s.id = f.season_id AND s.guild_id = f.guild_id
+                WHERE p.pending_partial_approval = TRUE AND f.guild_id = ? AND s.status = 'active'
                 ORDER BY f.week_number ASC, p.user_name COLLATE NOCASE ASC
                 """,
                 (guild_id,),

--- a/typer_bot/database/results.py
+++ b/typer_bot/database/results.py
@@ -27,7 +27,13 @@ class ResultsRepository:
             await db.execute("BEGIN IMMEDIATE")
             try:
                 async with db.execute(
-                    "SELECT status FROM fixtures WHERE id = ?", (fixture_id,)
+                    """
+                    SELECT f.status
+                    FROM fixtures f
+                    JOIN seasons s ON s.id = f.season_id AND s.guild_id = f.guild_id
+                    WHERE f.id = ? AND s.status = 'active'
+                    """,
+                    (fixture_id,),
                 ) as cur:
                     row = await cur.fetchone()
                 if row is None or row[0] == "closed":
@@ -65,6 +71,18 @@ class ResultsRepository:
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute("BEGIN IMMEDIATE")
             try:
+                async with db.execute(
+                    """
+                    SELECT 1
+                    FROM fixtures f
+                    JOIN seasons s ON s.id = f.season_id AND s.guild_id = f.guild_id
+                    WHERE f.id = ? AND s.status = 'active'
+                    """,
+                    (fixture_id,),
+                ) as cursor:
+                    if await cursor.fetchone() is None:
+                        raise ValueError("Fixture is not in the active season.")
+
                 await db.execute(
                     """
                     INSERT INTO results (fixture_id, results)

--- a/typer_bot/database/scores.py
+++ b/typer_bot/database/scores.py
@@ -41,10 +41,18 @@ async def _recalculate_scores_in_connection(db: aiosqlite.Connection, fixture_id
     prior_row_factory = db.row_factory
     db.row_factory = aiosqlite.Row
     try:
-        async with db.execute("SELECT * FROM fixtures WHERE id = ?", (fixture_id,)) as cursor:
+        async with db.execute(
+            """
+            SELECT f.*
+            FROM fixtures f
+            JOIN seasons s ON s.id = f.season_id AND s.guild_id = f.guild_id
+            WHERE f.id = ? AND s.status = 'active'
+            """,
+            (fixture_id,),
+        ) as cursor:
             fixture_row = await cursor.fetchone()
         if fixture_row is None:
-            raise ValueError("Fixture not found")
+            raise ValueError("Fixture not found in active season")
 
         async with db.execute(
             "SELECT results FROM results WHERE fixture_id = ? ORDER BY id DESC LIMIT 1",
@@ -152,6 +160,18 @@ class ScoreRepository:
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute("BEGIN IMMEDIATE")
             try:
+                async with db.execute(
+                    """
+                    SELECT 1
+                    FROM fixtures f
+                    JOIN seasons s ON s.id = f.season_id AND s.guild_id = f.guild_id
+                    WHERE f.id = ? AND s.status = 'active'
+                    """,
+                    (fixture_id,),
+                ) as cursor:
+                    if await cursor.fetchone() is None:
+                        raise ValueError("Fixture not found in active season")
+
                 await db.execute("DELETE FROM scores WHERE fixture_id = ?", (fixture_id,))
                 for score in scores:
                     await db.execute(
@@ -229,7 +249,8 @@ class ScoreRepository:
                            SELECT s.*
                            FROM scores s
                            JOIN fixtures f ON f.id = s.fixture_id
-                           WHERE f.guild_id = ?
+                           JOIN seasons season ON season.id = f.season_id AND season.guild_id = f.guild_id
+                           WHERE f.guild_id = ? AND season.status = 'active'
                        ),
                        latest_names AS (
                            SELECT user_id, user_name
@@ -279,7 +300,8 @@ class ScoreRepository:
                 """SELECT s.*, f.week_number
                    FROM scores s
                    JOIN fixtures f ON s.fixture_id = f.id
-                   WHERE f.status = 'closed' AND f.guild_id = ?
+                   JOIN seasons season ON season.id = f.season_id AND season.guild_id = f.guild_id
+                   WHERE f.status = 'closed' AND f.guild_id = ? AND season.status = 'active'
                    ORDER BY f.id DESC
                    LIMIT 1""",
                 (guild_id,),
@@ -292,7 +314,8 @@ class ScoreRepository:
                          SELECT s.*
                          FROM scores s
                          JOIN fixtures f ON f.id = s.fixture_id
-                         WHERE s.fixture_id = ? AND f.guild_id = ?
+                          JOIN seasons season ON season.id = f.season_id AND season.guild_id = f.guild_id
+                          WHERE s.fixture_id = ? AND f.guild_id = ? AND season.status = 'active'
                          ORDER BY points DESC, exact_scores DESC, correct_results DESC, user_name ASC
                          """,
                         (fixture_id, guild_id),


### PR DESCRIPTION
## Summary
- Scopes fixture lookup/listing, week allocation, standings, and last-fixture scores to the active season.
- Adds active-season guards to prediction, result, score, and fixture-delete write paths so stale views cannot mutate archived fixtures.
- Covers week reset, active-season fixture discovery, stale write rejection, standings scoping, and guild/season isolation.

## Verification
- `uv run pytest --tb=short`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check typer_bot`

Closes #218