### PR TITLE
refactor: extract calculation posting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ You are working on `TyperBot`, a Discord bot for football prediction leagues.
 - **Thread Predictions:** Users can post predictions in public threads under fixture announcements.
 - **Rate Limiting:** Thread predictions are rate-limited to 1 per second per user. Cooldown entries auto-expire after 1 hour.
 - **Async:** All database ops must be async (`aiosqlite`).
-- **Parsing:** Use `utils.prediction_parser.parse_line_predictions` for all score parsing. Do NOT write ad-hoc regex.
+- **Parsing:** Use `utils.prediction_parser.parse_prediction_lines` for all score parsing. Do NOT write ad-hoc regex.
 - **Logging:** Use `typer_bot.utils.logger.setup_logging()` early. Do not use `print()`.
 - **Timezones:** All datetime operations use timezone-aware objects. Use `utils.timezone.now()` instead of `datetime.now()`. Configure via `TZ` env var (default: `UTC`).
 - **Permissions:** Bot requires `Send Messages`, `Send Messages in Threads`, `Read Message History`, `Add Reactions`, `Create Public Threads`, and `Use Slash Commands`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ guild_config (
 - `typer_bot/commands/admin_panel/`: Admin panel UI views, selects, and modals split out of `admin_commands.py`.
 - `typer_bot/handlers/thread_prediction_handler.py`: Thread-based prediction processing (on_message) plus thread prediction cooldown state.
 - `typer_bot/commands/admin_commands.py`: `/admin` command surface and orchestration for admin workflows, including admin calculation cooldown state.
+- `typer_bot/services/calculation_posting.py`: Post-calculation side effects: best-effort DB backup, league-channel publishing, and admin interaction responses.
 - `typer_bot/utils/config.py`: Centralized configuration (data paths via env vars).
 - `typer_bot/utils/prediction_parser.py`: Central logic for parsing "2-1" or "2:1" strings.
 - `typer_bot/utils/scoring.py`: Point calculation using season scoring rules.

--- a/tests/admin_panel/test_fixture_panel_results_actions.py
+++ b/tests/admin_panel/test_fixture_panel_results_actions.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
+import typer_bot.commands.admin_panel.unified_actions as unified_actions
 from tests.admin_panel_helpers import get_button as _get_button
 from tests.admin_panel_helpers import has_button as _has_button
 from typer_bot.commands.admin_panel import (
@@ -74,6 +75,7 @@ class TestFixturePanelResultsActions:
         admin_cog,
         mock_interaction_admin,
         sample_games,
+        monkeypatch,
     ):
         fixture_id = await admin_cog.db.create_fixture(
             "111111", 45, sample_games, datetime.now(UTC) + timedelta(days=1)
@@ -86,18 +88,10 @@ class TestFixturePanelResultsActions:
             ["2-1", "1-1", "0-2"],
             False,
         )
-        command_channel = MagicMock(spec=discord.TextChannel)
-        command_channel.id = 999999
-        command_channel.send = AsyncMock()
-        league_channel = MagicMock(spec=discord.TextChannel)
-        league_channel.id = 123456
-        league_channel.send = AsyncMock()
-        mock_interaction_admin.channel = command_channel
-        admin_cog.bot.get_channel.return_value = None
-        admin_cog.bot.fetch_channel = AsyncMock(return_value=league_channel)
         mock_interaction_admin.message = MagicMock()
         mock_interaction_admin.message.edit = AsyncMock()
-        admin_cog._create_backup = AsyncMock()
+        post_calculation_result = AsyncMock()
+        monkeypatch.setattr(unified_actions, "post_calculation_result", post_calculation_result)
 
         view = UnifiedAdminPanelView(
             admin_cog.db,
@@ -118,67 +112,16 @@ class TestFixturePanelResultsActions:
             admin_cog.get_calculate_cooldown("111111", str(mock_interaction_admin.user.id))
             is not None
         )
-        league_channel.send.assert_awaited_once()
-        command_channel.send.assert_not_awaited()
-        assert (
-            "Week 45 results calculated and posted to the league channel"
-            in mock_interaction_admin.response_sent[-1]["content"]
+        post_calculation_result.assert_awaited_once()
+        assert post_calculation_result.call_args.args[:3] == (
+            admin_cog.bot,
+            admin_cog.db,
+            mock_interaction_admin,
         )
-        assert "User One" in league_channel.send.call_args.args[0]
         assert view.selection.fixture_label == "Week 45 [CLOSED]"
         assert _has_button(view, "Calculate Scores") is False
         assert _has_button(view, "Delete Fixture") is False
         assert mock_interaction_admin.message.edit.await_count == 1
-
-    @pytest.mark.asyncio
-    async def test_unified_panel_calculate_scores_button_rejects_unavailable_league_channel(
-        self,
-        admin_cog,
-        mock_interaction_admin,
-        sample_games,
-    ):
-        fixture_id = await admin_cog.db.create_fixture(
-            "111111", 46, sample_games, datetime.now(UTC) + timedelta(days=1)
-        )
-        await admin_cog.db.save_results(fixture_id, ["2-1", "1-1", "0-2"])
-        await admin_cog.db.save_prediction(
-            fixture_id,
-            "111",
-            "User One",
-            ["2-1", "1-1", "0-2"],
-            False,
-        )
-        command_channel = MagicMock(spec=discord.TextChannel)
-        command_channel.send = AsyncMock()
-        mock_interaction_admin.channel = command_channel
-        admin_cog.bot.get_channel.return_value = None
-        admin_cog.bot.fetch_channel = AsyncMock(
-            side_effect=discord.InvalidData("unknown channel type")
-        )
-        mock_interaction_admin.message = MagicMock()
-        mock_interaction_admin.message.edit = AsyncMock()
-        admin_cog._create_backup = AsyncMock()
-
-        view = UnifiedAdminPanelView(
-            admin_cog.db,
-            admin_cog.service,
-            str(mock_interaction_admin.user.id),
-            "111111",
-            admin_commands=admin_cog,
-            bot=admin_cog.bot,
-        )
-        await view.load_fixture_options()
-        view.fixture_select._values = [str(fixture_id)]
-        await view.fixture_select.callback(mock_interaction_admin)
-
-        calculate_button = _get_button(view, "Calculate Scores")
-        await calculate_button.callback(mock_interaction_admin)
-
-        command_channel.send.assert_not_awaited()
-        assert (
-            "configured league channel is unavailable"
-            in mock_interaction_admin.response_sent[-1]["content"].lower()
-        )
 
     @pytest.mark.asyncio
     async def test_stale_calculate_scores_button_refreshes_when_fixture_already_scored(
@@ -186,6 +129,7 @@ class TestFixturePanelResultsActions:
         admin_cog,
         mock_interaction_admin,
         sample_games,
+        monkeypatch,
     ):
         fixture_id = await admin_cog.db.create_fixture(
             "111111", 45, sample_games, datetime.now(UTC) + timedelta(days=1)
@@ -200,8 +144,8 @@ class TestFixturePanelResultsActions:
         )
         mock_interaction_admin.message = MagicMock()
         mock_interaction_admin.message.edit = AsyncMock()
-        admin_cog._create_backup = AsyncMock()
-        admin_cog._post_calculation_to_channel = AsyncMock()
+        post_calculation_result = AsyncMock()
+        monkeypatch.setattr(unified_actions, "post_calculation_result", post_calculation_result)
         view = UnifiedAdminPanelView(
             admin_cog.db,
             admin_cog.service,
@@ -219,8 +163,7 @@ class TestFixturePanelResultsActions:
         await stale_button.callback(mock_interaction_admin)
 
         assert "no longer open" in mock_interaction_admin.response_sent[-1]["content"]
-        admin_cog._create_backup.assert_not_awaited()
-        admin_cog._post_calculation_to_channel.assert_not_awaited()
+        post_calculation_result.assert_not_awaited()
         assert view.selection.fixture_label == "Week 45 [CLOSED]"
         assert _has_button(view, "Calculate Scores") is False
         assert _has_button(view, "Delete Fixture") is False
@@ -232,6 +175,7 @@ class TestFixturePanelResultsActions:
         admin_cog,
         mock_interaction_admin,
         sample_games,
+        monkeypatch,
     ):
         fixture_id = await admin_cog.db.create_fixture(
             "111111", 47, sample_games, datetime.now(UTC) + timedelta(days=1)
@@ -241,6 +185,8 @@ class TestFixturePanelResultsActions:
             "111111", str(mock_interaction_admin.user.id), current_time=now().timestamp()
         )
         admin_cog.service.calculate_fixture_scores = AsyncMock()
+        post_calculation_result = AsyncMock()
+        monkeypatch.setattr(unified_actions, "post_calculation_result", post_calculation_result)
 
         view = UnifiedAdminPanelView(
             admin_cog.db,
@@ -258,6 +204,7 @@ class TestFixturePanelResultsActions:
         await calculate_button.callback(mock_interaction_admin)
 
         assert "Please wait" in mock_interaction_admin.response_sent[-1]["content"]
+        post_calculation_result.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_unified_panel_calculate_scores_button_handles_service_error(
@@ -265,13 +212,14 @@ class TestFixturePanelResultsActions:
         admin_cog,
         mock_interaction_admin,
         sample_games,
+        monkeypatch,
     ):
         fixture_id = await admin_cog.db.create_fixture(
             "111111", 48, sample_games, datetime.now(UTC) + timedelta(days=1)
         )
         await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
-        admin_cog._create_backup = AsyncMock()
-
+        post_calculation_result = AsyncMock()
+        monkeypatch.setattr(unified_actions, "post_calculation_result", post_calculation_result)
         view = UnifiedAdminPanelView(
             admin_cog.db,
             admin_cog.service,
@@ -291,6 +239,42 @@ class TestFixturePanelResultsActions:
             mock_interaction_admin.response_sent[-1]["content"]
             == "No predictions found for this fixture"
         )
+        post_calculation_result.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unified_panel_calculate_scores_button_requires_bot_context(
+        self,
+        admin_cog,
+        mock_interaction_admin,
+        sample_games,
+        monkeypatch,
+    ):
+        fixture_id = await admin_cog.db.create_fixture(
+            "111111", 49, sample_games, datetime.now(UTC) + timedelta(days=1)
+        )
+        await admin_cog.db.save_results(fixture_id, ["1-0", "1-1", "0-0"])
+        admin_cog.service.calculate_fixture_scores = AsyncMock()
+        post_calculation_result = AsyncMock()
+        monkeypatch.setattr(unified_actions, "post_calculation_result", post_calculation_result)
+
+        view = UnifiedAdminPanelView(
+            admin_cog.db,
+            admin_cog.service,
+            str(mock_interaction_admin.user.id),
+            "111111",
+            admin_commands=admin_cog,
+            bot=None,
+        )
+        await view.load_fixture_options()
+        view.fixture_select._values = [str(fixture_id)]
+        await view.fixture_select.callback(mock_interaction_admin)
+
+        calculate_button = _get_button(view, "Calculate Scores")
+        await calculate_button.callback(mock_interaction_admin)
+
+        assert "unavailable" in mock_interaction_admin.response_sent[-1]["content"]
+        admin_cog.service.calculate_fixture_scores.assert_not_awaited()
+        post_calculation_result.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_unified_panel_post_results_button_opens_confirmation(

--- a/tests/test_admin_service.py
+++ b/tests/test_admin_service.py
@@ -242,7 +242,7 @@ class TestPredictionReplacement:
         fixture, updated_prediction, recalculation = await service.replace_prediction(
             fixture_id,
             "user-1",
-            "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2",
+            "Team E - Team F 0-2\nTeam A - Team B 2-1\nTeam C - Team D 1-1",
             "admin-1",
             "111111",
         )
@@ -388,7 +388,7 @@ class TestResultCorrection:
 
         fixture, results, recalculation = await service.correct_results(
             fixture1_id,
-            "Team A - Team B 2-1\nTeam C - Team D 1-1\nTeam E - Team F 0-2",
+            "Team E - Team F 0-2\nTeam A - Team B 2-1\nTeam C - Team D 1-1",
             "111111",
         )
 

--- a/tests/test_calculation_posting.py
+++ b/tests/test_calculation_posting.py
@@ -1,0 +1,130 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+import typer_bot.services.calculation_posting as calculation_posting
+from typer_bot.services.admin_service import FixtureScoreResult
+
+
+def _score_result(sample_games: list[str]) -> FixtureScoreResult:
+    return FixtureScoreResult(
+        fixture={"games": sample_games, "week_number": 7},
+        results=["2-1", "1-1", "0-2"],
+        predictions=[],
+        scores=[],
+        standings=[
+            {
+                "user_id": "111",
+                "user_name": "User One",
+                "total_points": 7,
+                "total_exact": 2,
+                "total_correct": 1,
+            }
+        ],
+        last_fixture=None,
+    )
+
+
+def _bot_with_executor() -> MagicMock:
+    bot = MagicMock(spec=discord.Client)
+    bot.loop = MagicMock()
+
+    async def run_in_executor(_executor, callback):
+        return callback()
+
+    bot.loop.run_in_executor = AsyncMock(side_effect=run_in_executor)
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_post_calculation_result_posts_to_configured_league_channel(
+    database,
+    mock_interaction_admin,
+    sample_games,
+    monkeypatch,
+):
+    bot = _bot_with_executor()
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.send = AsyncMock()
+    bot.get_channel.return_value = channel
+    monkeypatch.setattr(calculation_posting, "create_backup", MagicMock(return_value="backup.sql"))
+    monkeypatch.setattr(calculation_posting, "cleanup_old_backups", MagicMock(return_value=0))
+
+    await calculation_posting.post_calculation_result(
+        bot, database, mock_interaction_admin, _score_result(sample_games)
+    )
+
+    channel.send.assert_awaited_once()
+    assert "Week 7 Results" in channel.send.call_args.args[0]
+    assert "User One" in channel.send.call_args.args[0]
+    assert "posted to the league channel" in mock_interaction_admin.response_sent[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_post_calculation_result_posts_when_backup_fails(
+    database,
+    mock_interaction_admin,
+    sample_games,
+    monkeypatch,
+):
+    bot = _bot_with_executor()
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.send = AsyncMock()
+    bot.get_channel.return_value = channel
+    monkeypatch.setattr(
+        calculation_posting,
+        "create_backup",
+        MagicMock(side_effect=RuntimeError("backup failed")),
+    )
+
+    await calculation_posting.post_calculation_result(
+        bot, database, mock_interaction_admin, _score_result(sample_games)
+    )
+
+    channel.send.assert_awaited_once()
+    assert "posted to the league channel" in mock_interaction_admin.response_sent[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_post_calculation_result_reports_send_failure(
+    database,
+    mock_interaction_admin,
+    sample_games,
+    monkeypatch,
+):
+    bot = _bot_with_executor()
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.send = AsyncMock(side_effect=RuntimeError("discord unavailable"))
+    bot.get_channel.return_value = channel
+    monkeypatch.setattr(calculation_posting, "create_backup", MagicMock(return_value="backup.sql"))
+    monkeypatch.setattr(calculation_posting, "cleanup_old_backups", MagicMock(return_value=0))
+
+    await calculation_posting.post_calculation_result(
+        bot, database, mock_interaction_admin, _score_result(sample_games)
+    )
+
+    assert "failed to post" in mock_interaction_admin.response_sent[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_post_calculation_result_reports_unavailable_league_channel(
+    database,
+    mock_interaction_admin,
+    sample_games,
+    monkeypatch,
+):
+    bot = _bot_with_executor()
+    bot.get_channel.return_value = None
+    bot.fetch_channel = AsyncMock(side_effect=discord.InvalidData("unknown channel type"))
+    monkeypatch.setattr(calculation_posting, "create_backup", MagicMock(return_value="backup.sql"))
+    monkeypatch.setattr(calculation_posting, "cleanup_old_backups", MagicMock(return_value=0))
+
+    await calculation_posting.post_calculation_result(
+        bot, database, mock_interaction_admin, _score_result(sample_games)
+    )
+
+    assert (
+        "configured league channel is unavailable"
+        in mock_interaction_admin.response_sent[-1]["content"].lower()
+    )

--- a/tests/test_prediction_parser.py
+++ b/tests/test_prediction_parser.py
@@ -4,124 +4,22 @@ from typer_bot.utils.prediction_parser import (
     ascii_username,
     format_predictions_preview,
     format_standings,
-    parse_line_predictions,
     parse_prediction_lines,
-    parse_predictions,
 )
 
 
-class TestParsePredictions:
-    """Test suite for parse_predictions function."""
-
-    def test_basic_scores(self):
-        """Basic hyphen-separated scores."""
-        predictions, errors = parse_predictions("2-1 1-0 2-2", expected_count=3)
-        assert predictions == ["2-1", "1-0", "2-2"]
-        assert not errors
-
-    def test_colon_separators(self):
-        """Scores with colon separators."""
-        predictions, errors = parse_predictions("2:1 1:0 2:2", expected_count=3)
-        assert predictions == ["2-1", "1-0", "2-2"]
-        assert not errors
-
-    def test_mixed_separators(self):
-        """Mixed hyphen and colon separators."""
-        predictions, errors = parse_predictions("2-1 1:0 2-2", expected_count=3)
-        assert predictions == ["2-1", "1-0", "2-2"]
-        assert not errors
-
-    def test_extra_spaces(self):
-        """Scores with extra spaces around separators."""
-        predictions, errors = parse_predictions("2  -  1    1  :  0", expected_count=2)
-        assert predictions == ["2-1", "1-0"]
-        assert not errors
-
-    def test_comma_separation(self):
-        """Comma-separated scores."""
-        predictions, errors = parse_predictions("2-1, 1-0, 2-2", expected_count=3)
-        assert predictions == ["2-1", "1-0", "2-2"]
-        assert not errors
-
-    def test_random_newlines(self):
-        """Scores with random newlines mixed in."""
-        predictions, errors = parse_predictions("2-1\n\n1-0\n2-2\n", expected_count=3)
-        assert predictions == ["2-1", "1-0", "2-2"]
-        assert not errors
-
-    def test_leading_trailing_whitespace(self):
-        """Input with leading/trailing whitespace and indentation."""
-        predictions, errors = parse_predictions("   2-1   1-0   ", expected_count=2)
-        assert predictions == ["2-1", "1-0"]
-        assert not errors
-
-    def test_double_digit_scores(self):
-        """Double-digit scores like 10-0."""
-        predictions, errors = parse_predictions("10-0 0-10 12-12", expected_count=3)
-        assert predictions == ["10-0", "0-10", "12-12"]
-        assert not errors
-
-    def test_wrong_count_error(self):
-        """Error when count doesn't match expected."""
-        predictions, errors = parse_predictions("2-1 1-0", expected_count=3)
-        assert predictions == ["2-1", "1-0"]
-        assert len(errors) == 1
-        assert "Expected 3 scores, found 2" in errors[0]
-
-    def test_no_valid_scores(self):
-        """Input with no valid score patterns."""
-        predictions, errors = parse_predictions("hello world test", expected_count=3)
-        assert predictions == []
-        assert len(errors) == 1
-
-
-class TestParseLinePredictions:
-    """Test suite for parse_line_predictions function."""
-
-    def test_basic_line_parsing(self):
-        """Basic line-by-line parsing with game context."""
-        input_text = "Team A vs Team B 2-1\nTeam C vs Team D 1-0"
-        games = ["Team A vs Team B", "Team C vs Team D"]
-        predictions, errors = parse_line_predictions(input_text, games)
-        assert predictions == ["2-1", "1-0"]
-        assert not errors
-
-    def test_score_at_end_of_line(self):
-        """Score must be at end of line - trailing text causes parse failure."""
-        # Score at end works
-        input_text = "Team A vs Team B 2-1\nTeam B 1-0"
-        games = ["Team A", "Team B"]
-        predictions, errors = parse_line_predictions(input_text, games)
-        assert predictions == ["2-1", "1-0"]
-        assert not errors
-
-    def test_trailing_text_fails(self):
-        """Text after score fails - parser expects score at line end."""
-        input_text = "Team A 2-1 some comment\nTeam B 1-0"
-        games = ["Team A", "Team B"]
-        predictions, errors = parse_line_predictions(input_text, games)
-        assert predictions == ["1-0"]  # Only second line parses
-        assert len(errors) == 1
-        assert "Could not find score" in errors[0]
-
-    def test_leading_indentation(self):
-        """Lines with leading whitespace/indentation."""
-        input_text = "   Team A 2-1\n    Team B 1-0"
-        games = ["Team A", "Team B"]
-        predictions, errors = parse_line_predictions(input_text, games)
-        assert predictions == ["2-1", "1-0"]
-        assert not errors
-
-    def test_colon_separators_in_lines(self):
-        """Lines with colon separators."""
-        input_text = "Team A 2:1\nTeam B 1:0"
-        games = ["Team A", "Team B"]
-        predictions, errors = parse_line_predictions(input_text, games)
-        assert predictions == ["2-1", "1-0"]
-        assert not errors
-
-
 class TestParsePredictionLines:
+    def test_full_prediction_maps_by_game_name(self):
+        games = ["Team A vs Team B", "Team C vs Team D"]
+        predictions, game_indexes, errors = parse_prediction_lines(
+            "Team A vs Team B 2-1\nTeam C vs Team D 1-0",
+            games,
+        )
+
+        assert predictions == ["2-1", "1-0"]
+        assert game_indexes == [0, 1]
+        assert errors == []
+
     def test_partial_mapping_by_game_name(self):
         games = ["Team A - Team B", "Team C - Team D", "Team E - Team F"]
         input_text = "Team C - Team D 1-1\nTeam E - Team F 0-2"
@@ -143,6 +41,25 @@ class TestParsePredictionLines:
         assert predictions == ["2-1", "1-0"]
         assert game_indexes == [0, 1]
         assert errors == []
+
+    def test_score_at_end_of_line(self):
+        games = ["Team A", "Team B"]
+        predictions, game_indexes, errors = parse_prediction_lines("Team A 2-1\nTeam B 1-0", games)
+
+        assert predictions == ["2-1", "1-0"]
+        assert game_indexes == [0, 1]
+        assert errors == []
+
+    def test_trailing_text_fails(self):
+        games = ["Team A", "Team B"]
+        predictions, game_indexes, errors = parse_prediction_lines(
+            "Team A 2-1 some comment\nTeam B 1-0", games
+        )
+
+        assert predictions == []
+        assert game_indexes == []
+        assert len(errors) == 1
+        assert "Could not find score" in errors[0]
 
     def test_partial_requires_game_names(self):
         games = ["Team A - Team B", "Team C - Team D"]
@@ -175,125 +92,135 @@ class TestParsePredictionLines:
         assert errors == []
 
     def test_mixed_separators_in_lines(self):
-        """Lines with mixed separators."""
         input_text = "Team A 2-1\nTeam B 1:0\nTeam C 2-2"
         games = ["Team A", "Team B", "Team C"]
-        predictions, errors = parse_line_predictions(input_text, games)
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
         assert predictions == ["2-1", "1-0", "2-2"]
+        assert game_indexes == [0, 1, 2]
         assert not errors
 
+    def test_double_digit_scores(self):
+        games = ["Team A", "Team B"]
+        predictions, game_indexes, errors = parse_prediction_lines(
+            "Team A 10-0\nTeam B 0:12", games
+        )
+
+        assert predictions == ["10-0", "0-12"]
+        assert game_indexes == [0, 1]
+        assert errors == []
+
     def test_missing_score_in_line(self):
-        """Line without a valid score at the end."""
         input_text = "Team A 2-1\nTeam B no score here"
         games = ["Team A", "Team B"]
-        predictions, errors = parse_line_predictions(input_text, games)
-        assert predictions == ["2-1"]
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
+        assert predictions == []
+        assert game_indexes == []
         assert len(errors) == 1
         assert "Could not find score" in errors[0]
 
     def test_wrong_line_count_error(self):
-        """Error when line count doesn't match game count."""
         input_text = "Team A 2-1"
         games = ["Team A", "Team B"]
-        predictions, errors = parse_line_predictions(input_text, games)
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
         assert predictions == []
+        assert game_indexes == []
         assert len(errors) == 1
         assert "Expected 2 predictions, found 1" in errors[0]
 
     def test_extra_whitespace_in_lines(self):
-        """Lines with extra internal whitespace."""
         input_text = "Team A    2  -  1\nTeam B  1  :  0  "
         games = ["Team A", "Team B"]
-        predictions, errors = parse_line_predictions(input_text, games)
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
         assert predictions == ["2-1", "1-0"]
+        assert game_indexes == [0, 1]
         assert not errors
 
     def test_nullified_game_lowercase_x(self):
-        """Parse 'x' as nullified game marker."""
         input_text = "Team A 2-1\nTeam B x"
         games = ["Team A", "Team B"]
-        predictions, errors = parse_line_predictions(input_text, games)
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
         assert predictions == ["2-1", "x"]
+        assert game_indexes == [0, 1]
         assert not errors
 
     def test_nullified_game_uppercase_x(self):
-        """Parse 'X' as nullified game marker (case insensitive)."""
         input_text = "Team A 2-1\nTeam B X"
         games = ["Team A", "Team B"]
-        predictions, errors = parse_line_predictions(input_text, games)
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
         assert predictions == ["2-1", "x"]
+        assert game_indexes == [0, 1]
         assert not errors
 
     def test_mixed_scores_and_nullified(self):
-        """Mix of regular scores and nullified games."""
         input_text = "Team A 2-1\nTeam B x\nTeam C 0-0\nTeam D X"
         games = ["Team A", "Team B", "Team C", "Team D"]
-        predictions, errors = parse_line_predictions(input_text, games)
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
         assert predictions == ["2-1", "x", "0-0", "x"]
+        assert game_indexes == [0, 1, 2, 3]
         assert not errors
 
     def test_nullified_with_whitespace(self):
-        """Nullified marker with trailing whitespace."""
         input_text = "Team A x   \nTeam B X   "
         games = ["Team A", "Team B"]
-        predictions, errors = parse_line_predictions(input_text, games)
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
         assert predictions == ["x", "x"]
+        assert game_indexes == [0, 1]
         assert not errors
 
     def test_comma_separated_predictions(self):
-        """Comma-separated predictions."""
         input_text = "Team A 2-1, Team B 1-0"
         games = ["Team A", "Team B"]
-        predictions, errors = parse_line_predictions(input_text, games)
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
         assert predictions == ["2-1", "1-0"]
+        assert game_indexes == [0, 1]
         assert not errors
 
     def test_mixed_comma_and_newline(self):
-        """Mixed comma and newline delimiters."""
         input_text = "Team A 2-1, Team B 1-0\nTeam C 2-2"
         games = ["Team A", "Team B", "Team C"]
-        predictions, errors = parse_line_predictions(input_text, games)
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
         assert predictions == ["2-1", "1-0", "2-2"]
+        assert game_indexes == [0, 1, 2]
         assert not errors
 
     def test_comma_with_extra_whitespace(self):
-        """Comma-separated with extra whitespace."""
         input_text = "Team A 2-1 , Team B 1-0 , Team C 2-2"
         games = ["Team A", "Team B", "Team C"]
-        predictions, errors = parse_line_predictions(input_text, games)
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
         assert predictions == ["2-1", "1-0", "2-2"]
+        assert game_indexes == [0, 1, 2]
         assert not errors
 
     def test_trailing_comma(self):
-        """Trailing comma should be handled gracefully."""
         input_text = "Team A 2-1, Team B 1-0,"
         games = ["Team A", "Team B"]
-        predictions, errors = parse_line_predictions(input_text, games)
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
         assert predictions == ["2-1", "1-0"]
+        assert game_indexes == [0, 1]
         assert not errors
 
     def test_multiple_commas(self):
-        """Multiple consecutive commas should not create empty segments."""
         input_text = "Team A 2-1,, Team B 1-0"
         games = ["Team A", "Team B"]
-        predictions, errors = parse_line_predictions(input_text, games)
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
         assert predictions == ["2-1", "1-0"]
+        assert game_indexes == [0, 1]
         assert not errors
 
     def test_comma_with_nullified_games(self):
-        """Comma-separated with nullified games."""
         input_text = "Team A 2-1, Team B x, Team C 1-0"
         games = ["Team A", "Team B", "Team C"]
-        predictions, errors = parse_line_predictions(input_text, games)
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
         assert predictions == ["2-1", "x", "1-0"]
+        assert game_indexes == [0, 1, 2]
         assert not errors
 
     def test_comma_with_colon_separator(self):
-        """Comma-separated with colon score separators."""
         input_text = "Team A 2:1, Team B 1:0"
         games = ["Team A", "Team B"]
-        predictions, errors = parse_line_predictions(input_text, games)
+        predictions, game_indexes, errors = parse_prediction_lines(input_text, games)
         assert predictions == ["2-1", "1-0"]
+        assert game_indexes == [0, 1]
         assert not errors
 
 

--- a/typer_bot/commands/admin_commands.py
+++ b/typer_bot/commands/admin_commands.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import timedelta
 from typing import cast
 
@@ -15,22 +14,15 @@ from typer_bot.commands.admin_panel import (
 )
 from typer_bot.database import Database
 from typer_bot.services import AdminService
-from typer_bot.services.admin_service import FixtureScoreResult
 from typer_bot.utils import (
     SETUP_REQUIRED_MESSAGE,
-    format_fixture_results,
-    format_standings,
     get_admin_permission_error,
     has_setup_permission,
     now,
 )
-from typer_bot.utils.config import BACKUP_DIR
-from typer_bot.utils.db_backup import cleanup_old_backups, create_backup
 
 CALCULATE_COOLDOWN = 30.0
 COOLDOWN_ENTRY_EXPIRY = timedelta(hours=1)
-
-logger = logging.getLogger(__name__)
 
 
 def _is_everyone_role(role: discord.Role, guild_id: int | None) -> bool:
@@ -335,75 +327,6 @@ class AdminCommands(commands.Cog):
         for key in expired:
             self._calculate_cooldowns.pop(key, None)
         return len(expired)
-
-    async def _create_backup(self) -> None:
-        try:
-            await self.bot.loop.run_in_executor(
-                None, lambda: create_backup(self.db.db_path, BACKUP_DIR)
-            )
-            await self.bot.loop.run_in_executor(
-                None, lambda: cleanup_old_backups(BACKUP_DIR, keep=10)
-            )
-        except Exception as exc:
-            logger.warning(f"Backup failed but calculation succeeded: {exc}")
-
-    async def _post_calculation_to_channel(
-        self,
-        interaction: discord.Interaction,
-        score_result: FixtureScoreResult,
-    ) -> None:
-        if interaction.guild_id is None:
-            await interaction.response.send_message(
-                "Scores calculated but could not resolve this server.", ephemeral=True
-            )
-            return
-
-        config = await self.db.get_guild_config(str(interaction.guild_id))
-        channel = None
-        if config is not None:
-            try:
-                channel_id = int(config["league_channel_id"])
-            except (TypeError, ValueError):
-                channel_id = None
-            if channel_id is not None:
-                channel = self.bot.get_channel(channel_id)
-                if channel is None:
-                    fetch_channel = getattr(self.bot, "fetch_channel", None)
-                    if fetch_channel is not None:
-                        try:
-                            channel = await fetch_channel(channel_id)
-                        except discord.DiscordException:
-                            channel = None
-
-        if not isinstance(channel, discord.TextChannel):
-            await interaction.response.send_message(
-                "Scores calculated but the configured league channel is unavailable.",
-                ephemeral=True,
-            )
-            return
-
-        results_section = format_fixture_results(
-            score_result.fixture["games"],
-            score_result.results,
-            score_result.fixture["week_number"],
-        )
-        message = (
-            results_section
-            + "\n\n"
-            + format_standings(score_result.standings, score_result.last_fixture)
-        )
-
-        try:
-            await channel.send(message)
-            await interaction.response.send_message(
-                f"Week {score_result.fixture['week_number']} results calculated and posted to the league channel!",
-                ephemeral=True,
-            )
-        except Exception as exc:
-            logger.error(f"Failed to post results to channel: {exc}")
-            await interaction.response.send_message(
-                "Scores calculated but failed to post to channel.", ephemeral=True
-            )
 
     admin = app_commands.Group(
         name="admin", description="Open the admin panel and manage fixtures/results"

--- a/typer_bot/commands/admin_panel/result_modals.py
+++ b/typer_bot/commands/admin_panel/result_modals.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import discord
 
 from typer_bot.database import Database
-from typer_bot.utils import get_admin_permission_error, parse_line_predictions
+from typer_bot.utils import get_admin_permission_error, parse_prediction_lines
 
 from .base import _format_prediction_line
 
@@ -107,7 +107,7 @@ class EnterResultsModal(discord.ui.Modal):
             await interaction.response.send_message(permission_error, ephemeral=True)
             return
 
-        results, errors = parse_line_predictions(self.results_input.value, self.fixture["games"])
+        results, _, errors = parse_prediction_lines(self.results_input.value, self.fixture["games"])
         if errors:
             await interaction.response.send_message("\n".join(errors), ephemeral=True)
             return

--- a/typer_bot/commands/admin_panel/unified_actions.py
+++ b/typer_bot/commands/admin_panel/unified_actions.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import discord
 
+from typer_bot.services import post_calculation_result
 from typer_bot.utils import format_standings, get_admin_permission_error, has_setup_permission, now
 
 from .modals import CreateFixtureModal, EnterResultsModal
@@ -366,7 +367,7 @@ class CalculateScoresButton(discord.ui.Button):
             return
 
         admin_commands = self.parent_view.admin_commands
-        if admin_commands is None:
+        if admin_commands is None or self.parent_view.bot is None:
             await interaction.response.send_message(
                 "Calculate Scores is unavailable in this context.", ephemeral=True
             )
@@ -396,8 +397,9 @@ class CalculateScoresButton(discord.ui.Button):
         admin_commands.record_calculate_cooldown(
             self.parent_view.guild_id, user_id, current_time=current_time
         )
-        await admin_commands._create_backup()
-        await admin_commands._post_calculation_to_channel(interaction, score_result)
+        await post_calculation_result(
+            self.parent_view.bot, self.parent_view.db, interaction, score_result
+        )
         await self._refresh_parent_panel(fixture_id)
         await self._edit_parent_message(interaction)
 

--- a/typer_bot/services/__init__.py
+++ b/typer_bot/services/__init__.py
@@ -1,6 +1,7 @@
 """Shared service-layer helpers."""
 
 from .admin_service import AdminService
+from .calculation_posting import post_calculation_result
 from .errors import (
     AdminFlowError,
     FixtureNotFoundError,
@@ -16,4 +17,5 @@ __all__ = [
     "NoPredictionsSavedError",
     "PredictionDisappearedError",
     "PredictionNotFoundError",
+    "post_calculation_result",
 ]

--- a/typer_bot/services/admin_service.py
+++ b/typer_bot/services/admin_service.py
@@ -11,7 +11,7 @@ from typer_bot.services.errors import (
     PredictionDisappearedError,
     PredictionNotFoundError,
 )
-from typer_bot.utils import parse_line_predictions
+from typer_bot.utils import parse_prediction_lines
 
 
 @dataclass(slots=True)
@@ -190,7 +190,7 @@ class AdminService:
         if existing_prediction is None:
             raise PredictionNotFoundError
 
-        predictions, errors = parse_line_predictions(prediction_lines, fixture["games"])
+        predictions, _, errors = parse_prediction_lines(prediction_lines, fixture["games"])
         if errors:
             raise ValueError("\n".join(errors))
 
@@ -265,7 +265,7 @@ class AdminService:
         if fixture is None:
             raise FixtureNotFoundError
 
-        results, errors = parse_line_predictions(results_lines, fixture["games"])
+        results, _, errors = parse_prediction_lines(results_lines, fixture["games"])
         if errors:
             raise ValueError("\n".join(errors))
 

--- a/typer_bot/services/calculation_posting.py
+++ b/typer_bot/services/calculation_posting.py
@@ -1,0 +1,100 @@
+"""Post-calculation publishing helpers."""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord.ext import commands
+
+from typer_bot.database import Database
+from typer_bot.services.admin_service import FixtureScoreResult
+from typer_bot.utils import format_fixture_results, format_standings
+from typer_bot.utils.config import BACKUP_DIR
+from typer_bot.utils.db_backup import cleanup_old_backups, create_backup
+
+logger = logging.getLogger(__name__)
+
+
+async def post_calculation_result(
+    bot: commands.Bot | discord.Client,
+    db: Database,
+    interaction: discord.Interaction,
+    score_result: FixtureScoreResult,
+) -> None:
+    """Run best-effort DB backup, then publish fixture results and standings.
+
+    The interaction response must still be unused. Backup failures are logged but
+    do not fail score calculation; posting failures are reported ephemerally to
+    the admin.
+    """
+    await _create_backup(bot, db.db_path)
+    await _post_calculation_to_channel(bot, db, interaction, score_result)
+
+
+async def _create_backup(bot: commands.Bot | discord.Client, db_path: str) -> None:
+    try:
+        await bot.loop.run_in_executor(None, lambda: create_backup(db_path, BACKUP_DIR))
+        await bot.loop.run_in_executor(None, lambda: cleanup_old_backups(BACKUP_DIR, keep=10))
+    except Exception as exc:
+        logger.warning(f"Backup failed but calculation succeeded: {exc}")
+
+
+async def _post_calculation_to_channel(
+    bot: commands.Bot | discord.Client,
+    db: Database,
+    interaction: discord.Interaction,
+    score_result: FixtureScoreResult,
+) -> None:
+    if interaction.guild_id is None:
+        await interaction.response.send_message(
+            "Scores calculated but could not resolve this server.", ephemeral=True
+        )
+        return
+
+    config = await db.get_guild_config(str(interaction.guild_id))
+    channel = None
+    if config is not None:
+        try:
+            channel_id = int(config["league_channel_id"])
+        except (TypeError, ValueError):
+            channel_id = None
+        if channel_id is not None:
+            channel = bot.get_channel(channel_id)
+            if channel is None:
+                fetch_channel = getattr(bot, "fetch_channel", None)
+                if fetch_channel is not None:
+                    try:
+                        channel = await fetch_channel(channel_id)
+                    except discord.DiscordException:
+                        channel = None
+
+    if not isinstance(channel, discord.TextChannel):
+        await interaction.response.send_message(
+            "Scores calculated but the configured league channel is unavailable.",
+            ephemeral=True,
+        )
+        return
+
+    results_section = format_fixture_results(
+        score_result.fixture["games"],
+        score_result.results,
+        score_result.fixture["week_number"],
+    )
+    message = (
+        results_section
+        + "\n\n"
+        + format_standings(score_result.standings, score_result.last_fixture)
+    )
+
+    try:
+        await channel.send(message)
+        await interaction.response.send_message(
+            f"Week {score_result.fixture['week_number']} results calculated and posted to the league channel!",
+            ephemeral=True,
+        )
+    except Exception as exc:
+        logger.error(f"Failed to post results to channel: {exc}")
+        await interaction.response.send_message(
+            "Scores calculated but failed to post to channel.", ephemeral=True
+        )

--- a/typer_bot/utils/__init__.py
+++ b/typer_bot/utils/__init__.py
@@ -15,9 +15,7 @@ from .prediction_parser import (
     format_fixture_results,
     format_predictions_preview,
     format_standings,
-    parse_line_predictions,
     parse_prediction_lines,
-    parse_predictions,
 )
 from .prediction_submission import PredictionSubmission, build_prediction_submission
 from .scoring import (
@@ -38,9 +36,7 @@ __all__ = [
     "is_admin",
     "is_admin_member",
     "is_configured_admin",
-    "parse_predictions",
     "parse_prediction_lines",
-    "parse_line_predictions",
     "format_fixture_results",
     "format_predictions_preview",
     "format_standings",

--- a/typer_bot/utils/prediction_parser.py
+++ b/typer_bot/utils/prediction_parser.py
@@ -16,12 +16,22 @@ def parse_prediction_lines(
     *,
     allow_partial: bool = False,
 ) -> tuple[list[str], list[int], list[str]]:
-    """Parse prediction lines and map them to specific fixture rows.
+    """Parse prediction lines and map them to fixture rows.
 
-    Each non-empty line must end with a score like ``2:0`` or ``2-1``. When the
-    fixture label at the start of the line matches one of the provided games, the
-    prediction is mapped to that exact game row. Full submissions can still fall
-    back to positional matching for backward compatibility.
+    Each non-empty line must end with a score like ``2:0``/``2-1``, or cancelled
+    marker ``x``. Scores are normalized to ``home-away``. When a line starts with
+    an exact fixture label from ``games``, that prediction is mapped to the matching
+    fixture row. Otherwise, full submissions fall back to positional matching when
+    line count equals fixture count. Partial submissions must include fixture names.
+
+    Args:
+        input_text: Raw text using newline or comma separators.
+        games: Fixture rows used for mapping and count validation.
+        allow_partial: Whether fewer predictions than fixture rows are accepted.
+
+    Returns:
+        A tuple of fixture-ordered predictions, mapped fixture indexes, and errors.
+        Any parse or mapping error returns empty predictions and indexes.
     """
     normalized = input_text.replace(",", "\n")
     lines = [line.strip() for line in normalized.split("\n") if line.strip()]
@@ -37,7 +47,7 @@ def parse_prediction_lines(
         match = re.search(r"(\d+)\s*[-:]\s*(\d+)\s*$", stripped)
         if not match and not is_cancelled:
             errors.append(
-                f"Line {line_number}: Could not find score (expected format: '2:0' or '2-1')"
+                f"Line {line_number}: Could not find score (expected format: '2:0' or '2-1', or 'x' for cancelled games)"
             )
             continue
 
@@ -85,91 +95,6 @@ def parse_prediction_lines(
         return [], [], [f"Expected {len(games)} predictions, found {len(ordered_predictions)}"]
 
     return ordered_predictions, ordered_indexes, []
-
-
-def parse_predictions(input_text: str, expected_count: int = 9) -> tuple[list[str], list[str]]:
-    """Parse predictions from user input.
-
-    Format agnostic: "2-1 1-0", "2:1, 1:0", "2 - 1".
-    Returns: (valid_predictions, errors)
-    """
-    logger.debug(f"Parsing predictions: expected={expected_count}, input_length={len(input_text)}")
-
-    normalized = input_text.replace(",", " ")
-    pattern = r"\s*(\d+)\s*[-:]\s*(\d+)\s*"
-
-    predictions = []
-    errors = []
-
-    matches = list(re.finditer(pattern, normalized))
-    logger.debug(f"Found {len(matches)} score matches in input")
-
-    for match in matches:
-        home = match.group(1)
-        away = match.group(2)
-        predictions.append(f"{home}-{away}")
-
-    if len(predictions) != expected_count:
-        error_msg = f"Expected {expected_count} scores, found {len(predictions)}"
-        logger.warning(f"Prediction count mismatch: {error_msg}")
-        errors.append(error_msg)
-    else:
-        logger.debug(f"Successfully parsed {len(predictions)} predictions")
-
-    return predictions, errors
-
-
-def parse_line_predictions(input_text: str, games: list[str]) -> tuple[list[str], list[str]]:
-    """Parse predictions from user input with game context.
-
-    Accepts newline-separated or comma-separated predictions. Each segment should
-    contain a score at the end in format like ``2:0`` or ``2-1``. Cancelled or
-    voided fixtures can be marked with ``x`` and numeric scores are normalized to
-    ``home-away`` output regardless of the input separator.
-
-    Args:
-        input_text: Raw input text (supports commas or newlines as delimiters)
-        games: Fixture game list used to validate line count and build errors
-
-    Returns: (valid_predictions, errors)
-    """
-    normalized = input_text.replace(",", "\n")
-    lines = [line.strip() for line in normalized.split("\n") if line.strip()]
-
-    logger.debug(f"Parsing line predictions: {len(lines)} lines, {len(games)} games")
-
-    predictions = []
-    errors = []
-
-    if len(lines) != len(games):
-        error_msg = f"Expected {len(games)} predictions, found {len(lines)}"
-        logger.warning(f"Line count mismatch: {error_msg}")
-        errors.append(error_msg)
-        return predictions, errors
-
-    for i, line in enumerate(lines):
-        stripped = line.strip()
-
-        if re.search(r"[xX]\s*$", stripped):
-            predictions.append("x")
-            logger.debug(f"Line {i + 1}: Parsed nullified game (x)")
-            continue
-
-        match = re.search(r"(\d+)\s*[-:]\s*(\d+)\s*$", stripped)
-        if match:
-            home_score = match.group(1)
-            away_score = match.group(2)
-            predictions.append(f"{home_score}-{away_score}")
-            logger.debug(f"Line {i + 1}: Parsed {home_score}-{away_score}")
-        else:
-            error_msg = f"Line {i + 1}: Could not find score (expected format: '2:0' or '2-1', or 'x' for cancelled games)"
-            logger.warning(f"Parse error on line {i + 1}: '{line[:50]}...'")
-            errors.append(error_msg)
-
-    if not errors:
-        logger.debug(f"Successfully parsed all {len(predictions)} line predictions")
-
-    return predictions, errors
 
 
 def ascii_username(username: str, max_len: int = 20) -> str:


### PR DESCRIPTION
## Summary
- extract score-calculation backup and league-channel publishing into a service helper
- remove private AdminCommands method calls from Calculate Scores button
- add direct coverage for calculation posting success and failure paths

## Verification
- uv run pytest --tb=short
- uv run ruff check typer_bot tests
- uv run ty check typer_bot

Stacked on #250.
Closes #249