### PR TITLE
chore: bump version to 3.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typerbot"
-version = "2.0.0"
+version = "3.0.0"
 description = "TyperBot - Discord bot for football predictions"
 requires-python = ">=3.13"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -576,7 +576,7 @@ wheels = [
 
 [[package]]
 name = "typerbot"
-version = "2.0.0"
+version = "3.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- bump package metadata from 2.0.0 to 3.0.0
- update lockfile package version

## Verification
- uv run pytest
- uv run ruff check .
- uv run ruff format --check .
- uv run ty check typer_bot